### PR TITLE
feat: 設定タブに data editor を追加 (#1627 の手動ポート)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,11 @@ PR 前に上記 3 つ(lint / lint:ts / test)がすべて緑であること。
 
 ## 既知の固定と理由(上げる前に必ず読む)
 
-| 固定                                                            | 理由                                                                                    |
-| --------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `@electron-forge/*` 6.4.1 固定(`.ncurc.json` で reject)         | 6.4.2+ で preload の webpack ビルドが壊れる                                             |
-| CI (`build.yml` / `release.yml` / `nodejs.yml`) は Node 22 固定 | Node 24 では electron-forge 6.4.1 の make/publish が「Copying files」後に無言で失敗する |
-| Electron ほかメジャー更新は dependabot で ignore                | メジャー更新は計画的に 1 PR = 1 major で実施するため(ROADMAP 参照)                      |
+| 固定                                                            | 理由                                                                                                                                                                              |
+| --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@electron-forge/*` 6.4.1 固定(`.ncurc.json` で reject)         | 6.4.2+ で preload の webpack ビルドが壊れる                                                                                                                                       |
+| CI (`build.yml` / `release.yml` / `nodejs.yml`) は Node 22 固定 | Node 24 では electron-forge 6.4.1 の package/make/publish が「Copying files」後に無言で失敗する(exit 0 で `.app`/`out` が生成されない。ローカルでも同様なので Node 22 で実行する) |
+| Electron ほかメジャー更新は dependabot で ignore                | メジャー更新は計画的に 1 PR = 1 major で実施するため(ROADMAP 参照)                                                                                                                |
 
 ## 作業スタイル
 
@@ -42,3 +42,4 @@ PR 前に上記 3 つ(lint / lint:ts / test)がすべて緑であること。
 
 - `src/lib/compareVersion.ts` の `compareVersion` は比較不能時に `Number.NaN` を返す。NaN は全比較演算子で false になるため、呼び出し側は必ず `Number.isNaN()` で先に分岐する(`!== 0` 形式の分岐は意味が反転する)
 - `src/renderer/main/preload.ts` はビジネスロジックそのもの(`sandbox: false` 前提)。タブの React 化 = そのタブのロジックを main プロセス + tRPC へ移設する作業
+- `monaco-editor` は**型のみ**インポートする(`import type`)。実行時の Monaco は `@monaco-editor/loader` が CDN から読み込む。値インポートすると webpack が Monaco 全体をバンドルし、ビルドにヒープ拡大(`--max-old-space-size`)が必要になる。enum 値は onMount で渡される `monaco` インスタンスから取る

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,8 +29,8 @@ apm の開発方針の単一ソース。変更は PR 経由で行う(履歴 = �
 
 ## 次の一手
 
-**data editor(#1627)の手動ポート** → v3.11.0。
+**v3.11.0 をリリース(data editor 入り)→ Phase 2 骨格整理。**
 
-#1627 は main から大きく遅れており merge 不可のため、`gh pr diff 1627` を参考に手動で写す。Settings タブに Monaco JSON エディタを追加し `{instPath}/editorPackages.json` をパッケージ一覧にマージする機能。暫定許容(CDN Monaco・CSP 緩和)には `TODO(security)` を残し、セキュリティフェーズで必ず回収する。
+data editor(#1627 の手動ポート)がマージされたら release-it で v3.11.0 を出す。その後は骨格整理: `src/shared` の切り出し、main プロセスの services 化、ARCHITECTURE.md の作成。Config シングルトン化・ApmJson トランザクション化は該当箇所の特性化テストを先に書いてから行う。
 
-Done の定義: 手動ポート PR がマージされ、#1627 が close され、この節が次の作業に書き換わっていること。
+Done の定義: v3.11.0 がリリースされ、骨格整理の PR がマージされ、この節が次の作業(タブ単位の React + tRPC 移行)に書き換わっていること。

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -55,14 +55,16 @@ const config: ForgeConfig = {
     new WebpackPlugin({
       mainConfig: mainConfig,
       devServer: { liveReload: false },
+      // TODO(security): cdn.jsdelivr.net / 'unsafe-inline' / blob: は CDN 版 Monaco のための暫定緩和。
+      // セキュリティフェーズで Monaco をローカルバンドルに切り替えて回収する
       devContentSecurityPolicy:
-        "default-src 'self'; script-src 'self'; connect-src 'self'; img-src 'self' data: https://*.nicovideo.jp https://*.nicoseiga.jp https://nicovideo.cdn.nimg.jp",
+        "default-src 'self'; script-src-elem 'self' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' https://cdn.jsdelivr.net; img-src 'self' data: https://*.nicovideo.jp https://*.nicoseiga.jp https://nicovideo.cdn.nimg.jp",
       renderer: {
         config: rendererConfig,
         entryPoints: [
           {
             html: './src/renderer/main/index.html',
-            js: './src/renderer/main/renderer.ts',
+            js: './src/renderer/main/renderer.tsx',
             name: 'main_window',
             preload: {
               js: './src/renderer/main/preload.ts',

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "7zip-bin": "^5.2.0",
+    "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.101.1",
     "@trpc/client": "^10.45.4",
     "@trpc/react-query": "^10.45.4",
@@ -114,6 +115,7 @@
     "husky": "^9.1.7",
     "lint-staged": "^17.0.8",
     "mini-css-extract-plugin": "^2.10.2",
+    "monaco-editor": "0.52.2",
     "node-loader": "^2.1.0",
     "npm-run-all2": "^9.0.2",
     "prettier": "^3.8.5",

--- a/src/lib/modList.ts
+++ b/src/lib/modList.ts
@@ -84,10 +84,11 @@ export function getPackagesDataUrl(instPath: string) {
   return config.dataURL
     .getPackages()
     .concat(
-      instPath &&
-        instPath.length > 0 &&
-        fs.existsSync(getLocalPackagesDataUrl(instPath))
-        ? [getLocalPackagesDataUrl(instPath)]
+      instPath && instPath.length > 0
+        ? [
+            getLocalPackagesDataUrl(instPath),
+            getEditorPackagesDataUrl(instPath),
+          ].filter((p) => fs.existsSync(p))
         : [],
     );
 }
@@ -99,6 +100,15 @@ export function getPackagesDataUrl(instPath: string) {
  */
 export function getLocalPackagesDataUrl(instPath: string) {
   return path.join(instPath, 'packages.json');
+}
+
+/**
+ * Returns a data editor's package data file URL.
+ * @param {string} instPath - An installation path.
+ * @returns {string} - A package data file URL.
+ */
+export function getEditorPackagesDataUrl(instPath: string) {
+  return path.join(instPath, 'editorPackages.json');
 }
 
 /**

--- a/src/lib/parseJson.ts
+++ b/src/lib/parseJson.ts
@@ -47,7 +47,7 @@ export async function getPackages(packagesListPath: string) {
  * @param {string} packagesListPath - A path of Json file.
  * @param {object} packages - A list of packages.
  */
-async function setPackages(
+export async function setPackages(
   packagesListPath: string,
   packages: Packages['packages'],
 ) {

--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -3,9 +3,10 @@
 	<head>
 		<meta charset="UTF-8" />
 		<!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
+		<!-- TODO(security): cdn.jsdelivr.net / 'unsafe-inline' / blob: は CDN 版 Monaco のための暫定緩和。セキュリティフェーズで Monaco をローカルバンドルに切り替えて回収する -->
 		<meta
 			http-equiv="Content-Security-Policy"
-			content="default-src 'self'; script-src 'self'; connect-src 'self'; img-src 'self' data: https://*.nicovideo.jp https://*.nicoseiga.jp https://nicovideo.cdn.nimg.jp"
+			content="default-src 'self'; script-src-elem 'self' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' https://cdn.jsdelivr.net; img-src 'self' data: https://*.nicovideo.jp https://*.nicoseiga.jp https://nicovideo.cdn.nimg.jp"
 		/>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>AviUtl Package Manager</title>
@@ -706,6 +707,23 @@
 										></textarea>
 									</div>
 									<div class="col-sm-3"></div>
+								</div>
+								<div class="row mb-3">
+									<label for="container" class="form-label"
+										>追加テキストデータ</label
+									>
+									<div class="col-sm-9">
+										<div id="container" class="border rounded"></div>
+									</div>
+									<div class="col-sm-3">
+										<button
+											type="button"
+											class="btn btn-primary w-100"
+											id="save-editor-data"
+										>
+											保存 (Ctrl + S)
+										</button>
+									</div>
 								</div>
 								<div class="row mb-3">
 									<label

--- a/src/renderer/main/monacoEditorPreload.ts
+++ b/src/renderer/main/monacoEditorPreload.ts
@@ -1,0 +1,58 @@
+import { Packages } from 'apm-schema';
+import { contextBridge } from 'electron';
+import * as modList from '../../lib/modList';
+import * as parseJson from '../../lib/parseJson';
+import packageMain from './package';
+
+/**
+ * ContextBridge for monaco editor
+ */
+export class EditorContextBridge {
+  onLoad: () => Promise<void>;
+  instPath: { value: string };
+
+  /**
+   * constructor
+   */
+  constructor() {
+    contextBridge.exposeInMainWorld('editor', {
+      setOnload: async (event: (packages: Packages['packages']) => void) => {
+        this.onLoad = async () => {
+          try {
+            event(
+              await parseJson.getPackages(
+                modList.getEditorPackagesDataUrl(this.instPath.value),
+              ),
+            );
+          } catch {
+            // nop
+          }
+        };
+
+        // Callback function is called after both initializations.
+        // The order of initialization is indefinite.
+        if (this.onLoad && this.instPath) await this.onLoad();
+      },
+      save: async (packages: Packages['packages']) => {
+        await parseJson.setPackages(
+          modList.getEditorPackagesDataUrl(this.instPath.value),
+          packages,
+        );
+        await packageMain.checkPackagesList(this.instPath.value);
+      },
+    });
+  }
+
+  /**
+   * set instPath
+   * @param {{ value: string }} instPath - An installation path.
+   * @param {string} instPath.value - An installation path.
+   */
+  async setInstPath(instPath: { value: string }) {
+    this.instPath = instPath;
+
+    // Callback function is called after both initializations.
+    // The order of initialization is indefinite.
+    if (this.onLoad && this.instPath) await this.onLoad();
+  }
+}

--- a/src/renderer/main/monacoEditorRenderer.tsx
+++ b/src/renderer/main/monacoEditorRenderer.tsx
@@ -1,0 +1,214 @@
+import MonacoEditor, { BeforeMount, OnMount } from '@monaco-editor/react';
+import { Packages } from 'apm-schema';
+import schema from 'apm-schema/v3/schema/packages.json';
+// Type-only import to avoid bundling the entire monaco-editor package.
+// The editor itself is loaded from the CDN by @monaco-editor/react.
+import type { editor } from 'monaco-editor';
+import React from 'react';
+import * as buttonTransition from '../../lib/buttonTransition';
+
+const placeholderStr = `
+apm-data (https://github.com/team-apm/apm-data) に投稿されたパッケージデータをここにコピーアンドペーストすることで動作の確認ができます。
+\t
+下の例のように、全体を[]で囲む必要があります。
+[
+  {
+    "id": "AiosCiao/VSThost4aviutl",
+    "name": "VSTホストプラグイン＋α",
+    ...
+  },
+  {
+    "id": "amate/InputPipePlugin",
+    "name": "InputPipePlugin",
+    ...
+  },
+  ...
+]
+\t
+ショートカットキーは Visual Studio Code と同様です。
+Ctrl+Space: サジェスト, Shift+Alt+F: フォーマット など
+`;
+
+/**
+ *  Displays placeholder text when the editor is empty.
+ */
+class PlaceholderContentWidget {
+  static ID = 'editor.widget.placeholderHint';
+  placeholder: string;
+  editor: editor.IStandaloneCodeEditor;
+  positionPreference: editor.ContentWidgetPositionPreference;
+  domNode: HTMLElement;
+
+  /**
+   * @param {string} placeholder - placeholder text
+   * @param {editor.IStandaloneCodeEditor} editor - monaco editor
+   * @param {editor.ContentWidgetPositionPreference} positionPreference - EXACT position preference
+   */
+  constructor(
+    placeholder: string,
+    editor: editor.IStandaloneCodeEditor,
+    positionPreference: editor.ContentWidgetPositionPreference,
+  ) {
+    this.placeholder = placeholder;
+    this.editor = editor;
+    this.positionPreference = positionPreference;
+    editor.onDidChangeModelContent(() => this.onDidChangeModelContent());
+    this.onDidChangeModelContent();
+  }
+
+  /**
+   * onDidChangeModelContent
+   */
+  onDidChangeModelContent() {
+    if (this.editor.getValue() === '') {
+      this.editor.addContentWidget(this);
+    } else {
+      this.editor.removeContentWidget(this);
+    }
+  }
+
+  /**
+   * getId
+   * @returns {string} id
+   */
+  getId(): string {
+    return PlaceholderContentWidget.ID;
+  }
+
+  /**
+   * getDomNode
+   * @returns {HTMLElement} DomElement of Placeholder
+   */
+  getDomNode(): HTMLElement {
+    if (!this.domNode) {
+      this.domNode = document.createElement('div');
+      this.placeholder.split('\n').map((s) => {
+        const spanElm = document.createElement('div');
+        spanElm.textContent = s;
+        this.domNode.appendChild(spanElm);
+      });
+
+      this.domNode.style.whiteSpace = 'pre-wrap';
+      this.domNode.style.width = 'max-content';
+      this.domNode.style.pointerEvents = 'none';
+      this.domNode.style.fontStyle = 'italic';
+      this.editor.applyFontInfo(this.domNode);
+    }
+
+    return this.domNode;
+  }
+
+  /**
+   * getPosition
+   * @returns {object} position
+   */
+  getPosition(): {
+    position: { lineNumber: number; column: number };
+    preference: editor.ContentWidgetPositionPreference[];
+  } {
+    return {
+      position: { lineNumber: 1, column: 1 },
+      preference: [this.positionPreference],
+    };
+  }
+
+  /**
+   * dispose
+   */
+  dispose() {
+    this.editor.removeContentWidget(this);
+  }
+}
+
+self.MonacoEnvironment = null;
+type MonacoEditorRendererProps = {
+  saveButton: HTMLButtonElement;
+};
+
+/**
+ *  A small code editor for apm-data, with validation against apm-schema.
+ * @param {MonacoEditorRendererProps} root0 - props
+ * @param {HTMLButtonElement} root0.saveButton - The HTML element of the Save button.
+ * @returns {React.ReactElement} React component
+ */
+export const MonacoEditorRenderer: React.FC<MonacoEditorRendererProps> = ({
+  saveButton,
+}) => {
+  const modelUri = 'a://b/c.json';
+
+  const editorWillMount: BeforeMount = (monaco) => {
+    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+      validate: true,
+      schemas: [
+        {
+          uri: 'http://d/e-schema.json',
+          fileMatch: [modelUri],
+          schema: schema.properties.packages,
+        },
+      ],
+    });
+  };
+
+  const editorDidMount: OnMount = (editor, monaco) => {
+    editor.getModel().updateOptions({ tabSize: 2 });
+    new PlaceholderContentWidget(
+      placeholderStr,
+      editor,
+      monaco.editor.ContentWidgetPositionPreference.EXACT,
+    );
+    window.editor.setOnload(async (packages: Packages['packages']) => {
+      if (packages.length === 0) return;
+      editor.setValue(JSON.stringify(packages));
+      await editor.getAction('editor.action.formatDocument').run();
+    });
+
+    const save = async () => {
+      const { enableButton } = saveButton
+        ? buttonTransition.loading(saveButton, '保存 (Ctrl + S)')
+        : { enableButton: undefined };
+
+      await editor.getAction('editor.action.formatDocument').run();
+      let error =
+        monaco.editor
+          .getModelMarkers({})
+          .filter(
+            (m) =>
+              m.severity === monaco.MarkerSeverity.Warning ||
+              m.severity === monaco.MarkerSeverity.Error,
+          ).length > 0;
+
+      let json;
+      try {
+        json = JSON.parse(editor.getValue());
+      } catch {
+        error = true;
+      }
+      if (error) {
+        buttonTransition.message(saveButton, 'エラー', 'danger');
+        setTimeout(() => {
+          enableButton();
+        }, 3000);
+      } else {
+        await window.editor.save(json as Packages['packages']);
+
+        buttonTransition.message(saveButton, '保存完了', 'success');
+        setTimeout(() => {
+          enableButton();
+        }, 3000);
+      }
+    };
+
+    editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, save);
+    saveButton.addEventListener('click', save);
+  };
+
+  return (
+    <MonacoEditor
+      height="50vh"
+      defaultLanguage="json"
+      path={modelUri}
+      beforeMount={editorWillMount}
+      onMount={editorDidMount}
+    />
+  );
+};

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -10,6 +10,7 @@ import {
   openDialog,
 } from '../../lib/ipcWrapper';
 import * as modList from '../../lib/modList';
+import { EditorContextBridge } from './monacoEditorPreload';
 import migration2to3 from '../../migration/migration2to3';
 import core from './core';
 import packageMain from './package';
@@ -21,6 +22,7 @@ log.errorHandler.startCatching({
     await openDialog('エラー', '予期しないエラーが発生しました。', 'error');
   },
 });
+const editorContextBridge = new EditorContextBridge();
 
 window.addEventListener('DOMContentLoaded', async () => {
   // dark-theme
@@ -68,6 +70,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     'extra-data-url',
   ) as HTMLInputElement;
   extraDataURL.value = modList.getExtraDataUrl();
+  await editorContextBridge.setInstPath(installationPath);
   const zoomFactorSelect = document.getElementById(
     'zoom-factor-select',
   ) as HTMLSelectElement;

--- a/src/renderer/main/renderer.ts
+++ b/src/renderer/main/renderer.ts
@@ -1,5 +1,0 @@
-import 'bootstrap/dist/css/bootstrap.min.css';
-import '../../../node_modules/bootstrap-icons/font/bootstrap-icons.css';
-import '../main.css';
-import './index.css';
-import 'bootstrap/dist/js/bootstrap.bundle.min';

--- a/src/renderer/main/renderer.tsx
+++ b/src/renderer/main/renderer.tsx
@@ -1,0 +1,19 @@
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap/dist/js/bootstrap.bundle.min';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import '../../../node_modules/bootstrap-icons/font/bootstrap-icons.css';
+import '../main.css';
+import './index.css';
+import { MonacoEditorRenderer } from './monacoEditorRenderer';
+
+window.addEventListener('DOMContentLoaded', () => {
+  const root = createRoot(document.getElementById('container'));
+  root.render(
+    <MonacoEditorRenderer
+      saveButton={
+        document.getElementById('save-editor-data') as HTMLButtonElement
+      }
+    />,
+  );
+});

--- a/src/types/mainRenderer.d.ts
+++ b/src/types/mainRenderer.d.ts
@@ -1,0 +1,12 @@
+import { Packages } from 'apm-schema';
+
+export declare global {
+  interface Window {
+    editor: {
+      setOnload: (
+        onload: (packages: Packages['packages']) => Promise<void>,
+      ) => void;
+      save: (packages: Packages['packages']) => Promise<void>;
+    };
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,6 +1055,20 @@
   dependencies:
     cross-spawn "^7.0.1"
 
+"@monaco-editor/loader@^1.5.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/loader/-/loader-1.7.0.tgz#967aaa4601b19e913627688dfe8159d57549e793"
+  integrity sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==
+  dependencies:
+    state-local "^1.0.6"
+
+"@monaco-editor/react@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@monaco-editor/react/-/react-4.7.0.tgz#35a1ec01bfe729f38bfc025df7b7bac145602a60"
+  integrity sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==
+  dependencies:
+    "@monaco-editor/loader" "^1.5.0"
+
 "@napi-rs/wasm-runtime@^1.1.4":
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz#ed33806d0f9be98dc76d0c3d4fd872fda701b5d5"
@@ -7369,6 +7383,11 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+monaco-editor@0.52.2:
+  version "0.52.2"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.52.2.tgz#53c75a6fcc6802684e99fd1b2700299857002205"
+  integrity sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -9321,6 +9340,11 @@ stackback@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
   integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+state-local@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.7.tgz#da50211d07f05748d53009bee46307a37db386d5"
+  integrity sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==
 
 statuses@2.0.1:
   version "2.0.1"


### PR DESCRIPTION
## 概要

#1627 (feat: add data editor) の手動ポートです。#1627 は main から大きく遅れて merge 不可のため、`gh pr diff 1627` を参考に現行コードへ写しました。マージ後に #1627 を close し、v3.11.0 のリリース対象になります([ROADMAP](https://github.com/team-apm/apm/blob/main/ROADMAP.md) の「次の一手」)。

機能: 設定タブに Monaco JSON エディタを追加。apm-data 投稿用のパッケージデータを貼り付けて `{instPath}/editorPackages.json` に保存でき、パッケージ一覧のデータ源にマージされます。apm-schema による validation・プレースホルダー・Ctrl+S 保存に対応。

## 元 PR からの主な変更点

- **`monaco-editor` は型のみインポート**(`import type`)し、enum は onMount の `monaco` インスタンスから取得。元 PR は値インポートのため Monaco 全体(実行時は CDN からも二重に読込)がバンドルされ、`NODE_OPTIONS=--max-old-space-size=4096` が必要でしたが、このポートでは不要になったため scripts の変更ごと落としています(AGENTS.md の落とし穴に追記済み)
- **`getPackagesDataUrl` は現行の三項演算子形式を維持**。元 PR の `[].concat(a, instPath && ...)` は instPath が空のとき falsy 値が配列要素に混入するため採用せず
- placeholder 内の JSON 例の `id` のクォート欠けを修正
- 無関係なタブ表記の変更(`プラグイン <small>&</small> スクリプト` 等)はポート対象外
- React 19 対応の `@monaco-editor/react` 4.7.0 を使用

## 暫定許容(セキュリティフェーズで回収)

CDN Monaco (cdn.jsdelivr.net) と CSP 緩和(`script-src-elem`/`style-src 'unsafe-inline'`/`worker-src blob:` 等)は `TODO(security)` コメント付きで暫定許容としています。回収方針は Monaco のローカルバンドル化(ROADMAP のセキュリティフェーズ)。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(29 tests)すべて緑
- Node 22 で `yarn package` 成功(macOS arm64)
- パッケージ版アプリで起動スモーク: CDP 経由で Monaco のマウント・保存ボタン・contextBridge(`window.editor`)・プレースホルダー表示を確認、スクリーンショットでも設定タブの描画を確認
- 保存(editorPackages.json 書き込み → パッケージ一覧マージ)の実機確認は Windows 環境でお願いします

🤖 Generated with [Claude Code](https://claude.com/claude-code)