### PR TITLE
fix(unzip): 7z エラー時に promise を reject してハングを防ぐ

### DIFF
--- a/src/lib/unzip.test.ts
+++ b/src/lib/unzip.test.ts
@@ -1,0 +1,73 @@
+import { path7za } from '7zip-bin';
+import { chmod, mkdtemp, pathExists, remove, writeFile } from 'fs-extra';
+import { add } from 'node-7z';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import unzip from './unzip';
+
+// The prebuilt 7za binary shipped by 7zip-bin is not always installed with
+// the executable bit set (observed on some package manager / CI setups).
+// Ensure it is runnable before exercising 7z, without touching production
+// code (unzip.ts relies on the binary already being executable).
+beforeAll(async () => {
+  if (process.platform !== 'win32') {
+    await chmod(path7za, 0o755);
+  }
+});
+
+/**
+ * Creates a zip archive fixture containing a single text file.
+ * @param {string} dir - Directory in which to create the archive.
+ * @returns {Promise<string>} Path to the created zip archive.
+ */
+async function createZipFixture(dir: string): Promise<string> {
+  const zipPath = path.join(dir, 'fixture.zip');
+  const fileName = 'hello.txt';
+  await writeFile(path.join(dir, fileName), 'hello world');
+  // node-7z 3.x does not actually wire up `$spawnOptions` to the spawned
+  // child process, so a relative source path is resolved against the
+  // current process cwd. Temporarily chdir into the fixture directory so
+  // the archive stores a plain `hello.txt` entry instead of an absolute path.
+  const originalCwd = process.cwd();
+  process.chdir(dir);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const stream = add(zipPath, fileName, { $bin: path7za });
+      stream.once('end', () => resolve());
+      stream.once('error', (err: Error) => reject(err));
+    });
+  } finally {
+    process.chdir(originalCwd);
+  }
+  return zipPath;
+}
+
+describe('unzip', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => remove(dir)));
+  });
+
+  it('rejects when the zip path does not exist (regression: used to hang)', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'apm-unzip-'));
+    tempDirs.push(dir);
+    const missingZip = path.join(dir, 'missing.zip');
+
+    await expect(unzip(missingZip)).rejects.toThrow(
+      `Failed to unzip ${missingZip}`,
+    );
+  }, 30000);
+
+  it('extracts a zip archive to the target directory', async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'apm-unzip-'));
+    tempDirs.push(dir);
+    const zipPath = await createZipFixture(dir);
+
+    const targetPath = await unzip(zipPath);
+
+    expect(targetPath).toBe(path.join(dir, 'fixture'));
+    expect(await pathExists(path.join(targetPath, 'hello.txt'))).toBe(true);
+  }, 30000);
+});

--- a/src/lib/unzip.ts
+++ b/src/lib/unzip.ts
@@ -44,11 +44,16 @@ async function unzip(zipPath: string, folderName?: string) {
     // AviUtl script is encoded in Shift_JIS, so we need to specify the code page as Shift_JIS(932) when unzipping.
     // But you must not specify when unzipping .7z.
   });
-  return new Promise((resolve) => {
+  return new Promise<string>((resolve, reject) => {
     zipStream.once('end', () => {
       resolve(targetPath);
     });
-  }) as Promise<string>;
+    zipStream.once('error', (err: Error) => {
+      reject(
+        new Error(`Failed to unzip ${zipPath}: ${err.message}`, { cause: err }),
+      );
+    });
+  });
 }
 
 export default unzip;


### PR DESCRIPTION
## 概要

`unzip()` は `extractFull()`(node-7z)が返すストリームの `end` イベントのみを
待って Promise を解決していた。7z の子プロセス起動自体が失敗した場合
(実行権限がない・バイナリが存在しないなど)は子プロセスの `close` イベントが
発火せず、node-7z 内部でも `end` が emit されないため、`unzip()` の Promise が
永遠に解決しない(呼び出し元が無限にハングする)不具合があった。

対応として `zipStream.once('error', ...)` を追加し、7z がエラーを出した際は
対象の zip パスを含むメッセージ(`Failed to unzip ${zipPath}: ${err.message}`)
で reject するようにした。元のエラーは `cause` に保持している。
あわせて Promise の構築を `new Promise<string>((resolve, reject) => ...)` に
直し、不要になっていた `as Promise<string>` キャストを削除した。
`targetPath` の決定ロジックや `cp=932` の分岐など、それ以外の挙動は変更していない。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test` すべて緑
- `src/lib/unzip.test.ts` を追加(Vitest)
  - 存在しない zip パスを渡すと `unzip()` が reject されることを確認する回帰
    テスト(修正前はここでハングしていた)
  - 正常系: `node-7z` の `add` と `7zip-bin` の `path7za` を使い、
    `os.tmpdir()` 配下の一時ディレクトリに fixture zip を作成し、実際に
    `unzip()` で解凍できることを確認するテスト(`fs-extra` の `mkdtemp` /
    `remove` を使い、`afterEach` でクリーンアップ)
  - 両テストとも 30 秒のタイムアウトを設定
  - `path.join` でパスを組み立てており、Windows/macOS/Linux の 3 OS で動作する想定
- `yarn test` 全体: 6 ファイル 31 件すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)