### PR TITLE
refactor(setting): dataURL 検証を src/shared の純関数に抽出

### DIFF
--- a/src/renderer/main/setting.ts
+++ b/src/renderer/main/setting.ts
@@ -1,11 +1,10 @@
 import log from 'electron-log/renderer';
-import fs from 'fs-extra';
 import * as os from 'node:os';
-import path from 'node:path';
 import * as buttonTransition from '../../lib/buttonTransition';
 import { getConfig } from '../../lib/Config';
 import { changeMainZoomFactor, openDialog } from '../../lib/ipcWrapper';
 import * as modList from '../../lib/modList';
+import { validateDataUrls } from '../../shared/dataUrl';
 const config = getConfig();
 
 /**
@@ -30,52 +29,18 @@ async function setDataUrl(dataUrl: { value: string }, extraDataUrls: string) {
       ? buttonTransition.loading(btn, '設定')
       : { enableButton: undefined };
 
-  if (!dataUrl.value) {
-    dataUrl.value = 'https://cdn.jsdelivr.net/gh/team-apm/apm-data@main/v3/';
-  }
-  const value = dataUrl.value;
-
-  let error = false;
-  if (!value.startsWith('http') && !fs.existsSync(value)) {
-    await openDialog(
-      'エラー',
-      '有効なURLまたは場所を入力してください。',
-      'error',
-    );
-    error = true;
-  }
-  if (path.extname(value) === '.json') {
-    await openDialog('エラー', 'フォルダのURLを入力してください。', 'error');
-    error = true;
+  const { mainUrl, extraUrls, errors } = validateDataUrls(
+    dataUrl.value,
+    extraDataUrls,
+  );
+  dataUrl.value = mainUrl;
+  for (const message of errors) {
+    await openDialog('エラー', message, 'error');
   }
 
-  const tmpExtraUrls = extraDataUrls
-    .split(/\r?\n/)
-    .map((url) => url.trim())
-    .filter((url) => url !== '');
-
-  for (const tmpDataUrl of tmpExtraUrls) {
-    if (!tmpDataUrl.startsWith('http') && !fs.existsSync(tmpDataUrl)) {
-      await openDialog(
-        'エラー',
-        `有効なURLまたは場所を入力してください。(${tmpDataUrl})`,
-        'error',
-      );
-      error = true;
-    }
-    if (path.extname(tmpDataUrl) !== '.json') {
-      await openDialog(
-        'エラー',
-        `有効なJsonファイルのURLまたは場所を入力してください。(${tmpDataUrl})`,
-        'error',
-      );
-      error = true;
-    }
-  }
-
-  if (!error) {
-    config.dataURL.setMain(value);
-    config.dataURL.setExtra(tmpExtraUrls.join(os.EOL));
+  if (errors.length === 0) {
+    config.dataURL.setMain(mainUrl);
+    config.dataURL.setExtra(extraUrls.join(os.EOL));
     await modList.updateInfo();
 
     if (btn instanceof HTMLButtonElement) {

--- a/src/shared/dataUrl.test.ts
+++ b/src/shared/dataUrl.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_DATA_URL, validateDataUrls } from './dataUrl';
+
+/**
+ * validateDataUrls の特性化テスト。
+ * 旧 setting.ts の setDataUrl が持っていた検証仕様を固定する。
+ */
+describe('validateDataUrls', () => {
+  const noFile = () => false;
+
+  it('メインが空のときは既定の apm-data URL に置き換わる', () => {
+    const result = validateDataUrls('', '', noFile);
+    expect(result.mainUrl).toBe(DEFAULT_DATA_URL);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('http(s) の URL は存在確認なしで通る', () => {
+    const result = validateDataUrls('https://example.com/data/', '', noFile);
+    expect(result.mainUrl).toBe('https://example.com/data/');
+    expect(result.errors).toEqual([]);
+  });
+
+  it('http で始まらないメインは存在しなければエラー、存在すれば通る', () => {
+    expect(validateDataUrls('C:\\data', '', noFile).errors).toEqual([
+      '有効なURLまたは場所を入力してください。',
+    ]);
+    expect(validateDataUrls('C:\\data', '', () => true).errors).toEqual([]);
+  });
+
+  it('メインに .json を指定するとフォルダを要求するエラーになる', () => {
+    const result = validateDataUrls(
+      'https://example.com/packages.json',
+      '',
+      noFile,
+    );
+    expect(result.errors).toEqual(['フォルダのURLを入力してください。']);
+  });
+
+  it('追加 URL は改行区切りで、前後空白と空行が除去される', () => {
+    const result = validateDataUrls(
+      '',
+      '  https://a.example/x.json  \r\n\r\nhttps://b.example/y.json\n   \n',
+      noFile,
+    );
+    expect(result.extraUrls).toEqual([
+      'https://a.example/x.json',
+      'https://b.example/y.json',
+    ]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('追加 URL は .json でなければエラーになる(メインと逆の要求)', () => {
+    const result = validateDataUrls('', 'https://example.com/data/', noFile);
+    expect(result.errors).toEqual([
+      '有効なJsonファイルのURLまたは場所を入力してください。(https://example.com/data/)',
+    ]);
+  });
+
+  it('http で始まらない追加 URL は存在しなければ場所エラーも重なる', () => {
+    const result = validateDataUrls('', 'C:\\packages.txt', noFile);
+    // 場所エラーと .json エラーの両方が、この順で積まれる(現行仕様)
+    expect(result.errors).toEqual([
+      '有効なURLまたは場所を入力してください。(C:\\packages.txt)',
+      '有効なJsonファイルのURLまたは場所を入力してください。(C:\\packages.txt)',
+    ]);
+  });
+
+  it('エラーはメイン → 追加の順にすべて集まる', () => {
+    const result = validateDataUrls(
+      'bad-main.json',
+      'https://a.example/ok.json\nbad-extra',
+      noFile,
+    );
+    expect(result.errors).toEqual([
+      '有効なURLまたは場所を入力してください。',
+      'フォルダのURLを入力してください。',
+      '有効なURLまたは場所を入力してください。(bad-extra)',
+      '有効なJsonファイルのURLまたは場所を入力してください。(bad-extra)',
+    ]);
+  });
+});

--- a/src/shared/dataUrl.ts
+++ b/src/shared/dataUrl.ts
@@ -1,0 +1,59 @@
+import { existsSync } from 'fs-extra';
+import path from 'node:path';
+
+/** The default data files URL used when the input is empty. */
+export const DEFAULT_DATA_URL =
+  'https://cdn.jsdelivr.net/gh/team-apm/apm-data@main/v3/';
+
+export type DataUrlValidationResult = {
+  /** The normalized main data files URL (the default URL when the input is empty). */
+  mainUrl: string;
+  /** The extra data files URLs (one per line in the input, trimmed, empty lines removed). */
+  extraUrls: string[];
+  /** Error messages in the order the current UI shows them. Empty when valid. */
+  errors: string[];
+};
+
+/**
+ * Validates the data files URLs entered in the settings tab.
+ * 挙動は旧 setting.ts の setDataUrl の検証部分と同一(特性化テストで固定):
+ * メインはフォルダの URL(.json 不可)、追加はファイルの URL(.json 必須)。
+ * http(s) で始まらない場合はローカルパスとして存在確認する。
+ * @param {string} mainUrl - The main data files URL. Empty means the default URL.
+ * @param {string} extraDataUrls - Newline-separated extra data files URLs.
+ * @param {Function} [fileExists] - Injectable existence check for local paths.
+ * @returns {DataUrlValidationResult} The normalized URLs and error messages.
+ */
+export function validateDataUrls(
+  mainUrl: string,
+  extraDataUrls: string,
+  fileExists: (p: string) => boolean = existsSync,
+): DataUrlValidationResult {
+  const value = mainUrl || DEFAULT_DATA_URL;
+
+  const errors: string[] = [];
+  if (!value.startsWith('http') && !fileExists(value)) {
+    errors.push('有効なURLまたは場所を入力してください。');
+  }
+  if (path.extname(value) === '.json') {
+    errors.push('フォルダのURLを入力してください。');
+  }
+
+  const extraUrls = extraDataUrls
+    .split(/\r?\n/)
+    .map((url) => url.trim())
+    .filter((url) => url !== '');
+
+  for (const extraUrl of extraUrls) {
+    if (!extraUrl.startsWith('http') && !fileExists(extraUrl)) {
+      errors.push(`有効なURLまたは場所を入力してください。(${extraUrl})`);
+    }
+    if (path.extname(extraUrl) !== '.json') {
+      errors.push(
+        `有効なJsonファイルのURLまたは場所を入力してください。(${extraUrl})`,
+      );
+    }
+  }
+
+  return { mainUrl: value, extraUrls, errors };
+}


### PR DESCRIPTION
## 概要

Phase 3(Settings タブの React + tRPC 移行)の最初のスライスです。手順「特性化テスト → 移設」に従い、Settings タブの中核ロジックである dataURL 検証を electron 非依存の純関数に抽出します。

- `src/shared/dataUrl.ts`: `validateDataUrls(mainUrl, extraDataUrls)` と `DEFAULT_DATA_URL` を追加。検証仕様は旧 `setting.ts#setDataUrl` と同一:
  - メイン空欄 → 既定の apm-data URL に置換
  - メインはフォルダ URL(`.json` 拒否)、追加 URL は `.json` 必須(逆の要求)
  - 非 http はローカルパスとして存在確認
  - エラー文言・順序も現行どおり(特性化テスト 8 件で固定)
- `setting.ts` は検証を関数呼び出しに置き換え。ダイアログ表示・入力要素への書き戻し・エラー時に config を書き込まない挙動は不変

この関数は次のスライスで main プロセス(tRPC procedure)から呼ばれる予定です(shared に置いたのはそのため)。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(59 件)すべて緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)