### PR TITLE
feat(packageUtil.js): recognize lua files as AviUtl-related files

### DIFF
--- a/src/renderer/main/packageUtil.js
+++ b/src/renderer/main/packageUtil.js
@@ -159,7 +159,7 @@ async function downloadRepository(packageDataUrls) {
  * @returns {string[]} List of installed files
  */
 function getInstalledFiles(instPath) {
-  const regex = /^(?!exedit).*\.(auf|aui|auo|auc|aul|anm|obj|cam|tra|scn)$/;
+  const regex = /^(?!exedit).*\.(auf|aui|auo|auc|aul|anm|obj|cam|tra|scn|lua)$/;
   const safeReaddirSync = (path, option) => {
     try {
       return fs.readdirSync(path, option);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make `.lua` files recognized as AviUtl-related files. This allows us to detect manual installations of libraries that contain only lua files. Currently only `shummg/dotdrawer` and `shummg/shuGame` are affected by this change.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/team-apm/apm-data/pull/274

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Automatically detects installed shummg/shuGame.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
