### PR TITLE
fix(main.ts): don't use getSavePath()

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -493,38 +493,27 @@ function launch() {
   ipcMain.handle(
     'download',
     async (event, url, { loadCache = false, subDir = '', keyText } = {}) => {
-      const tmpDirectory = path.join(app.getPath('userData'), 'Data/', subDir);
       const opt = {
         overwrite: true,
-        directory: ['.zip', '.lzh', '.7z', '.rar'].includes(path.extname(url))
-          ? path.join(tmpDirectory, 'archive')
-          : tmpDirectory,
+        directory: path.join(
+          path.join(app.getPath('userData'), 'Data/', subDir),
+          ['.zip', '.lzh', '.7z', '.rar'].includes(path.extname(url))
+            ? 'archive'
+            : ''
+        ),
+        filename: (keyText ? getHash(keyText) + '_' : '') + path.basename(url),
       };
-
-      const tmpFilePath = keyText
-        ? path.join(opt.directory, getHash(keyText) + '_' + path.basename(url))
-        : path.join(opt.directory, path.basename(url));
-      if (loadCache && fs.existsSync(tmpFilePath)) return tmpFilePath;
+      const retFilePath = path.join(opt.directory, opt.filename);
+      if (loadCache && fs.existsSync(retFilePath)) return retFilePath;
 
       try {
-        let savePath;
         if (url.startsWith('http')) {
-          savePath = (await download(mainWindow, url, opt)).getSavePath();
+          await download(mainWindow, url, opt);
         } else {
-          savePath = path.join(opt.directory, path.basename(url));
-          mkdir(path.dirname(savePath), { recursive: true });
-          fs.copyFileSync(url, savePath);
+          await mkdir(path.dirname(retFilePath), { recursive: true });
+          fs.copyFileSync(url, retFilePath);
         }
-
-        if (keyText) {
-          const renamedPath = path.join(
-            path.dirname(savePath),
-            getHash(keyText) + '_' + path.basename(savePath)
-          );
-          fs.renameSync(savePath, renamedPath);
-          savePath = renamedPath;
-        }
-        return savePath;
+        return retFilePath;
       } catch (e) {
         log.error(e);
         return undefined;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A fix has been made to work around a bug where `getSavePath()` returned the wrong value when executed in parallel.

Instead of using `getSavePath()` and `renameSync()`, specify the name of the download file. This will also simplify the code.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- closes #683 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- A new installation of apm is successfully performed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
