### PR TITLE
feat: update darktheme

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "7zip-bin": "^5.2.0",
     "bootstrap": "^5.3.2",
-    "bootstrap-dark-5": "^1.1.3",
     "bootstrap-icons": "^1.11.1",
     "clipboard": "^2.0.11",
     "compare-versions": "^6.1.0",

--- a/src/main.ts
+++ b/src/main.ts
@@ -357,8 +357,8 @@ async function launch() {
 
   const getTitleBarColor = () => {
     return {
-      color: nativeTheme.shouldUseDarkColors ? '#2e2e2e' : '#f0f2f4',
-      symbolColor: nativeTheme.shouldUseDarkColors ? '#FFF' : '#000',
+      color: nativeTheme.shouldUseDarkColors ? '#2b3035' : '#f8f9fa',
+      symbolColor: nativeTheme.shouldUseDarkColors ? '#dee2e6' : '#212529',
     };
   };
 

--- a/src/renderer/main.css
+++ b/src/renderer/main.css
@@ -5,10 +5,7 @@
     'Hiragino Kaku Gothic ProN', 'Arial', 'Meiryo', sans-serif;
   --font-family-serif: 'Times New Roman', 'YuMincho', 'Hiragino Mincho ProN',
     'Yu Mincho', 'MS PMincho', serif;
-  --bs-gray-150: #f0f2f4;
-  --bs-gray-850: #2e2e2e;
-  --bs-gray-950: #1a1a1a;
-  --bs-light-blue: #58a6ff;
+  --bs-border-radius: 0.2rem;
 }
 body {
   font-family: 'Helvetica Neue', 'Helvetica', 'Hiragino Sans',
@@ -20,138 +17,11 @@ th {
 .nav-tabs .nav-link {
   color: var(--bs-body-color);
 }
-.nav-tabs .nav-link.active {
-  color: var(--bs-body-color);
-}
-@media (prefers-color-scheme: light) {
-  .list-group-item-secondary {
-    background-color: var(--bs-gray-100);
-  }
-  .list-group-item-secondary.list-group-item-action:hover {
-    background-color: var(--bs-gray-100);
-  }
-  .bg-light {
-    background-color: var(--bs-gray-150) !important;
-  }
-}
-@media (prefers-color-scheme: dark) {
-  /* dark mode background */
-  .bg-white {
-    background-color: var(--bs-gray-950) !important;
-  }
-  .bg-light {
-    background-color: var(--bs-gray-850) !important;
-  }
-  .nav-tabs .nav-link.active {
-    background-color: var(--bs-gray-950);
-  }
-  .card {
-    background-color: var(--bs-gray-900);
-  }
-  .dropdown-menu {
-    background-color: var(--bs-gray-850);
-  }
-  .list-group-item-secondary {
-    background-color: var(--bs-gray-850);
-  }
-  .list-group-item-secondary.list-group-item-action:hover {
-    background-color: var(--bs-gray-850);
-  }
-
-  /* improve text visibility */
-  .text-primary {
-    color: var(--bs-light-blue) !important;
-  }
-  a {
-    color: var(--bs-light-blue);
-  }
-  .form-control {
-    color: var(--bs-gray-100);
-  }
-  .form-control:focus {
-    color: var(--bs-gray-100);
-  }
-  .form-control::placeholder {
-    color: var(--bs-gray-300);
-  }
-  .form-control::placeholder:focus {
-    color: var(--bs-gray-300);
-  }
-  .list-group-item-secondary {
-    color: var(--bs-body-color);
-  }
-  .list-group-item-action:hover {
-    color: var(--bs-body-color);
-  }
-  .list-group-item-secondary.list-group-item-action:hover {
-    color: var(--bs-body-color);
-  }
-
-  /* use fill instead of outline */
-  .btn-outline-primary {
-    color: var(--bs-white);
-    background-color: rgba(var(--bs-primary-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-primary-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-primary:disabled {
-    color: var(--bs-white);
-    background-color: rgba(var(--bs-primary-rgb), 0.65);
-    border-color: rgba(var(--bs-primary-rgb), 0.65);
-    opacity: 1;
-  }
-  .btn-outline-secondary {
-    color: var(--bs-white);
-    background-color: rgba(var(--bs-secondary-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-secondary-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-secondary:disabled {
-    color: var(--bs-white);
-    background-color: rgba(var(--bs-secondary-rgb), 0.65);
-    border-color: rgba(var(--bs-secondary-rgb), 0.65);
-    opacity: 1;
-  }
-  .btn-outline-success {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-success-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-success-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-success:disabled {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-success-rgb), 0.65);
-    border-color: rgba(var(--bs-success-rgb), 0.65);
-    opacity: 1;
-  }
-  .btn-outline-danger {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-danger-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-danger-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-danger:disabled {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-danger-rgb), 0.65);
-    border-color: rgba(var(--bs-danger-rgb), 0.65);
-    opacity: 1;
-  }
-  .btn-outline-warning {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-warning-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-warning-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-warning:disabled {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-warning-rgb), 0.65);
-    border-color: rgba(var(--bs-warning-rgb), 0.65);
-    opacity: 1;
-  }
-  .btn-outline-info {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-info-rgb), var(--bs-bg-opacity));
-    border-color: rgba(var(--bs-info-rgb), var(--bs-bg-opacity));
-  }
-  .btn-outline-info:disabled {
-    color: var(--bs-black);
-    background-color: rgba(var(--bs-info-rgb), 0.65);
-    border-color: rgba(var(--bs-info-rgb), 0.65);
-    opacity: 1;
-  }
+.btn-primary {
+  --bs-btn-disabled-bg: #0b5ed7;
+  --bs-btn-disabled-border-color: #0a58ca;
+  --bs-btn-bg: #0b5ed7;
+  --bs-btn-border-color: #0a58ca;
+  --bs-btn-hover-bg: #0a58ca;
+  --bs-btn-hover-border-color: #0a53be;
 }

--- a/src/renderer/main.css
+++ b/src/renderer/main.css
@@ -28,7 +28,7 @@ th {
     background-color: var(--bs-gray-100);
   }
   .list-group-item-secondary.list-group-item-action:hover {
-    background-color: var(--bs-gray-150);
+    background-color: var(--bs-gray-100);
   }
   .bg-light {
     background-color: var(--bs-gray-150) !important;
@@ -55,7 +55,7 @@ th {
     background-color: var(--bs-gray-850);
   }
   .list-group-item-secondary.list-group-item-action:hover {
-    background-color: var(--bs-gray-800);
+    background-color: var(--bs-gray-850);
   }
 
   /* improve text visibility */

--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -100,24 +100,6 @@ async function displayInstalledVersion(instPath: string) {
     }
   }
 
-  // update the batch installation text
-  const batchInstallElm = document.getElementById('batch-install-programs');
-  batchInstallElm.innerHTML = null;
-  programs
-    .map((p) => {
-      if (isInstalled[p]) {
-        const pTag = document.createElement('span');
-        pTag.classList.add('text-muted');
-        pTag.innerText = '✔' + programsDisp[p];
-        batchInstallElm.appendChild(pTag);
-        return [pTag];
-      } else {
-        return [document.createTextNode(programsDisp[p])];
-      }
-    })
-    .reduce((a, b) => [].concat(a, document.createTextNode(' + '), b))
-    .forEach((e) => batchInstallElm.appendChild(e));
-
   if (store.has('modDate.core')) {
     const modDate = new Date(store.get('modDate.core') as number);
     replaceText('core-mod-date', modDate.toLocaleString());
@@ -265,10 +247,10 @@ async function checkLatestVersion(instPath: string) {
 
 /**
  * Shows a dialog to select installation path and set it.
- * @param {HTMLInputElement} input - A HTMLElement of input.
+ * @param {HTMLInputElement} installationPath - A HTMLElement of input.
  */
-async function selectInstallationPath(input: HTMLInputElement) {
-  const originalPath = input.value;
+async function selectInstallationPath(installationPath: HTMLSpanElement) {
+  const originalPath = installationPath.innerText;
   const selectedPath = await openDirDialog(
     'インストール先フォルダを選択',
     originalPath,
@@ -285,7 +267,7 @@ async function selectInstallationPath(input: HTMLInputElement) {
 
     const instPath = selectedPath[0];
     await changeInstallationPath(instPath);
-    input.value = instPath;
+    installationPath.innerText = instPath;
   }
 }
 
@@ -497,7 +479,10 @@ async function installProgram(
  */
 async function batchInstall(instPath: string) {
   const btn = document.getElementById('batch-install') as HTMLButtonElement;
-  const { enableButton } = buttonTransition.loading(btn, 'インストール');
+  const { enableButton } = buttonTransition.loading(
+    btn,
+    '最新版のAviUtl・拡張編集とおすすめプラグインをインストール',
+  );
 
   if (!instPath) {
     log.error('An installation path is not selected.');

--- a/src/renderer/main/index.css
+++ b/src/renderer/main/index.css
@@ -72,19 +72,11 @@ div#packages-table-overlay {
 }
 .sort.desc:after {
   border-width: 0 0.3em 0.6em;
-  border-color: #505050 transparent;
+  border-color: var(--bs-body-color) transparent;
 }
 .sort.asc:after {
   border-width: 0.6em 0.3em 0;
-  border-color: #505050 transparent;
-}
-@media (prefers-color-scheme: dark) {
-  .sort.desc:after {
-    border-color: #a0a0a0 transparent;
-  }
-  .sort.asc:after {
-    border-color: #a0a0a0 transparent;
-  }
+  border-color: var(--bs-body-color) transparent;
 }
 
 img.emoji {

--- a/src/renderer/main/index.css
+++ b/src/renderer/main/index.css
@@ -7,8 +7,6 @@ section,
 section#packages .container-lg,
 section#packages .container-lg > .card,
 section#packages .container-lg > .card > .card-body,
-section#packages .container-lg > .card > .card-body > div,
-section#packages .container-lg > .card > .card-body > div > div,
 section#nicommons .container-lg,
 section#nicommons .container-lg > .card,
 section#nicommons .container-lg > .card > .card-body {
@@ -20,6 +18,9 @@ main {
       env(titlebar-area-height, var(--fallback-title-bar-height))
   );
   overflow-y: auto;
+}
+.min-h-0 {
+  min-height: 0;
 }
 .draggable {
   -webkit-app-region: drag;
@@ -100,8 +101,4 @@ section#nicommons img {
   section#nicommons img {
     max-height: 96px;
   }
-}
-
-#install-package {
-  min-width: 8rem;
 }

--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -232,345 +232,351 @@
 				<div class="container-lg">
 					<div class="row card border-top-0 border-bottom-0 rounded-0">
 						<div class="card-body py-2">
-							<div class="row">
-								<div class="col-sm-auto overflow-auto">
-									<div class="position-relative">
-										<input
-											class="fuzzy-search-wrapped form-control position-absolute w-100"
-											placeholder="検索 / 🍎️🎞︎🎬︎"
-											aria-label="検索 / インポート"
-										/>
-										<!-- A very ugly element to work around the problem
-											of incorrect box-sizing being applied to the input element -->
-										<input
-											class="form-control px-0 mb-3"
-											placeholder="検索spacer"
-										/>
-									</div>
-									<ul
-										id="filter"
-										class="list-unstyled"
-										aria-labelledby="type-filter"
-									>
-										<li>
-											<button
-												class="dropdown-item install-filter px-0"
-												type="button"
-												data-install-filter="clear"
-											>
-												<i class="bi bi-check me-1"></i
-												><i class="bi bi-box-seam me-1"></i>
-											</button>
-											<ul class="list-unstyled ps-3" aria-labelledby="">
-												<li>
-													<button
-														class="dropdown-item install-filter px-0"
-														type="button"
-														data-install-filter="true"
-													>
-														<i class="bi bi-check"></i>インストール済み
-													</button>
-												</li>
-												<li>
-													<button
-														class="dropdown-item install-filter px-0"
-														type="button"
-														data-install-filter="manual"
-													>
-														<i class="bi bi-check"></i>手動インストール済み
-													</button>
-												</li>
-												<li>
-													<button
-														class="dropdown-item install-filter px-0"
-														type="button"
-														data-install-filter="false"
-													>
-														<i class="bi bi-check"></i>未インストール
-													</button>
-												</li>
-											</ul>
-										</li>
-										<li>
-											<hr class="mx-2 dropdown-divider" />
-											探す
-										</li>
-										<li>
-											<button
-												class="dropdown-item type-filter px-0"
-												type="button"
-												data-type-filter="plugin"
-											>
-												<i class="bi bi-check me-1"></i
-												><i class="bi bi-film me-1"></i>プラグイン
-											</button>
-											<ul class="list-unstyled ps-3" aria-labelledby="">
-												<li>
-													<button
-														class="dropdown-item type-filter px-0"
-														type="button"
-														data-type-filter="input"
-													>
-														<i class="bi bi-check"></i>入力
-													</button>
-												</li>
-												<li>
-													<button
-														class="dropdown-item type-filter px-0"
-														type="button"
-														data-type-filter="output"
-													>
-														<i class="bi bi-check"></i>出力
-													</button>
-												</li>
-												<li>
-													<button
-														class="dropdown-item type-filter px-0"
-														type="button"
-														data-type-filter="filter"
-													>
-														<i class="bi bi-check"></i>フィルター
-													</button>
-												</li>
-												<li>
-													<button
-														class="dropdown-item type-filter px-0"
-														type="button"
-														data-type-filter="color"
-													>
-														<i class="bi bi-check"></i>色変換
-													</button>
-												</li>
-												<li>
-													<button
-														class="dropdown-item type-filter px-0"
-														type="button"
-														data-type-filter="language"
-													>
-														<i class="bi bi-check"></i>言語
-													</button>
-												</li>
-											</ul>
-										</li>
-										<li>
-											<button
-												class="dropdown-item type-filter px-0"
-												type="button"
-												data-type-filter="script"
-											>
-												<i class="bi bi-check me-1"></i
-												><i class="bi bi-calendar3-range me-1"></i>スクリプト
-											</button>
-											<ul class="list-unstyled ps-3" aria-labelledby="">
-												<li>
-													<button
-														class="dropdown-item type-filter px-0"
-														type="button"
-														data-type-filter="script-dist"
-													>
-														<i class="bi bi-check"></i>配布サイトから探す
-													</button>
-												</li>
-												<li><hr class="mx-2 dropdown-divider" /></li>
-												<li>
-													<button
-														class="dropdown-item type-filter px-0"
-														type="button"
-														data-type-filter="animation"
-													>
-														<i class="bi bi-check"></i>アニメーション効果
-													</button>
-												</li>
-												<li>
-													<button
-														class="dropdown-item type-filter px-0"
-														type="button"
-														data-type-filter="object"
-													>
-														<i class="bi bi-check"></i>カスタムオブジェクト
-													</button>
-												</li>
-												<li>
-													<button
-														class="dropdown-item type-filter px-0"
-														type="button"
-														data-type-filter="scene"
-													>
-														<i class="bi bi-check"></i>シーンチェンジ
-													</button>
-												</li>
-												<li>
-													<button
-														class="dropdown-item type-filter px-0"
-														type="button"
-														data-type-filter="camera"
-													>
-														<i class="bi bi-check"></i>カメラ制御
-													</button>
-												</li>
-												<li>
-													<button
-														class="dropdown-item type-filter px-0"
-														type="button"
-														data-type-filter="track"
-													>
-														<i class="bi bi-check"></i>トラックバー
-													</button>
-												</li>
-											</ul>
-										</li>
-
-										<li>
-											<a
-												href="https://team-apm.github.io/apm/#%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%97%E3%83%88%E3%81%A8%E3%81%AF"
-												class="dropdown-item pe-0"
-												type="button"
-											>
-												<i class="bi bi-info-circle me-1"></i>これは何？<i
-													class="bi bi-box-arrow-up-right ms-1"
-												></i>
-											</a>
-										</li>
-										<li>
-											<hr class="mx-2 dropdown-divider" />
-											作る
-										</li>
-										<li>
-											<a
-												href="https://docs.google.com/forms/d/e/1FAIpQLSf0N-X_u_abi8rrWHVDdiK3YeYuQ7J1f8bQAy6QTD-OR94DWQ/viewform?usp=sf_link"
-												class="dropdown-item pe-0"
-												type="button"
-											>
-												<i class="bi bi-megaphone me-1"></i>提案する<i
-													class="bi bi-box-arrow-up-right ms-1"
-												></i>
-											</a>
-										</li>
-										<li>
-											<a
-												href="https://team-apm.github.io/apm-web/"
-												class="dropdown-item pe-0"
-												type="button"
-											>
-												<i class="bi bi-pencil me-1"></i>作ってみる<i
-													class="bi bi-box-arrow-up-right ms-1"
-												></i>
-											</a>
-										</li>
-									</ul>
-								</div>
-								<div class="col d-flex flex-column">
-									<div class="">
+							<div class="d-flex flex-column h-100">
+								<div class="flex-shrink-1">
+									<div class="d-flex mb-2">
+										<div class="border rounded flex-grow-1 w-auto d-flex">
+											<input
+												class="form-control border-0 flex-grow-1 w-auto fuzzy-search-wrapped"
+												placeholder="🔍︎ 検索  |  共有貼り付け"
+												aria-label="検索 / 共有"
+												size="2"
+											/>
+											<div class="d-flex" id="packages-sort"></div>
+										</div>
 										<button
 											type="button"
-											class="btn btn-outline-primary mb-2"
+											class="btn btn-outline-primary ms-2"
 											id="install-package"
 										>
 											インストール
 										</button>
 										<button
 											type="button"
-											class="btn btn-outline-primary mb-2"
+											class="btn btn-outline-primary ms-2"
 											id="uninstall-package"
 										>
 											アンインストール
 										</button>
 										<button
 											type="button"
-											class="btn btn-outline-primary mb-2"
+											class="btn btn-outline-primary ms-2"
 											id="open-package-folder"
 										>
 											ダウンロードフォルダ
 										</button>
 										<button
 											type="button"
-											class="btn btn-outline-primary mb-2"
+											class="btn btn-outline-primary ms-2"
 											id="share-packages"
 										>
 											共有
 										</button>
 									</div>
-									<div id="custom-search-alert"></div>
-									<div class="my-1 ms-auto" id="packages-sort"></div>
-									<div class="row flex-grow-1 overflow-auto">
-										<div class="col" id="packages-table">
+								</div>
+								<div class="h-100 min-h-0">
+									<div class="row h-100">
+										<div class="col-sm-auto overflow-auto h-100">
 											<ul
-												class="list list-group list-group-flush"
-												id="packages-list"
-											></ul>
-											<ul
-												class="list-group list-group-flush"
-												id="packages-list2"
-											></ul>
+												id="filter"
+												class="list-unstyled"
+												aria-labelledby="type-filter"
+											>
+												<li>
+													<button
+														class="dropdown-item install-filter px-0"
+														type="button"
+														data-install-filter="clear"
+													>
+														<i class="bi bi-check me-1"></i
+														><i class="bi bi-box-seam me-1"></i>
+													</button>
+													<ul class="list-unstyled ps-3" aria-labelledby="">
+														<li>
+															<button
+																class="dropdown-item install-filter px-0"
+																type="button"
+																data-install-filter="true"
+															>
+																<i class="bi bi-check"></i>インストール済み
+															</button>
+														</li>
+														<li>
+															<button
+																class="dropdown-item install-filter px-0"
+																type="button"
+																data-install-filter="manual"
+															>
+																<i class="bi bi-check"></i>手動インストール済み
+															</button>
+														</li>
+														<li>
+															<button
+																class="dropdown-item install-filter px-0"
+																type="button"
+																data-install-filter="false"
+															>
+																<i class="bi bi-check"></i>未インストール
+															</button>
+														</li>
+													</ul>
+												</li>
+												<li>
+													<hr class="mx-2 dropdown-divider" />
+													探す
+												</li>
+												<li>
+													<button
+														class="dropdown-item type-filter px-0"
+														type="button"
+														data-type-filter="plugin"
+													>
+														<i class="bi bi-check me-1"></i
+														><i class="bi bi-film me-1"></i>プラグイン
+													</button>
+													<ul class="list-unstyled ps-3" aria-labelledby="">
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="input"
+															>
+																<i class="bi bi-check"></i>入力
+															</button>
+														</li>
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="output"
+															>
+																<i class="bi bi-check"></i>出力
+															</button>
+														</li>
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="filter"
+															>
+																<i class="bi bi-check"></i>フィルター
+															</button>
+														</li>
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="color"
+															>
+																<i class="bi bi-check"></i>色変換
+															</button>
+														</li>
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="language"
+															>
+																<i class="bi bi-check"></i>言語
+															</button>
+														</li>
+													</ul>
+												</li>
+												<li>
+													<button
+														class="dropdown-item type-filter px-0"
+														type="button"
+														data-type-filter="script"
+													>
+														<i class="bi bi-check me-1"></i
+														><i class="bi bi-calendar3-range me-1"></i
+														>スクリプト
+													</button>
+													<ul class="list-unstyled ps-3" aria-labelledby="">
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="script-dist"
+															>
+																<i class="bi bi-check"></i>配布サイトから探す
+															</button>
+														</li>
+														<li><hr class="mx-2 dropdown-divider" /></li>
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="animation"
+															>
+																<i class="bi bi-check"></i>アニメーション効果
+															</button>
+														</li>
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="object"
+															>
+																<i class="bi bi-check"></i>カスタムオブジェクト
+															</button>
+														</li>
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="scene"
+															>
+																<i class="bi bi-check"></i>シーンチェンジ
+															</button>
+														</li>
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="camera"
+															>
+																<i class="bi bi-check"></i>カメラ制御
+															</button>
+														</li>
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="track"
+															>
+																<i class="bi bi-check"></i>トラックバー
+															</button>
+														</li>
+													</ul>
+												</li>
+
+												<li>
+													<a
+														href="https://team-apm.github.io/apm/#%E3%83%97%E3%83%A9%E3%82%B0%E3%82%A4%E3%83%B3%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%97%E3%83%88%E3%81%A8%E3%81%AF"
+														class="dropdown-item pe-0"
+														type="button"
+													>
+														<i class="bi bi-info-circle me-1"></i>これは何？<i
+															class="bi bi-box-arrow-up-right ms-1"
+														></i>
+													</a>
+												</li>
+												<li>
+													<hr class="mx-2 dropdown-divider" />
+													作る
+												</li>
+												<li>
+													<a
+														href="https://docs.google.com/forms/d/e/1FAIpQLSf0N-X_u_abi8rrWHVDdiK3YeYuQ7J1f8bQAy6QTD-OR94DWQ/viewform?usp=sf_link"
+														class="dropdown-item pe-0"
+														type="button"
+													>
+														<i class="bi bi-megaphone me-1"></i>提案する<i
+															class="bi bi-box-arrow-up-right ms-1"
+														></i>
+													</a>
+												</li>
+												<li>
+													<a
+														href="https://team-apm.github.io/apm-web/"
+														class="dropdown-item pe-0"
+														type="button"
+													>
+														<i class="bi bi-pencil me-1"></i>作ってみる<i
+															class="bi bi-box-arrow-up-right ms-1"
+														></i>
+													</a>
+												</li>
+											</ul>
 										</div>
-										<div
-											class="d-flex justify-content-center align-items-center fade"
-											id="packages-table-overlay"
-										>
-											<div class="spinner-border" role="status">
-												<span class="visually-hidden">Loading...</span>
-											</div>
-										</div>
-									</div>
-									<div class="d-none">
-										<div
-											id="sort-template"
-											class="sort rounded-pill d-inline-block px-2 mx-1 list-group-item-secondary small border"
-										></div>
-										<span
-											id="tag-template"
-											class="rounded-pill d-inline-block px-2 mx-1 list-group-item-secondary small border"
-										></span>
-										<li
-											id="list-template"
-											class="list-group-item list-group-item-action"
-										>
-											<input type="radio" name="accordion" />
-											<label class="d-block">
-												<div class="row">
-													<div class="col-sm-9">
-														<div class="d-none packageID"></div>
-														<h5 class="d-inline-block name"></h5>
-														<div
-															class="text-primary d-inline-block ms-2 developer"
-														></div>
-														<div class="d-inline-block ms-1 type"></div>
-														<br />
-														<div
-															class="d-inline-block text-break overview text-muted"
-														></div>
-														<div class="accordion-detail">
-															<div class="text-break description"></div>
-															<div
-																class="text-break dependencyInformation"
-															></div>
-															<div class="text-break">
-																<a class="pageURL"></a>
-															</div>
-														</div>
-													</div>
-													<div class="col-sm-3">
-														<div class="text-break latestVersion"></div>
-														<div class="text-break statusInformation"></div>
-														<div
-															class="text-break installationStatus text-muted"
-														></div>
+										<div class="col d-flex flex-column h-100">
+											<div id="custom-search-alert"></div>
+											<div class="row flex-grow-1 overflow-auto">
+												<div class="col" id="packages-table">
+													<ul
+														class="list list-group list-group-flush"
+														id="packages-list"
+													></ul>
+													<ul
+														class="list-group list-group-flush"
+														id="packages-list2"
+													></ul>
+												</div>
+												<div
+													class="d-flex justify-content-center align-items-center fade"
+													id="packages-table-overlay"
+												>
+													<div class="spinner-border" role="status">
+														<span class="visually-hidden">Loading...</span>
 													</div>
 												</div>
-											</label>
-										</li>
-										<div
-											id="alert-template"
-											class="mt-2 mb-1 alert alert-info alert-dismissible fade show"
-											role="alert"
-										>
-											<div class="alert-text"></div>
-											<button
-												type="button"
-												class="btn-close"
-												data-bs-dismiss="alert"
-												aria-label="Close"
-											></button>
+											</div>
+											<div class="d-none">
+												<div
+													id="sort-template"
+													class="sort rounded-pill d-inline-block px-2 mx-1 my-auto list-group-item-secondary small border"
+												></div>
+												<span
+													id="tag-template"
+													class="d-inline-block small"
+												></span>
+												<li
+													id="list-template"
+													class="list-group-item list-group-item-action text-muted"
+												>
+													<input type="radio" name="accordion" />
+													<label class="d-block">
+														<div class="row">
+															<div class="col-sm-9">
+																<div class="d-none packageID"></div>
+																<h5
+																	class="mb-1 text-body d-inline-block name"
+																></h5>
+																<div
+																	class="d-inline-block ms-2 developer"
+																></div>
+																<div class="d-inline-block ms-1 type"></div>
+																<br />
+																<div
+																	class="d-inline-block text-break overview"
+																></div>
+																<div class="accordion-detail mt-2">
+																	<div class="text-break description"></div>
+																	<div
+																		class="text-break dependencyInformation"
+																	></div>
+																	<div class="text-break">
+																		<a class="pageURL"></a>
+																	</div>
+																</div>
+															</div>
+															<div class="col-sm-3">
+																<div class="text-break latestVersion"></div>
+																<div
+																	class="text-break statusInformation fw-bold"
+																></div>
+																<div
+																	class="text-break installationStatus"
+																></div>
+															</div>
+														</div>
+													</label>
+												</li>
+												<div
+													id="alert-template"
+													class="mt-2 mb-1 alert alert-info alert-dismissible fade show"
+													role="alert"
+												>
+													<div class="alert-text"></div>
+													<button
+														type="button"
+														class="btn-close"
+														data-bs-dismiss="alert"
+														aria-label="Close"
+													></button>
+												</div>
+											</div>
 										</div>
 									</div>
 								</div>

--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -139,7 +139,7 @@
 									class="btn btn-primary rounded-0 rounded-end"
 									id="select-installation-path"
 								>
-									AviUtlフォルダを選択
+									AviUtlインストールフォルダを選択
 								</button>
 							</div>
 							<ul class="list-group mb-3" id="batch-install-packages">
@@ -269,7 +269,9 @@
 								</div>
 								<div class="h-100 min-h-0">
 									<div class="row h-100">
-										<div class="col-sm-auto overflow-auto h-100">
+										<div
+											class="col-sm-auto overflow-x-hidden overflow-y-auto h-100"
+										>
 											<ul
 												id="filter"
 												class="list-unstyled dropdown-menu d-block position-static border-0"
@@ -282,7 +284,7 @@
 														data-install-filter="clear"
 													>
 														<i class="bi bi-check me-1"></i
-														><i class="bi bi-box-seam me-1"></i>
+														><i class="bi bi-box-seam me-1"></i>パッケージ
 													</button>
 													<ul class="list-unstyled ps-3" aria-labelledby="">
 														<li>
@@ -390,16 +392,6 @@
 															<button
 																class="dropdown-item type-filter px-0"
 																type="button"
-																data-type-filter="script-dist"
-															>
-																<i class="bi bi-check"></i>配布サイトから探す
-															</button>
-														</li>
-														<li><hr class="mx-2 dropdown-divider" /></li>
-														<li>
-															<button
-																class="dropdown-item type-filter px-0"
-																type="button"
 																data-type-filter="animation"
 															>
 																<i class="bi bi-check"></i>アニメーション効果
@@ -439,6 +431,15 @@
 																data-type-filter="track"
 															>
 																<i class="bi bi-check"></i>トラックバー
+															</button>
+														</li>
+														<li>
+															<button
+																class="dropdown-item type-filter px-0"
+																type="button"
+																data-type-filter="script-dist"
+															>
+																<i class="bi bi-check"></i>配布サイトから探す
 															</button>
 														</li>
 													</ul>

--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -96,8 +96,10 @@
 									src="../../../icon/apm32.png"
 									alt=""
 									class="d-inline-block"
+									width="20"
+									height="20"
 								/>
-								<span class="align-middle">AviUtl Package Manager</span>
+								<span class="ms-1 align-middle">AviUtl Package Manager</span>
 							</span>
 						</div>
 					</nav>
@@ -122,101 +124,92 @@
 							></button>
 						</div>
 					</div>
-					<div class="row my-2">
-						<div class="card">
-							<div class="card-body">
-								<div class="row mb-3">
-									<label for="installation-path" class="col-sm-3 col-form-label"
-										>AviUtlフォルダ</label
-									>
-									<div class="col-sm-6">
-										<input
-											class="form-control-plaintext"
-											id="installation-path"
-											type="text"
-											placeholder="AviUtlフォルダ"
-											aria-label="Installation path"
-											readonly
-										/>
-									</div>
-									<div class="col-sm-3">
-										<button
-											type="button"
-											class="btn btn-outline-primary w-100"
-											id="select-installation-path"
-										>
-											フォルダを選択
-										</button>
-									</div>
+					<div class="row my-2 card">
+						<div class="card-body">
+							<div class="mb-3 d-flex">
+								<div
+									class="flex-grow-1 border rounded-start d-flex align-items-center px-3"
+									id="addon-wrapping"
+								>
+									<i class="bi bi-folder2 me-3"></i>
+									<span id="installation-path"></span>
 								</div>
-								<div class="row mb-4">
-									<p class="col-sm-3 col-form-label">おすすめインストール</p>
-									<p class="col-sm-6 col-form-label">
-										<span id="batch-install-programs"></span
-										><span id="batch-install-packages"></span>
-									</p>
-									<div class="col-sm-3">
-										<button
-											type="button"
-											class="btn btn-outline-primary w-100"
-											id="batch-install"
-										>
-											インストール
-										</button>
+								<button
+									type="button"
+									class="btn btn-outline-primary rounded-0 rounded-end"
+									id="select-installation-path"
+								>
+									AviUtlフォルダを選択
+								</button>
+							</div>
+							<ul class="list-group mb-3" id="batch-install-packages">
+								<li class="list-group-item py-0 pe-0 d-flex">
+									<div class="d-flex align-items-center flex-grow-1">
+										<i class="bi bi-film me-3"></i> AviUtl
 									</div>
-								</div>
-								<div class="row mb-4">
-									<p class="col-sm-3 col-form-label">
-										<i class="bi bi-film me-1"></i> AviUtl
-									</p>
-									<p class="col-sm-6 col-form-label">
+									<div>
 										<span id="aviutl-installed-version"></span>
-									</p>
-									<div class="col-sm-3">
+										<button
+											type="button"
+											class="btn btn-outline-primary dropdown-toggle"
+											id="install-aviutl"
+											data-bs-toggle="dropdown"
+											aria-expanded="false"
+										></button>
 										<div class="dropdown bg-body">
-											<button
-												type="button"
-												class="btn btn-outline-primary w-100 dropdown-toggle"
-												id="install-aviutl"
-												data-bs-toggle="dropdown"
-												aria-expanded="false"
-											>
-												インストール
-											</button>
 											<ul
-												class="dropdown-menu"
+												class="dropdown-menu dropdown-menu-end"
 												id="aviutl-version-select"
 												aria-labelledby="install-aviutl"
 											></ul>
 										</div>
 									</div>
-								</div>
-								<div class="row mb-4">
-									<p class="col-sm-3 col-form-label">
-										<i class="bi bi-calendar3-range me-1"></i> 拡張編集
-									</p>
-									<p class="col-sm-6 col-form-label">
+								</li>
+								<li class="list-group-item py-0 pe-0 d-flex">
+									<div class="d-flex align-items-center flex-grow-1">
+										<i class="bi bi-calendar3-range me-3"></i> 拡張編集
+									</div>
+									<div>
 										<span id="exedit-installed-version"></span>
-									</p>
-									<div class="col-sm-3">
+										<button
+											type="button"
+											class="btn btn-outline-primary dropdown-toggle"
+											id="install-exedit"
+											data-bs-toggle="dropdown"
+											aria-expanded="false"
+										></button>
 										<div class="dropdown bg-body">
-											<button
-												type="button"
-												class="btn btn-outline-primary w-100 dropdown-toggle"
-												id="install-exedit"
-												data-bs-toggle="dropdown"
-												aria-expanded="false"
-											>
-												インストール
-											</button>
 											<ul
-												class="dropdown-menu"
+												class="dropdown-menu dropdown-menu-end"
 												id="exedit-version-select"
 												aria-labelledby="install-exedit"
 											></ul>
 										</div>
 									</div>
-								</div>
+								</li>
+							</ul>
+							<div class="d-none">
+								<li
+									id="batch-install-package-template"
+									class="list-group-item py-0 d-flex py-2 batch-install-package"
+								>
+									<div class="d-flex align-items-center flex-grow-1">
+										<i class="bi bi-box-seam me-3"></i>
+										<div class="name"></div>
+									</div>
+									<div>
+										<span class="installed-version"></span>
+									</div>
+								</li>
+							</div>
+							<div class="d-flex justify-content-end">
+								<button
+									type="button"
+									class="btn btn-outline-primary"
+									id="batch-install"
+								>
+									最新版のAviUtl・拡張編集とおすすめプラグインをインストール
+								</button>
 							</div>
 						</div>
 					</div>

--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -13,7 +13,7 @@
 	</head>
 
 	<body>
-		<nav class="bg-light draggable">
+		<nav class="bg-body-tertiary draggable">
 			<div
 				class="title-bar app-name d-flex justify-content-center align-items-center text-muted"
 			></div>
@@ -81,7 +81,7 @@
 			</div>
 		</nav>
 
-		<main class="tab-content bg-white" id="nav-tabContent">
+		<main class="tab-content" id="nav-tabContent">
 			<section
 				class="tab-pane fade show active"
 				id="aviutl"
@@ -136,7 +136,7 @@
 								</div>
 								<button
 									type="button"
-									class="btn btn-outline-primary rounded-0 rounded-end"
+									class="btn btn-primary rounded-0 rounded-end"
 									id="select-installation-path"
 								>
 									AviUtlフォルダを選択
@@ -151,7 +151,7 @@
 										<span id="aviutl-installed-version"></span>
 										<button
 											type="button"
-											class="btn btn-outline-primary dropdown-toggle"
+											class="btn btn-primary dropdown-toggle"
 											id="install-aviutl"
 											data-bs-toggle="dropdown"
 											aria-expanded="false"
@@ -173,7 +173,7 @@
 										<span id="exedit-installed-version"></span>
 										<button
 											type="button"
-											class="btn btn-outline-primary dropdown-toggle"
+											class="btn btn-primary dropdown-toggle"
 											id="install-exedit"
 											data-bs-toggle="dropdown"
 											aria-expanded="false"
@@ -205,7 +205,7 @@
 							<div class="d-flex justify-content-end">
 								<button
 									type="button"
-									class="btn btn-outline-primary"
+									class="btn btn-primary"
 									id="batch-install"
 								>
 									最新版のAviUtl・拡張編集とおすすめプラグインをインストール
@@ -239,28 +239,28 @@
 										</div>
 										<button
 											type="button"
-											class="btn btn-outline-primary ms-2"
+											class="btn btn-primary ms-2"
 											id="install-package"
 										>
 											インストール
 										</button>
 										<button
 											type="button"
-											class="btn btn-outline-primary ms-2"
+											class="btn btn-primary ms-2"
 											id="uninstall-package"
 										>
 											アンインストール
 										</button>
 										<button
 											type="button"
-											class="btn btn-outline-primary ms-2"
+											class="btn btn-primary ms-2"
 											id="open-package-folder"
 										>
 											ダウンロードフォルダ
 										</button>
 										<button
 											type="button"
-											class="btn btn-outline-primary ms-2"
+											class="btn btn-primary ms-2"
 											id="share-packages"
 										>
 											共有
@@ -272,7 +272,7 @@
 										<div class="col-sm-auto overflow-auto h-100">
 											<ul
 												id="filter"
-												class="list-unstyled"
+												class="list-unstyled dropdown-menu d-block position-static border-0"
 												aria-labelledby="type-filter"
 											>
 												<li>
@@ -592,7 +592,7 @@
 								<div class="col-auto">
 									<button
 										type="button"
-										class="btn btn-copy btn-outline-primary"
+										class="btn btn-copy btn-primary"
 										id="copy-nicommons-id-textarea"
 										data-clipboard-target="#nicommons-id-textarea"
 									>
@@ -681,7 +681,7 @@
 									<div class="col-sm-3">
 										<button
 											type="button"
-											class="btn btn-outline-primary w-100"
+											class="btn btn-primary w-100"
 											id="set-data-url"
 										>
 											設定
@@ -807,7 +807,7 @@
 													<div class="bg-body">
 														<button
 															type="button"
-															class="btn btn-outline-primary w-100"
+															class="btn btn-primary w-100"
 															id="check-core-version"
 														>
 															更新
@@ -823,7 +823,7 @@
 													<div class="bg-body">
 														<button
 															type="button"
-															class="btn btn-outline-primary w-100"
+															class="btn btn-primary w-100"
 															id="check-packages-list"
 														>
 															更新
@@ -839,7 +839,7 @@
 													<div class="bg-body">
 														<button
 															type="button"
-															class="btn btn-outline-primary w-100"
+															class="btn btn-primary w-100"
 															id="check-apm-update"
 														>
 															更新
@@ -874,7 +874,7 @@
 									<div class="col-sm-6 btn-group-vertical">
 										<button
 											type="button"
-											class="btn btn-outline-primary"
+											class="btn btn-primary"
 											id="open-about-window"
 										>
 											このアプリについて
@@ -884,14 +884,14 @@
 											<a
 												href="https://github.com/team-apm/apm"
 												role="button"
-												class="btn btn-outline-primary"
+												class="btn btn-primary"
 											>
 												<i class="bi bi-github"></i> GitHub
 											</a>
 											<a
 												href="https://discord.gg/YEQRqnGsG2"
 												role="button"
-												class="btn btn-outline-primary"
+												class="btn btn-primary"
 											>
 												<i class="bi bi-discord"></i> Discord
 											</a>
@@ -906,7 +906,7 @@
 										<a
 											href="https://team-apm.github.io/apm-web/"
 											role="button"
-											class="btn btn-outline-primary w-100"
+											class="btn btn-primary w-100"
 										>
 											開く <i class="bi bi-box-arrow-up-right"></i>
 										</a>
@@ -920,7 +920,7 @@
 										<a
 											href="https://docs.google.com/forms/d/e/1FAIpQLSf0N-X_u_abi8rrWHVDdiK3YeYuQ7J1f8bQAy6QTD-OR94DWQ/viewform?usp=sf_link"
 											role="button"
-											class="btn btn-outline-primary w-100"
+											class="btn btn-primary w-100"
 										>
 											Googleフォーム <i class="bi bi-box-arrow-up-right"></i>
 										</a>
@@ -929,7 +929,7 @@
 										<a
 											href="https://github.com/team-apm/apm/issues"
 											role="button"
-											class="btn btn-outline-primary w-100"
+											class="btn btn-primary w-100"
 										>
 											<i class="bi bi-github"></i> GitHub (要アカウント)
 											<i class="bi bi-box-arrow-up-right"></i>
@@ -941,7 +941,7 @@
 									<div class="col-sm-6">
 										<button
 											type="button"
-											class="btn btn-outline-primary w-100"
+											class="btn btn-primary w-100"
 											id="quit-app"
 										>
 											終了

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -445,18 +445,22 @@ async function setPackagesList(instPath: string) {
 
   // update the batch installation text
   const batchInstallElm = document.getElementById('batch-install-packages');
-  batchInstallElm.innerHTML = null;
+  [...batchInstallElm.getElementsByClassName('batch-install-package')].map(
+    (e) => e.remove(),
+  );
   packages
     .filter((p) => p.info.directURL)
-    .flatMap((p) => {
-      if (p.installationStatus !== packageUtil.states.notInstalled) {
-        const pTag = document.createElement('span');
-        pTag.classList.add('text-muted');
-        pTag.innerText = '✔' + p.info.name;
-        return [document.createTextNode(' + '), pTag];
-      } else {
-        return [document.createTextNode(' + ' + p.info.name)];
-      }
+    .map((p) => {
+      const liTag = document
+        .getElementById('batch-install-package-template')
+        .cloneNode(true) as HTMLSpanElement;
+      liTag.removeAttribute('id');
+      (liTag.getElementsByClassName('name')[0] as HTMLElement).innerText =
+        p.info.name;
+      (
+        liTag.getElementsByClassName('installed-version')[0] as HTMLElement
+      ).innerText = p.installationStatus;
+      return liTag;
     })
     .forEach((e) => batchInstallElm.appendChild(e));
 

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -220,9 +220,9 @@ async function setPackagesList(instPath: string) {
       selectedEntryType = entryType.package;
       li.getElementsByTagName('input')[0].checked = true;
       for (const tmpli of Array.from(packagesList.getElementsByTagName('li'))) {
-        tmpli.classList.remove('list-group-item-secondary');
+        tmpli.classList.remove('list-group-item-light');
       }
-      li.classList.add('list-group-item-secondary');
+      li.classList.add('list-group-item-light');
       document.getElementById('install-package').innerText =
         installationStatus.innerText.startsWith('インストール済み')
           ? '　　更新　　'

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -225,7 +225,7 @@ async function setPackagesList(instPath: string) {
       li.classList.add('list-group-item-secondary');
       document.getElementById('install-package').innerText =
         installationStatus.innerText.startsWith('インストール済み')
-          ? '更新'
+          ? '　　更新　　'
           : 'インストール';
     });
     packageID.innerText = packageItem.id;
@@ -239,7 +239,7 @@ async function setPackagesList(instPath: string) {
         .getElementById('tag-template')
         .cloneNode(true) as HTMLSpanElement;
       typeItem.removeAttribute('id');
-      typeItem.innerText = e;
+      typeItem.innerText = '🏷️' + e;
       type.appendChild(typeItem);
     });
     latestVersion.innerText = packageItem.info.latestVersion;
@@ -268,7 +268,8 @@ async function setPackagesList(instPath: string) {
     packageItem.detached.forEach((p) => {
       const aTag = document.createElement('a');
       aTag.href = '#';
-      aTag.innerText = `❗ 要導入: ${p.info.name}\r\n`;
+      aTag.classList.add('text-danger');
+      aTag.innerText = `要導入: ${p.info.name}\r\n`;
       statusInformation.appendChild(aTag);
       aTag.addEventListener('click', async () => {
         await installPackage(instPath, p);
@@ -276,9 +277,8 @@ async function setPackagesList(instPath: string) {
       });
     });
     const verText = document.createElement('div');
-    verText.innerText = packageItem.doNotInstall
-      ? '⚠️インストール不可\r\n'
-      : '';
+    verText.classList.add('text-warning');
+    verText.innerText = packageItem.doNotInstall ? 'インストール不可\r\n' : '';
     statusInformation.appendChild(verText);
     if (
       packageItem.installationStatus === packageUtil.states.installed &&
@@ -340,7 +340,7 @@ async function setPackagesList(instPath: string) {
       'list-group-item-secondary',
       'list-group-item-success',
     );
-    typeItem.innerText = 'スクリプト配布サイト';
+    typeItem.innerText = '🏷️スクリプト配布サイト';
     type.appendChild(typeItem);
     latestVersion.innerText = '';
     installationStatus.innerText = '';

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -29,6 +29,19 @@ log.catchErrors({
 });
 
 window.addEventListener('DOMContentLoaded', async () => {
+  // dark-theme
+  const updateTheme = () => {
+    document.querySelector('html').dataset.bsTheme = window.matchMedia(
+      '(prefers-color-scheme: dark)',
+    ).matches
+      ? 'dark'
+      : 'light';
+  };
+  window
+    .matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', updateTheme);
+  updateTheme();
+
   // *global*
   // migration
   if (!(await migration2to3.global())) {

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -53,8 +53,8 @@ window.addEventListener('DOMContentLoaded', async () => {
   }
   const installationPath = document.getElementById(
     'installation-path',
-  ) as HTMLInputElement;
-  installationPath.value = instPath;
+  ) as HTMLSpanElement;
+  installationPath.innerText = instPath;
   const dataURL = document.getElementById('data-url') as HTMLInputElement;
   dataURL.value = modList.getDataUrl();
   const extraDataURL = document.getElementById(
@@ -89,12 +89,12 @@ window.addEventListener('DOMContentLoaded', async () => {
 window.addEventListener('load', () => {
   const installationPath = document.getElementById(
     'installation-path',
-  ) as HTMLInputElement;
+  ) as HTMLSpanElement;
 
   // core
   const checkCoreVersionBtn = document.getElementById('check-core-version');
   checkCoreVersionBtn.addEventListener('click', async () => {
-    await core.checkLatestVersion(installationPath.value);
+    await core.checkLatestVersion(installationPath.innerText);
   });
 
   const selectInstallationPathBtn = document.getElementById(
@@ -106,23 +106,23 @@ window.addEventListener('load', () => {
 
   const batchInstallBtn = document.getElementById('batch-install');
   batchInstallBtn.addEventListener('click', async () => {
-    await core.batchInstall(installationPath.value);
+    await core.batchInstall(installationPath.innerText);
   });
 
   // packages
   const checkPackagesListBtn = document.getElementById('check-packages-list');
   checkPackagesListBtn.addEventListener('click', async () => {
-    await packageMain.checkPackagesList(installationPath.value);
+    await packageMain.checkPackagesList(installationPath.innerText);
   });
 
   const installPackageBtn = document.getElementById('install-package');
   installPackageBtn.addEventListener('click', async () => {
-    await packageMain.installPackage(installationPath.value);
+    await packageMain.installPackage(installationPath.innerText);
   });
 
   const uninstallPackageBtn = document.getElementById('uninstall-package');
   uninstallPackageBtn.addEventListener('click', async () => {
-    await packageMain.uninstallPackage(installationPath.value);
+    await packageMain.uninstallPackage(installationPath.innerText);
   });
 
   const openPackageFolderBtn = document.getElementById('open-package-folder');
@@ -150,7 +150,7 @@ window.addEventListener('load', () => {
 
   const sharePackagesBtn = document.getElementById('share-packages');
   sharePackagesBtn.addEventListener('click', async () => {
-    await packageMain.sharePackages(installationPath.value);
+    await packageMain.sharePackages(installationPath.innerText);
   });
 
   // nicommons ID

--- a/src/renderer/main/renderer.ts
+++ b/src/renderer/main/renderer.ts
@@ -1,4 +1,4 @@
-import '../../../node_modules/bootstrap-dark-5/dist/css/bootstrap-dark.min.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
 import '../../../node_modules/bootstrap-icons/font/bootstrap-icons.css';
 import '../main.css';
 import './index.css';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1936,19 +1936,12 @@ boolean@^3.0.1:
   resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.1.4.tgz#f51a2fb5838a99e06f9b6ec1edb674de67026435"
   integrity sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==
 
-bootstrap-dark-5@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/bootstrap-dark-5/-/bootstrap-dark-5-1.1.3.tgz#a40c42083f2ee1f05ca0423f334d5edf52c35f9e"
-  integrity sha512-3Paopsp8wyOM1oeaLWLFuUZThhRc3tBYKUnoF+uwrU/xN4G47MCLZlALBJNqYqAecg7dSln9vgaYK1CwPnTeBw==
-  dependencies:
-    bootstrap "^5.1.3"
-
 bootstrap-icons@^1.11.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.11.1.tgz#79e32494871d8c98e9d14f4bcdc278cee9b1dafd"
   integrity sha512-F0DDp7nKUX+x/QtpfRZ+XHFya60ng9nfdpdS59vDDfs4Uhuxp7zym/QavMsu/xx51txkoM9eVmpE7D08N35blw==
 
-bootstrap@^5.1.3, bootstrap@^5.3.2:
+bootstrap@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.2.tgz#97226583f27aae93b2b28ab23f4c114757ff16ae"
   integrity sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Dark themes are now supported as standard from Bootstrap 5.3. Remove bootstrap-dark-5 and CSS that have finished their role.

It also includes minor fixes to button design and wording.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This PR depends on
- #1498

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Check the visibility in the dark theme.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
