### PR TITLE
fix(unzip.ts): no codepoint when unzipping .7z

### DIFF
--- a/src/lib/unzip.ts
+++ b/src/lib/unzip.ts
@@ -37,7 +37,13 @@ async function unzip(zipPath: string, folderName?: string) {
   const zipStream = extractFull(zipPath, targetPath, {
     $bin: pathTo7zip,
     overwrite: 'a',
-    method: ['cp=932'], // AviUtl script is encoded in Shift_JIS, so we need to specify the code page as Shift_JIS(932) when unzipping.
+    ...(path.extname(zipPath) === '.7z'
+      ? {}
+      : {
+          method: ['cp=932'],
+        }),
+    // AviUtl script is encoded in Shift_JIS, so we need to specify the code page as Shift_JIS(932) when unzipping.
+    // But you must not specify when unzipping .7z.
   });
   return new Promise((resolve) => {
     zipStream.once('end', () => {


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a bug that prevented .7z files from being unzipped.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- #1188

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Motion Tracking MK-II can be installed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
