### PR TITLE
fix: fix bugs related to list.json

### DIFF
--- a/src/lib/modList.ts
+++ b/src/lib/modList.ts
@@ -77,22 +77,16 @@ async function updateInfo() {
 async function getInfo() {
   const modFile = await ipcRenderer.invoke('exists-temp-file', 'list.json');
   if (modFile.exists) {
-    try {
-      return await parseJson.getMod(modFile.path);
-    } catch {
-      return null;
-    }
+    return await parseJson.getMod(modFile.path).catch((): null => null);
   } else {
     await updateInfo();
     const downloadedModFile = await ipcRenderer.invoke(
       'exists-temp-file',
       'list.json'
     );
-    try {
-      return await parseJson.getMod(downloadedModFile.path);
-    } catch {
-      return null;
-    }
+    return await parseJson
+      .getMod(downloadedModFile.path)
+      .catch((): null => null);
   }
 }
 

--- a/src/lib/modList.ts
+++ b/src/lib/modList.ts
@@ -59,7 +59,7 @@ async function setPackagesDataUrl() {
 /**
  * Download list.json.
  */
-async function downloadData() {
+async function updateInfo() {
   await ipcRenderer.invoke(
     'download',
     path.join(getDataUrl(), 'list.json'),
@@ -83,7 +83,7 @@ async function getInfo() {
       return null;
     }
   } else {
-    await downloadData();
+    await updateInfo();
     const downloadedModFile = await ipcRenderer.invoke(
       'exists-temp-file',
       'list.json'
@@ -170,7 +170,7 @@ async function getScriptsDataUrl() {
 }
 
 const mod = {
-  downloadData,
+  updateInfo,
   getInfo,
   getDataUrl,
   getExtraDataUrl,

--- a/src/renderer/main/core.js
+++ b/src/renderer/main/core.js
@@ -223,7 +223,7 @@ async function checkLatestVersion(instPath) {
       false,
       'core'
     );
-    await modList.downloadData();
+    await modList.updateInfo();
     store.set('checkDate.core', Date.now());
     const modInfo = await modList.getInfo();
     store.set('modDate.core', new Date(modInfo.core.modified).getTime());
@@ -278,7 +278,7 @@ async function changeInstallationPath(instPath) {
   store.set('installationPath', instPath);
 
   // update 1
-  await modList.downloadData();
+  await modList.updateInfo();
   const currentMod = await modList.getInfo();
 
   if (fs.existsSync(instPath)) {

--- a/src/renderer/main/package.js
+++ b/src/renderer/main/package.js
@@ -342,7 +342,7 @@ async function checkPackagesList(instPath) {
 
   try {
     await packageUtil.downloadRepository(modList.getPackagesDataUrl(instPath));
-    await modList.downloadData();
+    await modList.updateInfo();
     store.set('checkDate.packages', Date.now());
     const modInfo = await modList.getInfo();
     store.set(

--- a/src/renderer/main/setting.ts
+++ b/src/renderer/main/setting.ts
@@ -2,6 +2,7 @@ import { ipcRenderer } from 'electron';
 import fs from 'fs-extra';
 import Store from 'electron-store';
 import path from 'path';
+import * as os from 'os';
 const store = new Store();
 import buttonTransition from '../../lib/buttonTransition';
 import modList from '../../lib/modList';
@@ -78,8 +79,8 @@ async function setDataUrl(dataUrl: { value: string }, extraDataUrls: string) {
 
   if (!error) {
     store.set('dataURL.main', value);
-    store.set('dataURL.extra', extraDataUrls);
-    await modList.setPackagesDataUrl(tmpExtraUrls);
+    store.set('dataURL.extra', tmpExtraUrls.join(os.EOL));
+    await modList.downloadData();
 
     if (btn instanceof HTMLButtonElement) {
       buttonTransition.message(btn, '設定完了', 'success');

--- a/src/renderer/main/setting.ts
+++ b/src/renderer/main/setting.ts
@@ -80,7 +80,7 @@ async function setDataUrl(dataUrl: { value: string }, extraDataUrls: string) {
   if (!error) {
     store.set('dataURL.main', value);
     store.set('dataURL.extra', tmpExtraUrls.join(os.EOL));
-    await modList.downloadData();
+    await modList.updateInfo();
 
     if (btn instanceof HTMLButtonElement) {
       buttonTransition.message(btn, '設定完了', 'success');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix bugs related to `list.json`.

- An error occurs when starting apm with a clean install.
  - This is because `getInfo()` is executed before `list.json` is downloaded.
- If I change apm-data to `main` branch after loading https://github.com/team-apm/apm-data/pull/182 , I get an error that test/khsk-packages.json cannot be loaded.
  - This is because the list of packages in the electron-store is not updated when the new `list.json` is downloaded.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Ensure that the above bugs are not occurring.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
