### PR TITLE
fix(core.js): detect location of exedit.auf

### DIFF
--- a/src/renderer/main/core.js
+++ b/src/renderer/main/core.js
@@ -10,6 +10,7 @@ import {
   app,
   download,
   existsTempFile,
+  openDialog,
   openDirDialog,
   openYesNoDialog,
 } from '../../lib/ipcWrapper';
@@ -241,6 +242,15 @@ async function selectInstallationPath(input) {
     originalPath
   );
   if (selectedPath.length !== 0 && selectedPath[0] !== originalPath) {
+    if (fs.existsSync(path.join(selectedPath[0], 'plugins/exedit.auf'))) {
+      await openDialog(
+        'エラー',
+        '拡張編集が「plugins」フォルダに配置されています。apmは拡張編集を「aviutl.exe」と同じフォルダに配置する場合のみに対応しています。',
+        'error'
+      );
+      return;
+    }
+
     const instPath = selectedPath[0];
     await changeInstallationPath(instPath);
     input.value = instPath;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If `exedit.auf` is placed in the `plugins` folder, apm will corrupt the existing environment. This PR will prevent such a folder from being selected.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- If `Exedit` exists in the `plugins` folder, apm cannot move to that installation folder.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
