### PR TITLE
fix(packageUtil): match() may return null

### DIFF
--- a/src/renderer/main/packageUtil.ts
+++ b/src/renderer/main/packageUtil.ts
@@ -380,9 +380,10 @@ async function getPackagesStatus(instPath: string, _packages: PackageItem[]) {
     }
   };
   const isInstalled = (rawId: string): boolean => {
-    const [, id, operator, version] = rawId.match(
-      /^((?:[A-Za-z0-9]+\/[A-Za-z0-9]+)|(?:aviutl[A-Za-z0-9.]+)|(?:exedit[A-Za-z0-9.]+))(?:(<|<=|=|>=|>)([^<=>&|\n]+))?$/u,
-    );
+    const [, id, operator, version] =
+      rawId.match(
+        /^((?:[A-Za-z0-9]+\/[A-Za-z0-9]+)|(?:aviutl[A-Za-z0-9.]+)|(?:exedit[A-Za-z0-9.]+))(?:(<|<=|=|>=|>)([^<=>&|\n]+))?$/u,
+      ) ?? [];
     const thisPackage = packages.filter((p) => p.id === id).find(() => true);
     if (thisPackage) {
       const statusInstalled =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
match() returns null for strings that do not match the regex. This time, the cause was a package id such as `script_a1d871c` generated by the automatic script installation.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- fix #1969

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- No error occurs with the reproduction procedure https://github.com/team-apm/apm/issues/1969  .

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
