### PR TITLE
Refactor for future removal the warning

### DIFF
--- a/src/migration/migration1to2.ts
+++ b/src/migration/migration1to2.ts
@@ -1,6 +1,6 @@
 import log from 'electron-log';
 import Store from 'electron-store';
-import fs from 'fs-extra';
+import { existsSync, readdir, rename, unlink } from 'fs-extra';
 import path from 'path';
 import * as apmJson from '../lib/apmJson';
 import {
@@ -43,7 +43,7 @@ async function global() {
       const newDataURL = await migration1to2DataurlInputDialog();
       if (!newDataURL) {
         continue;
-      } else if (!newDataURL.startsWith('http') && !fs.existsSync(newDataURL)) {
+      } else if (!newDataURL.startsWith('http') && !existsSync(newDataURL)) {
         await openDialog(
           'エラー',
           '有効なURLまたは場所を入力してください。',
@@ -83,7 +83,7 @@ async function global() {
     path.join(dataFolder, 'mod.xml'),
     path.join(dataFolder, 'core/core.xml'),
     ...(
-      await fs.readdir(path.join(dataFolder, 'package/'), {
+      await readdir(path.join(dataFolder, 'package/'), {
         withFileTypes: true,
       })
     )
@@ -95,7 +95,7 @@ async function global() {
   ];
   files.forEach(async (file) => {
     try {
-      await fs.unlink(file);
+      await unlink(file);
     } catch (e) {
       log.error(e);
     }
@@ -120,7 +120,7 @@ async function global() {
 async function byFolder(instPath: string) {
   // Guard condition
   const jsonPath = apmJson.getPath(instPath);
-  const jsonExists = fs.existsSync(jsonPath);
+  const jsonExists = existsSync(jsonPath);
   if (!jsonExists) return;
 
   const isVerOne = !(await apmJson.has(instPath, 'dataVersion'));
@@ -134,8 +134,8 @@ async function byFolder(instPath: string) {
 
   // 2. Renaming the local repository
   try {
-    if (fs.existsSync(path.join(instPath, 'packages_list.xml'))) {
-      await fs.rename(
+    if (existsSync(path.join(instPath, 'packages_list.xml'))) {
+      await rename(
         path.join(instPath, 'packages_list.xml'),
         path.join(instPath, 'packages.xml')
       );

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -9,7 +9,7 @@ import {
   readdir,
   readJson,
   rename,
-  rmdir,
+  rm,
 } from 'fs-extra';
 import List, { ListItem } from 'list.js';
 import * as matcher from 'matcher';
@@ -1167,7 +1167,7 @@ async function installScript(instPath: string) {
 
     // Rename the extracted folder
     const newPath = path.join(path.dirname(unzippedPath), id);
-    if (existsSync(newPath)) await rmdir(newPath, { recursive: true });
+    if (existsSync(newPath)) await rm(newPath, { recursive: true });
     await rename(unzippedPath, newPath);
 
     // Save package information


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Refactor for the future removal and for fixing of the warning.

- Remove `fs.rmdir` for the future removal.
- Change to named imports in `migration1to2.ts`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
