### PR TITLE
docs: update security, branching, and contributor guides

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,7 @@
 <!--- Describe your changes in detail -->
 
 ## Related Issue
-<!--- This project only accepts pull requests related to open issues -->
-<!--- If suggesting a new feature or change, please discuss it in an issue first -->
-<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
-<!--- Please link to the issue here: -->
+<!--- If your pull request fixes an issue, link it here. Issues are encouraged for large changes but not required for small fixes, docs, or dependency updates. -->
 
 ## Motivation and Context
 <!--- Why is this change required? What problem does it solve? -->

--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -1,0 +1,27 @@
+# Branching
+
+## Active branches
+
+| Branch | Purpose                                                                    |
+| ------ | -------------------------------------------------------------------------- |
+| `main` | Development head. Open pull requests target this branch.                   |
+| `v3`   | Marker for the latest v3 release tag. Updated when a release is published. |
+
+## Historical branches
+
+| Branch     | Purpose                                 |
+| ---------- | --------------------------------------- |
+| `v1`, `v2` | Archived release lines. Reference only. |
+
+## Release tags
+
+Tags named `v*` mark releases. Pushing a tag triggers the [Release workflow](.github/workflows/release.yml) to build and publish installers for Windows, macOS, and Linux.
+
+After publishing a release, update the `v3` marker:
+
+```bash
+git branch -f v3 vX.Y.Z
+git push -f origin v3
+```
+
+See [docs/RELEASING.md](./docs/RELEASING.md) for the full release process.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,13 +8,15 @@ Here is a guide on how to contribute.
 
 ## Technology/Language Used
 
-This application has been created using [Electron](https://www.electronjs.org/).
+This application is built with [Electron](https://www.electronjs.org/).
 
-The languages used are:
+The languages and frameworks used include:
 
+- TypeScript
 - JavaScript (Node.js)
-- HTML
-- CSS
+- HTML / CSS
+- React (About window; main window migration in progress)
+- tRPC (partial)
 
 ## Issues
 
@@ -31,7 +33,7 @@ We also welcome fundamental improvement issues, such as how to develop, how to s
 
 Pull Requests are also welcome.
 
-We accept the following types of pull requests. You don't need to make an Issue for basic Pull Requests.
+We accept the following types of pull requests. **You do not need to open an issue first** for small bug fixes, dependency updates, documentation fixes, or refactors with limited scope.
 
 If you have a question about a new feature, improvement, or fix, or if the impact of a major new feature or change is significant, please make an Issue to discuss it.
 
@@ -43,7 +45,7 @@ If you have a question about a new feature, improvement, or fix, or if the impac
 
 When the pull request is merged, your contribution will be added to the [Contributors list](https://github.com/team-apm/apm/graphs/contributors), and the [MIT License](./LICENSE) will be applied to the code content.
 
-And after that, if you don't mind, add your name to [credits](./src/about.html) and send a pull request.
+And after that, if you don't mind, add your name to the credits in [`src/renderer/about/About.tsx`](./src/renderer/about/About.tsx) and send a pull request.
 
 Submissions containing content that violates the [CODE OF CONDUCT](./CODE_OF_CONDUCT.md) will not be accepted.
 
@@ -65,23 +67,20 @@ By running `yarn package`, the packaged app is output to `out/`, so run it.
 
 ## Directory Structure
 
-Under `src`, place HTML, CSS, and preloaded JavaScript for each screen, and cut directories for each library and each section, and place modules under them.
-
 ```text
-└── src
-    ├── core
-    │   └── core.js
-    ├── lib
-    │   └── someLibrary.js
-    ├── package
-    │   └── package.js
-    ├── setting
-    │   └── setting.js
-    ├── some_window.html
-    ├── some_window.css
-    ├── some_window_preload.ts
-    └── some_window_renderer.ts
+src/
+├── common/          # Shared constants (IPC channel names)
+├── lib/             # Shared libraries (config, paths, integrity, etc.)
+├── main/            # Electron main process
+├── migration/       # Data version migrations
+├── renderer/
+│   ├── about/       # About window (React)
+│   ├── main/        # Main window (legacy DOM; being migrated)
+│   └── splash/      # Splash screen
+└── types/           # TypeScript declarations
 ```
+
+See [BRANCHING.md](./BRANCHING.md) for branch workflow.
 
 ## Commit Message Convention
 
@@ -91,7 +90,7 @@ We are using Conventional Changelog, which is based on Angular's Commit Message 
 
 The commit message is automatically checked by [commitlint](https://commitlint.js.org/) at commit time, and the commit will fail if it does not follow the conventions.
 
-Since [Standard Version](https://github.com/conventional-changelog/standard-version) is used to output the changelog, commits that contain new features or bug fixes should especially follow this convention.
+Since [release-it](https://github.com/release-it/release-it) is used to manage releases and changelogs, commits that contain new features or bug fixes should especially follow this convention.
 
 ### How to Commit
 
@@ -109,9 +108,9 @@ This project has the following writing style/rules, but you may not need to worr
 
 We are using [ESLint](https://eslint.org/) for linting, and the settings are based on the [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html). The contents are as follows.
 
-- ECMAScript 2020 can be used.
+- ECMAScript 2022 can be used.
 - Basically, use `const` / `let` to declare variables.
-- Use `require` to load modules.
+- Use ES `import` / `export` to load modules.
 - Comment functions with JSDoc.
 
 ### Formatting

--- a/README.en.md
+++ b/README.en.md
@@ -65,6 +65,7 @@ After launching the AviUtl Package Manager, please perform the following setting
 ## Other
 
 - If a package cannot be installed using the above method, it can be installed using the traditional method of manually copying the files.
+- Settings allow custom package data URLs. Untrusted mirrors may serve malicious package metadata or downloads. Use the official [apm-data](https://github.com/team-apm/apm-data) repository or sources you trust.
 - We have tested the Windows version only; we are not supporting the operation of the Mac or Linux versions.
   - If you encounter any problems, regardless of OS, please create an Issue and report it to us.
 - If you have any requests for additions, updates or deletions to the list of plugins and scripts, please contact [apm-data](https://github.com/team-apm/apm-data/issues).
@@ -74,7 +75,7 @@ After launching the AviUtl Package Manager, please perform the following setting
 ### Prerequisites
 
 - [Git](https://git-scm.com/)
-- [Node.js](https://nodejs.org/) LTS Version (Current: 18.x.x)
+- [Node.js](https://nodejs.org/) LTS (18.x / 20.x / 22.x)
 - [Yarn 1](https://classic.yarnpkg.com/)
 
 ### Clone
@@ -115,10 +116,10 @@ Also, I'm Japanese, so any pull requests related to English or i18n are most wel
 ## Languages & Framework
 
 - Electron (Node.js)
-  - HTML
-  - CSS
-  - JavaScript
   - TypeScript
+  - HTML / CSS
+  - JavaScript
+  - React (About window; main window migration in progress)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ _Read this in [English](./README.en.md)_.
 ## その他
 
 - 上記の方法で導入できないパッケージも、手動でファイルをコピーする従来の方法により導入できます。
+- 設定の「データ取得先」には任意の URL を指定できます。信頼できない第三者のミラーを指定すると、悪意のあるパッケージ情報やダウンロードに誘導される恐れがあります。公式の [apm-data](https://github.com/team-apm/apm-data) または信頼できるソースのみを使用してください。
 - 動作確認は、Windows版のみで行っています。
   - Mac版・Linux版は動作保証しておりませんが、問題等が発生した場合はIssueを作成して報告いただければ、対応します。
 - プラグイン・スクリプト一覧への追加・更新・削除等の要望がありましたら[apm-data](https://github.com/team-apm/apm-data/issues)までご連絡ください。
@@ -69,7 +70,7 @@ _Read this in [English](./README.en.md)_.
 ### 前提条件
 
 - [Git](https://git-scm.com/)
-- [Node.js](https://nodejs.org/) LTSバージョン（現在18.x.x）
+- [Node.js](https://nodejs.org/) LTS（18.x / 20.x / 22.x）
 - [Yarn 1](https://classic.yarnpkg.com/)
 
 ### クローン
@@ -110,10 +111,10 @@ yarn start
 ### 使用言語・フレームワーク
 
 - Electron (Node.js)
-  - HTML
-  - CSS
-  - JavaScript
   - TypeScript
+  - HTML / CSS
+  - JavaScript
+  - React (About window; main window migration in progress)
 
 ## ライセンス
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Currently, we are providing support with security updates for these versions of apm.
+Security updates are provided for the following versions of apm.
 
 | Version | Supported          |
 | ------- | ------------------ |
@@ -11,10 +11,33 @@ Currently, we are providing support with security updates for these versions of 
 
 ## Reporting a Vulnerability
 
-To be added in the future
+If you discover a security vulnerability, please report it responsibly.
 
-<!-- Use this section to tell people how to report a vulnerability.
+**Preferred:** [GitHub Security Advisories](https://github.com/team-apm/apm/security/advisories/new) (private report)
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.-->
+**Alternative:** Open a minimal public issue asking for a private contact channel, or contact the maintainers listed in [package.json](./package.json).
+
+Please do **not** disclose security issues in public issues with full exploit details before a fix is available.
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected versions
+- Impact assessment (if known)
+
+### What to expect
+
+- **Acknowledgement:** within 7 days
+- **Status update:** within 30 days, or an explanation of delay
+- **Fix:** coordinated disclosure after a patch release when possible
+
+We appreciate responsible disclosure and will credit reporters in the release notes when appropriate.
+
+## Custom data sources
+
+apm allows users to configure custom package data URLs in settings. Pointing apm at an untrusted mirror can expose you to malicious package metadata or downloads. Use only sources you trust. Integrity checks (SSRI) reduce but do not eliminate this risk.
+
+## Platform support
+
+apm is tested primarily on **Windows**. Builds for macOS and Linux are provided without a support guarantee. Security fixes target Windows behavior first.


### PR DESCRIPTION
## Summary
Phase 0 documentation updates for the v3.10.0 maintenance release.

## Changes
- Add `BRANCHING.md` (`main` vs `v3` marker)
- Complete `SECURITY.md` (reporting policy, data URL note)
- Update `CONTRIBUTING.md` (TypeScript, React, real directory layout)
- Update README prerequisites and custom data URL warning
- Align PR template with CONTRIBUTING (issues not required for small PRs)

## Test plan
- [x] Markdown renders correctly (manual review)


Made with [Cursor](https://cursor.com)