### PR TITLE
build(webpack): 本番ビルドの renderer から inline source map を除外

### DIFF
--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -22,7 +22,10 @@ rules.push({
 plugins.push(new MiniCssExtractPlugin());
 
 export const rendererConfig: Configuration = {
-  devtool: 'inline-source-map',
+  // 本番ビルドに inline source map を含めない(バンドル肥大 + ソース露出防止)。
+  // 別ファイルの .map は electron-log / source-map-support のスタックトレース解決に使われる
+  devtool:
+    process.env.NODE_ENV === 'development' ? 'inline-source-map' : 'source-map',
   module: {
     rules,
   },


### PR DESCRIPTION
## 概要

Phase 2(骨格整理)の最初のスライスです。renderer の webpack 設定が本番ビルドでも `inline-source-map` を使っており、バンドルに全ソースが base64 で埋め込まれていました(バンドル肥大 + ソース露出)。

`NODE_ENV=development`(`yarn start`)のときのみ inline とし、本番は別ファイルの `source-map` に切り替えます。

## 効果(macOS arm64 の実測)

- main_window の `index.js`: **290KB**(source map 1.1MB は別ファイル `index.js.map` へ)
- electron-forge の packaging は JS の `.map` を asar に同梱しないため、**配布物からソースマップが消えます**(従来は inline で全ソースが配布物に入っていた)

## 検証

- `yarn lint:ts` 緑
- Node 22 で `yarn package` 後、asar 内の `index.js` に `sourceMappingURL=data:` が 0 件、外部参照 1 件であることを確認
- 開発時(`yarn start`)は従来どおり inline-source-map

🤖 Generated with [Claude Code](https://claude.com/claude-code)