### PR TITLE
fix: fix scrolling the detail panel

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,10 @@ div#scripts-table-overlay {
   height: 100%;
   background-color: rgba(127, 127, 127, 0.5);
 }
+.plugin-detail,
+.script-detail {
+  overflow-x: auto;
+}
 .plugin-detail .row,
 .script-detail .row {
   margin-top: 2px;

--- a/src/index.html
+++ b/src/index.html
@@ -196,7 +196,7 @@
 				role="tabpanel"
 				aria-labelledby="plugins"
 			>
-				<div class="container-fluid d-flex flex-column py-2">
+				<div class="container-fluid d-flex flex-column pt-2">
 					<div class="row border-bottom">
 						<div class="col">
 							<button
@@ -257,7 +257,9 @@
 						</div>
 					</div>
 
-					<div class="row border-top pt-1 plugin-detail">
+					<div
+						class="row border-top pt-1 flex-shrink-0 plugin-detail"
+					>
 						<div class="col">
 							<div class="row">
 								<div class="col-12 col-sm-4 col-md-3 col-lg-2">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When plugin's or script's details are long, we have to scroll the whole pane, not the detail panel.
So, changes it so that only that panel can be scrolled.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->Closes #61 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
OS: Windows 10
Version: 21H1

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
