### PR TITLE
build: allow Node.js 24 in package engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   },
   "packageManager": "yarn@1.22.22",
   "engines": {
-    "node": "22.x || 20.x || 18.x"
+    "node": "24.x || 22.x || 20.x || 18.x"
   },
   "productName": "AviUtl Package Manager"
 }


### PR DESCRIPTION
## Summary
CI fails because `actions/setup-node` with `lts/*` now installs Node 24, while `package.json` engines only allowed 18/20/22.

This PR adds Node 24 to engines only. Other Phase 0 PRs will be rebased after this lands.

## Test plan
- [ ] CI lint + build pass on this PR


Made with [Cursor](https://cursor.com)