### PR TITLE
feat(apm-json): begin/commit トランザクションを追加し一括操作を 1 回書き込みに

### DIFF
--- a/src/lib/ApmJson.test.ts
+++ b/src/lib/ApmJson.test.ts
@@ -185,6 +185,79 @@ describe('ApmJson', () => {
     });
   });
 
+  describe('begin / commit(トランザクション)', () => {
+    it('begin 中の set は書き込みを遅延し、commit で 1 回だけ書き込む', async () => {
+      const instPath = await makeInstPath();
+      const jsonPath = ApmJson.getPath(instPath);
+      const apmJson = await ApmJson.load(instPath);
+
+      apmJson.begin();
+      await apmJson.set('core.aviutl', '1.10');
+      await apmJson.set('core.exedit', '0.92');
+
+      // commit まではディスクに書き込まれない
+      expect(await pathExists(jsonPath)).toBe(false);
+      // read-your-writes: メモリ上では set した値が見える
+      expect(await apmJson.get('core.aviutl')).toBe('1.10');
+      expect(await apmJson.has('core.exedit')).toBe(true);
+
+      await apmJson.commit();
+      expect(await readJson(jsonPath)).toEqual({
+        dataVersion: '3',
+        core: { aviutl: '1.10', exedit: '0.92' },
+        packages: {},
+      });
+    });
+
+    it('begin 中の delete も遅延され、戻り値の意味は変わらない', async () => {
+      const instPath = await makeInstPath();
+      const jsonPath = ApmJson.getPath(instPath);
+      await writeJson(jsonPath, {
+        dataVersion: '3',
+        core: { aviutl: '1.10' },
+        packages: {},
+      });
+      const apmJson = await ApmJson.load(instPath);
+
+      apmJson.begin();
+      // 戻り値は「親パスまで辿れたかどうか」(即時書き込み時と同じ)
+      expect(await apmJson.delete('core.aviutl')).toBe(true);
+      expect(await apmJson.delete('nonexistent.parent.key')).toBe(false);
+      expect((await readJson(jsonPath)).core).toEqual({ aviutl: '1.10' });
+
+      await apmJson.commit();
+      expect((await readJson(jsonPath)).core).toEqual({});
+    });
+
+    it('変更がないまま commit してもファイルを書き込まない', async () => {
+      const instPath = await makeInstPath();
+      const apmJson = await ApmJson.load(instPath);
+
+      apmJson.begin();
+      // 存在しないキーの delete はオブジェクトを変更しないため dirty にならない
+      await apmJson.delete('nonexistent.parent.key');
+      await apmJson.commit();
+
+      expect(await pathExists(ApmJson.getPath(instPath))).toBe(false);
+    });
+
+    it('commit 後の set は従来どおり即時書き込みに戻る', async () => {
+      const instPath = await makeInstPath();
+      const jsonPath = ApmJson.getPath(instPath);
+      const apmJson = await ApmJson.load(instPath);
+
+      apmJson.begin();
+      await apmJson.set('core.aviutl', '1.10');
+      await apmJson.commit();
+
+      await apmJson.set('core.exedit', '0.92');
+      expect((await readJson(jsonPath)).core).toEqual({
+        aviutl: '1.10',
+        exedit: '0.92',
+      });
+    });
+  });
+
   describe('round-trip', () => {
     it('書き込んだ内容を別インスタンスで読み直しても同じ値になる', async () => {
       const instPath = await makeInstPath();

--- a/src/lib/ApmJson.ts
+++ b/src/lib/ApmJson.ts
@@ -12,6 +12,8 @@ import { type ApmJsonObject } from '../types/apmJson';
 class ApmJson {
   private path: string;
   private object: ApmJsonObject;
+  private inTransaction = false;
+  private dirty = false;
 
   /**
    * Gets the path to `apm.json`.
@@ -70,6 +72,27 @@ class ApmJson {
   }
 
   /**
+   * Starts a transaction. Subsequent set / delete calls are kept in memory
+   * (still visible via get / has) until commit() is called.
+   */
+  public begin() {
+    this.inTransaction = true;
+  }
+
+  /**
+   * Saves the changes accumulated since begin() to `apm.json` at once and
+   * ends the transaction. Does not write when nothing has changed.
+   * @returns {Promise<void>} A promise that resolves when the object is saved.
+   */
+  public async commit() {
+    this.inTransaction = false;
+    if (this.dirty) {
+      this.dirty = false;
+      await this.save();
+    }
+  }
+
+  /**
    * Checks whether `apm.json` has the property.
    * @param {string} path - Key to check existing
    * @returns {Promise<boolean>} Whether `apm.json` has the property.
@@ -98,7 +121,11 @@ class ApmJson {
    */
   public async set(path: string, value: unknown) {
     setProperty(this.object, path, value);
-    await this.save();
+    if (this.inTransaction) {
+      this.dirty = true;
+    } else {
+      await this.save();
+    }
   }
 
   /**
@@ -108,7 +135,11 @@ class ApmJson {
    */
   public async delete(path: string) {
     const existed = deleteProperty(this.object, path);
-    await this.save();
+    if (this.inTransaction) {
+      if (existed) this.dirty = true;
+    } else {
+      await this.save();
+    }
     return existed;
   }
 

--- a/src/lib/convertId.ts
+++ b/src/lib/convertId.ts
@@ -39,6 +39,7 @@ export async function getIdDict(
  */
 export async function convertId(instPath: string, modTime: number) {
   const apmJson = await ApmJson.load(instPath);
+  apmJson.begin();
   const packages = (await apmJson.get('packages')) as {
     [key: string]: { id: string };
   };
@@ -55,4 +56,5 @@ export async function convertId(instPath: string, modTime: number) {
 
   await apmJson.set('packages', packages);
   await apmJson.set('convertMod', modTime);
+  await apmJson.commit();
 }

--- a/src/migration/migration1to2.ts
+++ b/src/migration/migration1to2.ts
@@ -127,6 +127,8 @@ async function byFolder(instPath: string) {
 
   // Main
   log.info(`Start migration: migration1to2.byFolder(${instPath})`);
+  // packages の変換と dataVersion の更新を 1 回の書き込みで確定させる
+  apmJson.begin();
 
   // 1. Backup apm.json
   await download(jsonPath, { subDir: 'migration1to2', keyText: jsonPath });
@@ -176,6 +178,7 @@ async function byFolder(instPath: string) {
 
   // Finalize
   await apmJson.set('dataVersion', '2');
+  await apmJson.commit();
   log.info(`End of migration: migration1to2.byFolder(${instPath})`);
 }
 

--- a/src/migration/migration2to3.ts
+++ b/src/migration/migration2to3.ts
@@ -68,6 +68,8 @@ async function byFolder(instPath: string) {
 
   // Main
   log.info(`Start migration: migration2to3.byFolder(${instPath})`);
+  // packages の変換と dataVersion の更新を 1 回の書き込みで確定させる
+  apmJson.begin();
 
   // 1. Backup apm.json
   await download(jsonPath, { subDir: 'migration2to3', keyText: jsonPath });
@@ -140,6 +142,7 @@ async function byFolder(instPath: string) {
 
   // Finalize
   await apmJson.set('dataVersion', '3');
+  await apmJson.commit();
   log.info(`End of migration: migration2to3.byFolder(${instPath})`);
 }
 

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -139,6 +139,7 @@ async function setPackagesList(instPath: string) {
 
   // guess which packages are installed from integrity
   let modified = false;
+  apmJson.begin();
   for (const p of packages.filter(
     (p) =>
       p.info.releases &&
@@ -151,6 +152,7 @@ async function setPackagesList(instPath: string) {
       }
     }
   }
+  await apmJson.commit();
   if (modified) {
     const packagesExtraMod = await packageUtil.getPackagesExtra(
       packages,


### PR DESCRIPTION
## 概要

Phase 2 の「ApmJson トランザクション化」本体です(計画の意図: set 毎の writeJson をやめ、メモリ更新 → 最後に 1 回保存)。

### ApmJson の変更

- `begin()` / `commit()` を追加。begin 中の set / delete はメモリのみ更新し、commit で 1 回だけ全体を書き込む
- **read-your-writes は維持**(begin 中でも get / has は set した値を返す)
- `delete` の戻り値の意味(親パスまで辿れたか)は不変
- 変更ゼロのまま commit した場合は書き込まない(dirty フラグ)。delete が false を返したケースはオブジェクト不変なので dirty にしない
- **begin を使わない従来の呼び出しは即時書き込みのまま**(単発の導入・削除記録の耐クラッシュ性を維持)

### begin/commit を適用した一括操作(4 箇所)

| 箇所 | 効果 |
| --- | --- |
| `src/lib/convertId.ts` | packages 変換 + convertMod が 1 書き込みで確定 |
| `src/migration/migration1to2.ts` | packages 変換 + dataVersion='2' が原子的に確定。中断時に「変換済みなのに旧バージョン」の中途半端な状態が残らない |
| `src/migration/migration2to3.ts` | 同上(dataVersion='3') |
| `src/renderer/main/package.ts`(整合性スキャン) | 手動導入パッケージの推測結果を N 回 → 1 回書き込みに。ヒット 0 件なら apm.json に触らない現行挙動も維持 |

#2297 の特性化テストは全件そのまま緑(既定の即時書き込み挙動は不変)。トランザクションの仕様は新規テスト 4 件で固定しました。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(47 件)すべて緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)