### PR TITLE
refactor(config): getConfig() による設定ストアのシングルトン化

### DIFF
--- a/src/lib/Config.ts
+++ b/src/lib/Config.ts
@@ -26,6 +26,19 @@ type StoreType = {
   };
 };
 
+let instance: Config | undefined;
+
+/**
+ * Returns the process-wide Config instance.
+ * 状態は electron-store がディスク(config.json)で共有するため、
+ * インスタンスを 1 つにするのは初期化経路の一本化と get 毎のオーバーヘッド削減が目的。
+ * @returns {Config} The Config instance.
+ */
+export function getConfig(): Config {
+  instance ??= new Config();
+  return instance;
+}
+
 export default class Config extends Store<StoreType> {
   public hasDataVersion() {
     return this.has('dataVersion');

--- a/src/lib/modList.ts
+++ b/src/lib/modList.ts
@@ -1,11 +1,11 @@
 import fs from 'fs-extra';
 import * as os from 'node:os';
 import path from 'node:path';
-import Config from './Config';
+import { getConfig } from './Config';
 import { download, existsTempFile } from './ipcWrapper';
 import * as parseJson from './parseJson';
 import { resolvePath } from '../shared/resolvePath';
-const config = new Config();
+const config = getConfig();
 
 /**
  * Sets package data files URLs.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,7 +3,7 @@ import debug from 'electron-debug';
 import log from 'electron-log/main';
 import Store from 'electron-store';
 import 'source-map-support/register';
-import Config from '../lib/Config';
+import { getConfig } from '../lib/Config';
 import * as shortcut from '../lib/shortcut';
 import { registerIpcHandlers } from './ipcHandlers';
 import { ensureAutoUpdateDefault } from './services/appUpdate';
@@ -40,7 +40,7 @@ if (isDevEnv) app.setPath('userData', app.getPath('userData') + '_Dev');
 debug({ showDevTools: false }); // Press F12 to open DevTools
 
 Store.initRenderer();
-const config = new Config();
+const config = getConfig();
 
 ensureAutoUpdateDefault(config);
 

--- a/src/migration/migration1to2.ts
+++ b/src/migration/migration1to2.ts
@@ -2,7 +2,7 @@ import log from 'electron-log';
 import { existsSync, readdir, rename, unlink } from 'fs-extra';
 import path from 'node:path';
 import ApmJson from '../lib/ApmJson';
-import Config from '../lib/Config';
+import { getConfig } from '../lib/Config';
 import {
   app,
   download,
@@ -10,7 +10,7 @@ import {
   migration1to2DataurlInputDialog,
   openDialog,
 } from '../lib/ipcWrapper';
-const config = new Config();
+const config = getConfig();
 
 /**
  * Migration of common settings.

--- a/src/migration/migration2to3.ts
+++ b/src/migration/migration2to3.ts
@@ -2,11 +2,11 @@ import log from 'electron-log';
 import fs, { writeJson } from 'fs-extra';
 import path from 'node:path';
 import ApmJson from '../lib/ApmJson';
-import Config from '../lib/Config';
+import { getConfig } from '../lib/Config';
 import { download, openDialog } from '../lib/ipcWrapper';
 import migration1to2 from './migration1to2';
 import parseXML from './parseXML';
-const config = new Config();
+const config = getConfig();
 
 /**
  * Migration of common settings.

--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import ApmJson from '../../lib/ApmJson';
 import * as buttonTransition from '../../lib/buttonTransition';
 import { compareVersion } from '../../shared/compareVersion';
-import Config from '../../lib/Config';
+import { getConfig } from '../../lib/Config';
 import { convertId } from '../../lib/convertId';
 import { checkIntegrity, verifyFile } from '../../shared/integrity';
 import {
@@ -25,7 +25,7 @@ import migration2to3 from '../../migration/migration2to3';
 import { install, programs, verifyFilesByCount } from './common';
 import packageMain from './package';
 import packageUtil from './packageUtil';
-const config = new Config();
+const config = getConfig();
 
 // Functions to be exported
 

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -16,7 +16,7 @@ import path from 'node:path';
 import ApmJson from '../../lib/ApmJson';
 import * as buttonTransition from '../../lib/buttonTransition';
 import { compareVersion } from '../../shared/compareVersion';
-import Config from '../../lib/Config';
+import { getConfig } from '../../lib/Config';
 import { getHash } from '../../shared/getHash';
 import { checkIntegrity, verifyFile } from '../../shared/integrity';
 import {
@@ -37,7 +37,7 @@ import createList, { UpdatableList } from '../../lib/updatableList';
 import { PackageItem } from '../../types/packageItem';
 import { install, programs, programsDisp, verifyFilesByCount } from './common';
 import packageUtil from './packageUtil';
-const config = new Config();
+const config = getConfig();
 
 // To avoid a bug in the library
 // https://github.com/sindresorhus/matcher/issues/32

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -1,7 +1,7 @@
 import ClipboardJS from 'clipboard/src/clipboard';
 import log from 'electron-log/renderer';
 import 'source-map-support/register';
-import Config from '../../lib/Config';
+import { getConfig } from '../../lib/Config';
 import {
   app,
   checkUpdate,
@@ -15,7 +15,7 @@ import migration2to3 from '../../migration/migration2to3';
 import core from './core';
 import packageMain from './package';
 import setting from './setting';
-const config = new Config();
+const config = getConfig();
 
 log.errorHandler.startCatching({
   onError: async () => {

--- a/src/renderer/main/setting.ts
+++ b/src/renderer/main/setting.ts
@@ -3,10 +3,10 @@ import fs from 'fs-extra';
 import * as os from 'node:os';
 import path from 'node:path';
 import * as buttonTransition from '../../lib/buttonTransition';
-import Config from '../../lib/Config';
+import { getConfig } from '../../lib/Config';
 import { changeMainZoomFactor, openDialog } from '../../lib/ipcWrapper';
 import * as modList from '../../lib/modList';
-const config = new Config();
+const config = getConfig();
 
 /**
  * Initializes settings


### PR DESCRIPTION
## 概要

Phase 2 最後のタスク「Config シングルトン化(getConfig() 1 入口)」です。

- `src/lib/Config.ts` に遅延生成の `getConfig()` を追加
- 8 箇所に散らばっていた `const config = new Config()` をすべて `getConfig()` に置換(preload / setting / core / package / modList / migration1to2 / migration2to3 / main の index.ts)
- `Config` クラス自体は export のまま(テストでは `new Config({ cwd })` を引き続き使用)

**挙動は不変**です。状態は従来どおり electron-store がディスク(config.json)経由で共有するため([#2301](https://github.com/team-apm/apm/pull/2301) の特性化テストで固定した境界)、目的は正しさではなく初期化経路の一本化とインスタンス生成オーバーヘッドの削減です。webpack のバンドル(main / preload / renderer)ごとにモジュールスコープは分かれますが、これも従来と同じで、ディスク共有により整合します。

#2301(Config 特性化テスト)とはファイルが重ならないため、マージ順は任意です。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test` すべて緑
- Node 22 で `yarn package` 成功 + パッケージ版の CDP 起動スモーク(main 窓表示、Monaco マウント、preload ブリッジ経由の instPath 受け渡しまで)確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)