### PR TITLE
refactor(setting): Settings タブのロジックを main プロセス + tRPC 化

### DIFF
--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -15,7 +15,6 @@ export const IPC_CHANNELS = {
   OPEN_ABOUT_WINDOW: 'open-about-window',
   MIGRATION1TO2_CONFIRM_DIALOG: 'migration1to2-confirm-dialog',
   MIGRATION1TO2_DATAURL_INPUT_DIALOG: 'migration1to2-dataurl-input-dialog',
-  CHANGE_MAIN_ZOOM_FACTOR: 'change-main-zoom-factor',
   DOWNLOAD: 'download',
   OPEN_BROWSER: 'open-browser',
 };

--- a/src/lib/ipcWrapper.ts
+++ b/src/lib/ipcWrapper.ts
@@ -182,14 +182,6 @@ export async function migration1to2DataurlInputDialog() {
 }
 
 /**
- * Changes the zoom factor of the main window.
- * @param {number} zoomFactor - A zoom factor to be changed to. Zoom factor is zoom percent divided by 100, so 300% = 3.0.
- */
-export async function changeMainZoomFactor(zoomFactor: number) {
-  await ipcRenderer.invoke(IPC_CHANNELS.CHANGE_MAIN_ZOOM_FACTOR, zoomFactor);
-}
-
-/**
  * Downloads a file.
  * @param {string} url - The URL of a file to download.
  * @param {object} [options] - Options

--- a/src/lib/trpcClient.ts
+++ b/src/lib/trpcClient.ts
@@ -1,0 +1,24 @@
+import { createTRPCProxyClient } from '@trpc/client';
+import { ipcRenderer } from 'electron';
+import { ELECTRON_TRPC_CHANNEL } from 'electron-trpc/main';
+import { ipcLink } from 'electron-trpc/renderer';
+import type { AppRouter } from '../main/api';
+
+type ElectronTRPC = {
+  sendMessage: (message: unknown) => void;
+  onMessage: (callback: (message: unknown) => void) => void;
+};
+
+// exposeElectronTRPC は contextBridge でメインワールドにだけ bridge を生やすため、
+// preload(隔離ワールド)で動くレガシーコードからは見えない。ipcLink が参照する
+// globalThis.electronTRPC を、このワールドに同じ形で直接用意する。
+(globalThis as { electronTRPC?: ElectronTRPC }).electronTRPC ??= {
+  sendMessage: (message) => ipcRenderer.send(ELECTRON_TRPC_CHANNEL, message),
+  onMessage: (callback) =>
+    ipcRenderer.on(ELECTRON_TRPC_CHANNEL, (_event, message) =>
+      callback(message),
+    ),
+};
+
+/** レガシー(非 React)コードから main プロセスの tRPC procedure を呼ぶためのクライアント。 */
+export const trpc = createTRPCProxyClient<AppRouter>({ links: [ipcLink()] });

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -1,12 +1,65 @@
 import { initTRPC } from '@trpc/server';
-import { app } from 'electron';
+import { app, type IpcMainInvokeEvent } from 'electron';
+import type { CreateContextOptions } from 'electron-trpc/main';
+import { getConfig } from '../lib/Config';
+import { ensureExtraDataUrl, setDataUrls } from './services/settings';
 
-const t = initTRPC.create({ isServer: true });
+export type Context = {
+  event: IpcMainInvokeEvent;
+};
+
+/**
+ * Creates the tRPC context for each request.
+ * @param {CreateContextOptions} opts - The options containing the IPC event.
+ * @returns {Promise<Context>} The context.
+ */
+export async function createContext({
+  event,
+}: CreateContextOptions): Promise<Context> {
+  return { event };
+}
+
+const t = initTRPC.context<Context>().create({ isServer: true });
 const procedure = t.procedure;
+
+const stringInput = (value: unknown): string => {
+  if (typeof value !== 'string') throw new TypeError('A string is expected.');
+  return value;
+};
+
+const dataUrlsInput = (
+  value: unknown,
+): { mainUrl: string; extraDataUrls: string } => {
+  if (typeof value !== 'object' || value === null)
+    throw new TypeError('An object is expected.');
+  const { mainUrl, extraDataUrls } = value as Record<string, unknown>;
+  if (typeof mainUrl !== 'string' || typeof extraDataUrls !== 'string')
+    throw new TypeError(
+      'mainUrl and extraDataUrls are expected to be strings.',
+    );
+  return { mainUrl, extraDataUrls };
+};
 
 export const router = t.router({
   getAppVersion: procedure.query(async () => {
     return app.getVersion();
+  }),
+  settings: t.router({
+    ensureExtraDataUrl: procedure.mutation(() =>
+      ensureExtraDataUrl(getConfig()),
+    ),
+    setDataUrls: procedure
+      .input(dataUrlsInput)
+      .mutation(({ input }) =>
+        setDataUrls(getConfig(), input.mainUrl, input.extraDataUrls),
+      ),
+    getZoomFactor: procedure.query(() => getConfig().getZoomFactor()),
+    changeZoomFactor: procedure
+      .input(stringInput)
+      .mutation(({ input, ctx }) => {
+        getConfig().setZoomFactor(input);
+        ctx.event.sender.setZoomFactor(parseInt(input) / 100);
+      }),
   }),
 });
 

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -1,0 +1,93 @@
+import { mkdtemp, remove } from 'fs-extra';
+import * as os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import Config from '../../lib/Config';
+import { DEFAULT_DATA_URL } from '../../shared/dataUrl';
+import { ensureExtraDataUrl, setDataUrls } from './settings';
+
+/**
+ * Settings サービスの特性化テスト。
+ * 旧 setting.ts(renderer)が持っていた「検証が通ったときだけ config に
+ * 書き込む」挙動を、main プロセスへの移設にあたって固定する。
+ */
+describe('settings service', () => {
+  const tempDirs: string[] = [];
+
+  const makeConfig = async (): Promise<Config> => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'apm-settings-'));
+    tempDirs.push(dir);
+    return new Config({ cwd: dir });
+  };
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => remove(dir)));
+  });
+
+  describe('ensureExtraDataUrl', () => {
+    it('追加 URL が未設定なら空文字列を設定する', async () => {
+      const config = await makeConfig();
+
+      const result = ensureExtraDataUrl(config);
+
+      expect(config.dataURL.hasExtra()).toBe(true);
+      expect(result).toEqual({ hasMain: false, extra: '' });
+    });
+
+    it('設定済みの値は変更せず、メイン URL の有無を返す', async () => {
+      const config = await makeConfig();
+      config.dataURL.setMain('https://example.com/data/');
+      config.dataURL.setExtra('https://example.com/x.json');
+
+      const result = ensureExtraDataUrl(config);
+
+      expect(result).toEqual({
+        hasMain: true,
+        extra: 'https://example.com/x.json',
+      });
+    });
+  });
+
+  describe('setDataUrls', () => {
+    it('検証が通ると main と extra(改行結合)を書き込む', async () => {
+      const config = await makeConfig();
+
+      const result = setDataUrls(
+        config,
+        'https://example.com/data/',
+        'https://a.example/x.json\nhttps://b.example/y.json',
+      );
+
+      expect(result.errors).toEqual([]);
+      expect(config.dataURL.getMain()).toBe('https://example.com/data/');
+      expect(config.dataURL.getExtra()).toBe(
+        ['https://a.example/x.json', 'https://b.example/y.json'].join(os.EOL),
+      );
+    });
+
+    it('メインが空なら既定 URL が書き込まれる', async () => {
+      const config = await makeConfig();
+
+      const result = setDataUrls(config, '', '');
+
+      expect(result.mainUrl).toBe(DEFAULT_DATA_URL);
+      expect(config.dataURL.getMain()).toBe(DEFAULT_DATA_URL);
+    });
+
+    it('検証エラー時は config を変更しない', async () => {
+      const config = await makeConfig();
+      config.dataURL.setMain('https://example.com/data/');
+      config.dataURL.setExtra('https://example.com/x.json');
+
+      const result = setDataUrls(
+        config,
+        'https://example.com/broken.json',
+        'not-a-json-url',
+      );
+
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(config.dataURL.getMain()).toBe('https://example.com/data/');
+      expect(config.dataURL.getExtra()).toBe('https://example.com/x.json');
+    });
+  });
+});

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -1,0 +1,44 @@
+import * as os from 'node:os';
+import type Config from '../../lib/Config';
+import {
+  validateDataUrls,
+  type DataUrlValidationResult,
+} from '../../shared/dataUrl';
+
+/**
+ * Ensures that the extra data URLs entry exists in the config.
+ * 旧 setting.ts の initSettings が行っていた前処理と同一。
+ * @param {Config} config - The config instance.
+ * @returns {object} Whether the main data URL is set, and the extra data URLs.
+ */
+export function ensureExtraDataUrl(config: Config): {
+  hasMain: boolean;
+  extra: string;
+} {
+  if (!config.dataURL.hasExtra()) config.dataURL.setExtra('');
+  return {
+    hasMain: config.dataURL.hasMain(),
+    extra: config.dataURL.getExtra(),
+  };
+}
+
+/**
+ * Validates the data files URLs and saves them to the config only when valid.
+ * 旧 setting.ts の setDataUrl のうち、検証と設定書き込みの部分と同一の挙動。
+ * @param {Config} config - The config instance.
+ * @param {string} mainUrl - The main data files URL. Empty means the default URL.
+ * @param {string} extraDataUrls - Newline-separated extra data files URLs.
+ * @returns {DataUrlValidationResult} The validation result.
+ */
+export function setDataUrls(
+  config: Config,
+  mainUrl: string,
+  extraDataUrls: string,
+): DataUrlValidationResult {
+  const result = validateDataUrls(mainUrl, extraDataUrls);
+  if (result.errors.length === 0) {
+    config.dataURL.setMain(result.mainUrl);
+    config.dataURL.setExtra(result.extraUrls.join(os.EOL));
+  }
+  return result;
+}

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -13,7 +13,7 @@ import windowStateKeeper from 'electron-window-state';
 import path from 'node:path';
 import { IPC_CHANNELS } from '../common/ipc';
 import type Config from '../lib/Config';
-import { router } from './api';
+import { createContext, router } from './api';
 import { runAutoUpdate } from './services/appUpdate';
 import { downloadFile } from './services/download';
 
@@ -81,6 +81,14 @@ export async function launch(config: Config) {
     },
   });
 
+  // ipcMain へのリスナー登録は 1 回だけにし、窓の追加は attachWindow で行う
+  // (窓を開くたびに createIPCHandler を呼ぶとリスナーが重複する)
+  const ipcHandler = createIPCHandler({
+    router,
+    createContext,
+    windows: [mainWindow],
+  });
+
   Menu.setApplicationMenu(null);
 
   mainWindow.webContents.on('will-navigate', async (event, url) => {
@@ -119,7 +127,7 @@ export async function launch(config: Config) {
         sandbox: false,
       },
     });
-    createIPCHandler({ router, windows: [aboutWindow] });
+    ipcHandler.attachWindow(aboutWindow);
     aboutWindow.once('close', () => {
       if (!aboutWindow.isDestroyed()) {
         aboutWindow.destroy();
@@ -158,10 +166,6 @@ export async function launch(config: Config) {
       },
       mainWindow,
     );
-  });
-
-  ipcMain.handle(IPC_CHANNELS.CHANGE_MAIN_ZOOM_FACTOR, (event, zoomFactor) => {
-    mainWindow.webContents.setZoomFactor(zoomFactor);
   });
 
   ipcMain.handle(IPC_CHANNELS.DOWNLOAD, async (event, url, options) => {

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -74,7 +74,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   const zoomFactorSelect = document.getElementById(
     'zoom-factor-select',
   ) as HTMLSelectElement;
-  setting.setZoomFactor(zoomFactorSelect);
+  await setting.setZoomFactor(zoomFactorSelect);
 
   const doAutoUpdate = config.getAutoUpdate();
   const autoUpdateRadios = document.getElementsByName('auto-update');

--- a/src/renderer/main/setting.ts
+++ b/src/renderer/main/setting.ts
@@ -1,19 +1,15 @@
 import log from 'electron-log/renderer';
-import * as os from 'node:os';
 import * as buttonTransition from '../../lib/buttonTransition';
-import { getConfig } from '../../lib/Config';
-import { changeMainZoomFactor, openDialog } from '../../lib/ipcWrapper';
+import { openDialog } from '../../lib/ipcWrapper';
 import * as modList from '../../lib/modList';
-import { validateDataUrls } from '../../shared/dataUrl';
-const config = getConfig();
+import { trpc } from '../../lib/trpcClient';
 
 /**
  * Initializes settings
  */
 async function initSettings() {
-  if (!config.dataURL.hasExtra()) config.dataURL.setExtra('');
-  if (!config.dataURL.hasMain())
-    await setDataUrl({ value: '' }, config.dataURL.getExtra());
+  const { hasMain, extra } = await trpc.settings.ensureExtraDataUrl.mutate();
+  if (!hasMain) await setDataUrl({ value: '' }, extra);
 }
 
 /**
@@ -29,18 +25,16 @@ async function setDataUrl(dataUrl: { value: string }, extraDataUrls: string) {
       ? buttonTransition.loading(btn, '設定')
       : { enableButton: undefined };
 
-  const { mainUrl, extraUrls, errors } = validateDataUrls(
-    dataUrl.value,
+  const { mainUrl, errors } = await trpc.settings.setDataUrls.mutate({
+    mainUrl: dataUrl.value,
     extraDataUrls,
-  );
+  });
   dataUrl.value = mainUrl;
   for (const message of errors) {
     await openDialog('エラー', message, 'error');
   }
 
   if (errors.length === 0) {
-    config.dataURL.setMain(mainUrl);
-    config.dataURL.setExtra(extraUrls.join(os.EOL));
     await modList.updateInfo();
 
     if (btn instanceof HTMLButtonElement) {
@@ -64,8 +58,8 @@ async function setDataUrl(dataUrl: { value: string }, extraDataUrls: string) {
  * Sets a zoom factor.
  * @param {HTMLSelectElement} zoomFactorSelect - A zoom factor select to change value.
  */
-function setZoomFactor(zoomFactorSelect: HTMLSelectElement) {
-  const zoomFactor = config.getZoomFactor();
+async function setZoomFactor(zoomFactorSelect: HTMLSelectElement) {
+  const zoomFactor = await trpc.settings.getZoomFactor.query();
   for (const optionElement of Array.from(zoomFactorSelect.options)) {
     if (optionElement.getAttribute('value') === zoomFactor) {
       optionElement.selected = true;
@@ -79,8 +73,7 @@ function setZoomFactor(zoomFactorSelect: HTMLSelectElement) {
  * @param {string} zoomFactor - A zoom factor to change.
  */
 async function changeZoomFactor(zoomFactor: string) {
-  config.setZoomFactor(zoomFactor);
-  await changeMainZoomFactor(parseInt(zoomFactor) / 100);
+  await trpc.settings.changeZoomFactor.mutate(zoomFactor);
 }
 
 const setting = {


### PR DESCRIPTION
## 概要

Phase 3(Settings タブ移行)のスライス 2 です。#2305 で抽出した `validateDataUrls` を main プロセスから呼び、Settings タブのビジネスロジック(dataURL 検証+書き込み・zoomFactor)を tRPC procedure として main プロセスへ移設しました。renderer 側 `setting.ts` に残るのは DOM 操作(buttonTransition・ダイアログ表示・modList 更新の起動)だけです。

## 変更内容

- **`src/main/services/settings.ts`(新規)**: `ensureExtraDataUrl` / `setDataUrls`。「検証エラーゼロのときだけ config に書き込む」現行挙動を特性化テスト 5 件で固定(`new Config({ cwd })` パターンで electron 非依存に実行)
- **`src/main/api.ts`**: `settings` ルーター追加(`ensureExtraDataUrl` / `setDataUrls` / `getZoomFactor` / `changeZoomFactor`)。Zod 未導入のため素の検証関数で入力チェック。`createContext` を導入し、`changeZoomFactor` は `ctx.event.sender` に適用(旧実装の mainWindow 固定適用と等価)
- **`src/main/windows.ts`**: `createIPCHandler` を起動時 1 回だけ生成(main 窓を含む)し、About 窓は `attachWindow` で追加。**潜在バグ修正**: 旧実装は About 窓を開くたびに `createIPCHandler` を呼んでおり、内部の `ipcMain.on` リスナーが 2 回目以降重複していました
- **`src/lib/trpcClient.ts`(新規)**: preload(隔離ワールド)から使う vanilla tRPC クライアント。`contextBridge` の bridge はメインワールド専用で preload からは見えないため、同形の bridge を `globalThis` に直接用意
- **`src/renderer/main/setting.ts`**: ロジックを tRPC 呼び出しに置換。Config への直接アクセスが消滅
- **旧コード削除**: `CHANGE_MAIN_ZOOM_FACTOR` チャンネルと `ipcWrapper.changeMainZoomFactor`(呼び出し元ゼロ化のため)

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(64 件)すべて緑
- macOS で `yarn package` + CDP スモーク **6 項目 PASS**:
  - tRPC 経由の初期化完了(app-name 反映)/ data-url 反映 / zoom select 反映
  - `changeZoomFactor` mutation で実際にズーム変化(innerWidth 960→768)
  - 設定ボタンで `setDataUrls` mutation + `modList.updateInfo` →「設定完了」表示
  - About 窓を開いて `attachWindow` + `getAppVersion` query(apm=3.10.0 表示)

## 次のスライス

Settings タブの React UI 化(About 窓パターン)→ preload から Settings ロジック削除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)