### PR TITLE
build(deps): bump electron from 34 to 39

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "css-loader": "^7.1.4",
     "cz-conventional-changelog": "3.3.0",
     "cz-conventional-changelog-ja": "^0.0.2",
-    "electron": "^34.5.8",
+    "electron": "^39.8.10",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,6 +1875,13 @@
   dependencies:
     undici-types "~6.19.2"
 
+"@types/node@^22.7.7":
+  version "22.20.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.20.1.tgz#84e7cdf63cdaa20c134aa317ccc901aa21e16f0e"
+  integrity sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==
+  dependencies:
+    undici-types "~6.21.0"
+
 "@types/normalize-package-data@^2.4.4":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz#56e2cc26c397c038fab0e3a917a12d5c5909e901"
@@ -4271,13 +4278,13 @@ electron-winstaller@^5.0.0:
   optionalDependencies:
     "@electron/windows-sign" "^1.1.2"
 
-electron@^34.5.8:
-  version "34.5.8"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-34.5.8.tgz#e0d4782dac48f7c8fef6798ad319d1549949802f"
-  integrity sha512-vxLD65mabTzYmEVa9KceMHM0+zO+vqgrhcyNVlmTd0IGV5J7XZ8v/qElm0o4YQ4wPeq7olZkUjZkBQQEdr23/g==
+electron@^39.8.10:
+  version "39.8.10"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-39.8.10.tgz#998d9c5b9e7601debb70bd7355e8d4dfd6d70f43"
+  integrity sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==
   dependencies:
     "@electron/get" "^2.0.0"
-    "@types/node" "^20.9.0"
+    "@types/node" "^22.7.7"
     extract-zip "^2.0.1"
 
 electron@latest:
@@ -9898,6 +9905,11 @@ undici-types@~6.20.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 undici@7.28.0:
   version "7.28.0"


### PR DESCRIPTION
## 概要

再建プランの「早期パック」その3: EOL となっている Electron 34 を現行の 39 系へ更新します(1 PR = 1 major の方針)。

## 事前検証(ローカルスパイク)

懸念だった「forge 6.4.1 固定(6.4.2+ で preload webpack が壊れる)と新しい Electron が両立するか」を worktree で検証済み:

- electron ^39 + @electron-forge 6.4.1 + Node 22 で `yarn package` 成功(webpack バンドル生成・パッケージングとも正常)

この PR の CI(3 OS の `yarn make`)が残りの検証になります。マージ前に `yarn start` での起動スモーク(ウィンドウ表示・パッケージ一覧読込)を推奨します。

## 動作確認

- [x] `yarn lint` / `yarn lint:ts` / `yarn test` 緑(ローカル)
- [x] `yarn package` 成功(ローカル、macOS)
- [ ] `yarn start` での起動スモーク(Windows 実機推奨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)