### PR TITLE
fix(package.js): ensure script data is loaded

### DIFF
--- a/src/renderer/main/core.js
+++ b/src/renderer/main/core.js
@@ -308,10 +308,7 @@ async function changeInstallationPath(instPath) {
     oldScriptsMod.getTime() <
     Math.max(...currentMod.scripts.map((p) => new Date(p.modified).getTime()))
   ) {
-    await packageMain.getScriptsList(
-      true,
-      Math.max(...currentMod.scripts.map((p) => new Date(p.modified).getTime()))
-    );
+    await packageMain.getScriptsList(true);
   }
   if (oldCoreMod.getTime() < new Date(currentMod.core.modified).getTime()) {
     await checkLatestVersion(instPath);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When scripts.json is read, if it has not already been downloaded, it will be downloaded.


### Steps to reproduce the bug
1. Change the path of the dataURL. (The update date of scripts.json must be the same or older than before the change.)
2. The list of script download sites will no longer be displayed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
- The bug has been fixed.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
