### PR TITLE
refactor(modList): updateInfo を main プロセスへ移設し tRPC 化

### DIFF
--- a/src/lib/modList.ts
+++ b/src/lib/modList.ts
@@ -1,38 +1,21 @@
 import fs from 'fs-extra';
-import * as os from 'node:os';
 import path from 'node:path';
 import { resolvePath } from '../shared/resolvePath';
 import { getConfig } from './Config';
-import { download, existsTempFile } from './ipcWrapper';
+import { existsTempFile } from './ipcWrapper';
 import * as parseJson from './parseJson';
+import { trpc } from './trpcClient';
 
 const config = getConfig();
-
-/**
- * Sets package data files URLs.
- */
-async function setPackagesDataUrl() {
-  const URLs = config.dataURL
-    .getExtra()
-    .split(os.EOL)
-    .filter((url) => url !== '');
-  const packages = ([] as string[]).concat(
-    (await getInfo()).packages.map((packageItem) =>
-      resolvePath(getDataUrl(), packageItem.path),
-    ),
-    URLs,
-  );
-  config.dataURL.setPackages(packages);
-}
 
 // Functions to be exported
 
 /**
  * Download list.json.
+ * 実装は main プロセス側(src/main/services/modList.ts)へ移設済み。
  */
 export async function updateInfo() {
-  await download(path.join(getDataUrl(), 'list.json'));
-  await setPackagesDataUrl();
+  await trpc.modList.updateInfo.mutate();
 }
 
 /**

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -1,7 +1,8 @@
 import { initTRPC } from '@trpc/server';
-import { app, type IpcMainInvokeEvent } from 'electron';
+import { app, BrowserWindow, type IpcMainInvokeEvent } from 'electron';
 import type { CreateContextOptions } from 'electron-trpc/main';
 import { getConfig } from '../lib/Config';
+import { updateInfo } from './services/modList';
 import { ensureExtraDataUrl, setDataUrls } from './services/settings';
 
 export type Context = {
@@ -60,6 +61,13 @@ export const router = t.router({
         getConfig().setZoomFactor(input);
         ctx.event.sender.setZoomFactor(parseInt(input) / 100);
       }),
+  }),
+  modList: t.router({
+    updateInfo: procedure.mutation(async ({ ctx }) => {
+      const win = BrowserWindow.fromWebContents(ctx.event.sender);
+      if (!win) throw new Error('The calling window was not found.');
+      await updateInfo(win, getConfig());
+    }),
   }),
 });
 

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -11,9 +11,9 @@ import fs from 'fs-extra';
 import path from 'node:path';
 import { IPC_CHANNELS } from '../common/ipc';
 import { isParent } from '../shared/apmPath';
-import { getHash } from '../shared/getHash';
 import { checkUpdate, isExeVersion } from './services/appUpdate';
 import { getNicommonsData } from './services/nicommons';
+import { existsTempFile } from './services/tempFile';
 
 const APP_PATH_NAMES = new Set([
   'home',
@@ -83,18 +83,7 @@ export function registerIpcHandlers() {
   ipcMain.handle(
     IPC_CHANNELS.EXISTS_TEMP_FILE,
     (event, relativePath, keyText) => {
-      const dataDir = path.join(app.getPath('userData'), 'Data/');
-      let filePath = path.join(dataDir, relativePath);
-      if (!isParent(dataDir, filePath)) {
-        throw new Error(`An invalid path was requested: ${relativePath}`);
-      }
-      if (keyText) {
-        filePath = path.join(
-          path.dirname(filePath),
-          getHash(keyText) + '_' + path.basename(filePath),
-        );
-      }
-      return { exists: fs.existsSync(filePath), path: filePath };
+      return existsTempFile(relativePath, keyText);
     },
   );
 

--- a/src/main/services/modList.ts
+++ b/src/main/services/modList.ts
@@ -1,0 +1,33 @@
+import type { List } from 'apm-schema';
+import type { BrowserWindow } from 'electron';
+import { readJson } from 'fs-extra';
+import * as os from 'node:os';
+import path from 'node:path';
+import type Config from '../../lib/Config';
+import { resolvePath } from '../../shared/resolvePath';
+import { downloadFile } from './download';
+import { existsTempFile } from './tempFile';
+
+/**
+ * Downloads list.json and updates the package data file URLs in the config.
+ * 旧 src/lib/modList.ts の updateInfo(+ setPackagesDataUrl)と同一の挙動。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ */
+export async function updateInfo(win: BrowserWindow, config: Config) {
+  await downloadFile(win, path.join(config.dataURL.getMain(), 'list.json'));
+
+  const modFile = existsTempFile('list.json');
+  const info = (await readJson(modFile.path)) as List;
+  const URLs = config.dataURL
+    .getExtra()
+    .split(os.EOL)
+    .filter((url) => url !== '');
+  const packages = ([] as string[]).concat(
+    info.packages.map((packageItem) =>
+      resolvePath(config.dataURL.getMain(), packageItem.path),
+    ),
+    URLs,
+  );
+  config.dataURL.setPackages(packages);
+}

--- a/src/main/services/tempFile.ts
+++ b/src/main/services/tempFile.ts
@@ -1,0 +1,27 @@
+import { app } from 'electron';
+import fs from 'fs-extra';
+import path from 'node:path';
+import { isParent } from '../../shared/apmPath';
+import { getHash } from '../../shared/getHash';
+
+/**
+ * Returns whether the temporary file exists and its path.
+ * 旧 EXISTS_TEMP_FILE ハンドラのロジックと同一(IPC と main 内部の両方から使う)。
+ * @param {string} relativePath - A relative path from the data directory.
+ * @param {string} [keyText] - String used to generate the hash prefix.
+ * @returns {object} Whether the file exists, and its absolute path.
+ */
+export function existsTempFile(relativePath: string, keyText?: string) {
+  const dataDir = path.join(app.getPath('userData'), 'Data/');
+  let filePath = path.join(dataDir, relativePath);
+  if (!isParent(dataDir, filePath)) {
+    throw new Error(`An invalid path was requested: ${relativePath}`);
+  }
+  if (keyText) {
+    filePath = path.join(
+      path.dirname(filePath),
+      getHash(keyText) + '_' + path.basename(filePath),
+    );
+  }
+  return { exists: fs.existsSync(filePath), path: filePath };
+}


### PR DESCRIPTION
## 概要

Phase 3(Settings タブ移行)のスライス 3 です。`setDataUrl` 成功後に呼ばれる `modList.updateInfo()`(list.json ダウンロード + `dataURL.packages` の組み立て)を main プロセスへ移設しました。これが Settings タブのロジックのうち renderer の fs/download に依存する最後の部分で、次スライスの React UI が tRPC だけで完結するための前提整理です。

## 変更内容

- **`src/main/services/tempFile.ts`(新規)**: `EXISTS_TEMP_FILE` ハンドラのロジックを関数化(IPC と main 内部の両方から使用。挙動同一)
- **`src/main/services/modList.ts`(新規)**: `updateInfo(win, config)` — 旧 renderer 実装(updateInfo + setPackagesDataUrl)と同一の挙動。既存の `downloadFile` サービスを利用
- **`src/main/api.ts`**: `modList.updateInfo` mutation 追加(`ctx.event.sender` から呼び出し元窓を解決)
- **`src/lib/modList.ts`(renderer)**: `updateInfo` は tRPC への薄い委譲に。**呼び出し元(core.ts / package.ts / convertId.ts / setting.ts)は変更不要**

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(64 件)緑
- macOS `yarn package` + CDP スモーク 6 項目 PASS — 特に「設定ボタン →『設定完了』」は renderer → tRPC `setDataUrls` → renderer → tRPC `modList.updateInfo` → main `downloadFile` の全経路を通過

## 次のスライス

Settings タブの React UI 化(About 窓パターン)→ preload/setting.ts から Settings ロジック削除。

🤖 Generated with [Claude Code](https://claude.com/claude-code)