### PR TITLE
feat(settings): 設定タブの UI を React 化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
         update-types: ['version-update:semver-major']
       - dependency-name: '@trpc/*'
         update-types: ['version-update:semver-major']
+      # tRPC v10 の peer 要求が react-query v4 のため(tRPC 11 化と同時に上げる)
+      - dependency-name: '@tanstack/react-query'
+        update-types: ['version-update:semver-major']
       - dependency-name: 'eslint'
         update-types: ['version-update:semver-major']
       - dependency-name: '@typescript-eslint/*'

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "7zip-bin": "^5.2.0",
     "@monaco-editor/react": "^4.7.0",
-    "@tanstack/react-query": "^5.101.1",
+    "@tanstack/react-query": "^4.36.1",
     "@trpc/client": "^10.45.4",
     "@trpc/react-query": "^10.45.4",
     "@trpc/server": "^10.45.4",

--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -3,7 +3,6 @@ export const IPC_CHANNELS = {
   GET_APP_VERSION: 'get-app-version',
   APP_GET_PATH: 'app-get-path',
   APP_QUIT: 'app-quit',
-  IS_EXE_VERSION: 'is-exe-version',
   CHECK_UPDATE: 'check-update',
   OPEN_PATH: 'open-path',
   EXISTS_TEMP_FILE: 'exists-temp-file',

--- a/src/lib/ipcWrapper.ts
+++ b/src/lib/ipcWrapper.ts
@@ -57,14 +57,6 @@ export const app = {
 };
 
 /**
- * Whether the app is exe version.
- * @returns {Promise<boolean>} Whether the app is exe version.
- */
-export async function isExeVersion() {
-  return (await ipcRenderer.invoke(IPC_CHANNELS.IS_EXE_VERSION)) as boolean;
-}
-
-/**
  * Check the update of the app.
  */
 export async function checkUpdate() {

--- a/src/lib/modList.ts
+++ b/src/lib/modList.ts
@@ -44,14 +44,6 @@ export function getDataUrl() {
 }
 
 /**
- * Returns extra data files URLs.
- * @returns {string} - Data files URLs.
- */
-export function getExtraDataUrl() {
-  return config.dataURL.getExtra();
-}
-
-/**
  * Returns a core data file URL.
  * @returns {string} - A core data file URL.
  */

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -1,7 +1,8 @@
 import { initTRPC } from '@trpc/server';
-import { app, BrowserWindow, type IpcMainInvokeEvent } from 'electron';
+import { app, BrowserWindow, dialog, type IpcMainInvokeEvent } from 'electron';
 import type { CreateContextOptions } from 'electron-trpc/main';
 import { getConfig } from '../lib/Config';
+import { isExeVersion } from './services/appUpdate';
 import { updateInfo } from './services/modList';
 import { ensureExtraDataUrl, setDataUrls } from './services/settings';
 
@@ -41,9 +42,44 @@ const dataUrlsInput = (
   return { mainUrl, extraDataUrls };
 };
 
+const AUTO_UPDATE_VALUES = ['download', 'notify', 'disable'] as const;
+const autoUpdateInput = (value: unknown): 'download' | 'notify' | 'disable' => {
+  if (
+    typeof value !== 'string' ||
+    !(AUTO_UPDATE_VALUES as readonly string[]).includes(value)
+  )
+    throw new TypeError('One of download, notify, or disable is expected.');
+  return value as 'download' | 'notify' | 'disable';
+};
+
+const DIALOG_TYPES = ['none', 'info', 'error', 'question', 'warning'] as const;
+const dialogInput = (
+  value: unknown,
+): { title: string; message: string; type: (typeof DIALOG_TYPES)[number] } => {
+  if (typeof value !== 'object' || value === null)
+    throw new TypeError('An object is expected.');
+  const { title, message, type } = value as Record<string, unknown>;
+  if (
+    typeof title !== 'string' ||
+    typeof message !== 'string' ||
+    typeof type !== 'string' ||
+    !(DIALOG_TYPES as readonly string[]).includes(type)
+  )
+    throw new TypeError('title, message, and a valid type are expected.');
+  return { title, message, type: type as (typeof DIALOG_TYPES)[number] };
+};
+
 export const router = t.router({
   getAppVersion: procedure.query(async () => {
     return app.getVersion();
+  }),
+  isExeVersion: procedure.query(() => isExeVersion()),
+  openDialog: procedure.input(dialogInput).mutation(async ({ input }) => {
+    await dialog.showMessageBox({
+      title: input.title,
+      message: input.message,
+      type: input.type,
+    });
   }),
   settings: t.router({
     ensureExtraDataUrl: procedure.mutation(() =>
@@ -54,6 +90,17 @@ export const router = t.router({
       .mutation(({ input }) =>
         setDataUrls(getConfig(), input.mainUrl, input.extraDataUrls),
       ),
+    getDataUrls: procedure.query(() => {
+      const config = getConfig();
+      return {
+        main: config.dataURL.getMain(),
+        extra: config.dataURL.getExtra(),
+      };
+    }),
+    getAutoUpdate: procedure.query(() => getConfig().getAutoUpdate()),
+    setAutoUpdate: procedure
+      .input(autoUpdateInput)
+      .mutation(({ input }) => getConfig().setAutoUpdate(input)),
     getZoomFactor: procedure.query(() => getConfig().getZoomFactor()),
     changeZoomFactor: procedure
       .input(stringInput)

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -11,7 +11,7 @@ import fs from 'fs-extra';
 import path from 'node:path';
 import { IPC_CHANNELS } from '../common/ipc';
 import { isParent } from '../shared/apmPath';
-import { checkUpdate, isExeVersion } from './services/appUpdate';
+import { checkUpdate } from './services/appUpdate';
 import { getNicommonsData } from './services/nicommons';
 import { existsTempFile } from './services/tempFile';
 
@@ -55,10 +55,6 @@ export function registerIpcHandlers() {
 
   ipcMain.handle(IPC_CHANNELS.APP_QUIT, () => {
     app.quit();
-  });
-
-  ipcMain.handle(IPC_CHANNELS.IS_EXE_VERSION, () => {
-    return isExeVersion();
   });
 
   ipcMain.handle(IPC_CHANNELS.CHECK_UPDATE, async () => {

--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -671,43 +671,7 @@
 						<div class="card">
 							<div class="card-body">
 								<h3 class="card-title">設定</h3>
-								<div class="row mb-3">
-									<label for="data-url" class="col-sm-3 col-form-label"
-										>データ取得先</label
-									>
-									<div class="col-sm-6">
-										<input
-											class="form-control"
-											id="data-url"
-											type="text"
-											placeholder="空白でデフォルト"
-											aria-label="Data URL"
-										/>
-									</div>
-									<div class="col-sm-3">
-										<button
-											type="button"
-											class="btn btn-primary w-100"
-											id="set-data-url"
-										>
-											設定
-										</button>
-									</div>
-								</div>
-								<div class="row mb-3">
-									<label for="extra-data-url" class="col-sm-3 col-form-label"
-										>追加データ取得先</label
-									>
-									<div class="col-sm-6">
-										<textarea
-											class="form-control"
-											id="extra-data-url"
-											placeholder="例: https://example.com/packages.json"
-											aria-label="Extra Data URL"
-										></textarea>
-									</div>
-									<div class="col-sm-3"></div>
-								</div>
+								<div id="settings-data-url-root"></div>
 								<div class="row mb-3">
 									<label for="container" class="form-label"
 										>追加テキストデータ</label
@@ -725,90 +689,7 @@
 										</button>
 									</div>
 								</div>
-								<div class="row mb-3">
-									<label
-										for="zoom-factor-select"
-										class="col-sm-3 col-form-label"
-										>拡大率</label
-									>
-									<div class="col-sm-6">
-										<select
-											class="form-select"
-											id="zoom-factor-select"
-											aria-label="Zoom level select"
-										>
-											<option value="50">50%</option>
-											<option value="67">67%</option>
-											<option value="75">75%</option>
-											<option value="80">80%</option>
-											<option value="90">90%</option>
-											<option value="100" selected>100%（標準）</option>
-											<option value="110">110%</option>
-											<option value="125">125%</option>
-											<option value="150">150%</option>
-											<option value="175">175%</option>
-											<option value="200">200%</option>
-										</select>
-									</div>
-									<div class="col-sm-3"></div>
-								</div>
-								<div class="row mb-3">
-									<label
-										for="zoom-factor-select"
-										class="col-sm-3 col-form-label"
-										>apmの自動更新</label
-									>
-									<div class="col-sm-6">
-										<div class="col">
-											<div class="form-check">
-												<input
-													class="form-check-input"
-													type="radio"
-													name="auto-update"
-													id="auto-update-disable"
-													value="disable"
-												/>
-												<label
-													class="form-check-label"
-													for="auto-update-disable"
-												>
-													自動更新しない
-												</label>
-											</div>
-											<div class="form-check">
-												<input
-													class="form-check-input"
-													type="radio"
-													name="auto-update"
-													id="auto-update-notify"
-													value="notify"
-												/>
-												<label
-													class="form-check-label"
-													for="auto-update-notify"
-												>
-													更新があれば通知する
-												</label>
-											</div>
-											<div class="form-check">
-												<input
-													class="form-check-input"
-													type="radio"
-													name="auto-update"
-													id="auto-update-download"
-													value="download"
-												/>
-												<label
-													class="form-check-label"
-													for="auto-update-download"
-												>
-													自動で更新をダウンロードし、インストール前に通知する
-												</label>
-											</div>
-										</div>
-									</div>
-									<div class="col-sm-3"></div>
-								</div>
+								<div id="settings-preferences-root"></div>
 								<hr />
 								<div class="row mb-3">
 									<h4>手動更新</h4>

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -1,15 +1,14 @@
 import ClipboardJS from 'clipboard/src/clipboard';
 import log from 'electron-log/renderer';
+import { exposeElectronTRPC } from 'electron-trpc/main';
 import 'source-map-support/register';
 import { getConfig } from '../../lib/Config';
 import {
   app,
   checkUpdate,
-  isExeVersion,
   openAboutWindow,
   openDialog,
 } from '../../lib/ipcWrapper';
-import * as modList from '../../lib/modList';
 import migration2to3 from '../../migration/migration2to3';
 import core from './core';
 import { EditorContextBridge } from './monacoEditorPreload';
@@ -24,6 +23,11 @@ log.errorHandler.startCatching({
   },
 });
 const editorContextBridge = new EditorContextBridge();
+
+// メインワールドの React(Settings ほか)から tRPC を使うための bridge
+process.once('loaded', () => {
+  exposeElectronTRPC();
+});
 
 window.addEventListener('DOMContentLoaded', async () => {
   // dark-theme
@@ -65,30 +69,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     'installation-path',
   ) as HTMLInputElement;
   installationPath.value = instPath;
-  const dataURL = document.getElementById('data-url') as HTMLInputElement;
-  dataURL.value = modList.getDataUrl();
-  const extraDataURL = document.getElementById(
-    'extra-data-url',
-  ) as HTMLInputElement;
-  extraDataURL.value = modList.getExtraDataUrl();
   await editorContextBridge.setInstPath(installationPath);
-  const zoomFactorSelect = document.getElementById(
-    'zoom-factor-select',
-  ) as HTMLSelectElement;
-  await setting.setZoomFactor(zoomFactorSelect);
-
-  const doAutoUpdate = config.getAutoUpdate();
-  const autoUpdateRadios = document.getElementsByName('auto-update');
-  autoUpdateRadios.forEach((element: HTMLInputElement) => {
-    if (element instanceof HTMLInputElement)
-      if (element.value === doAutoUpdate) {
-        element.checked = true;
-      }
-  });
-  if (!(await isExeVersion())) {
-    const e = document.getElementById('auto-update-download');
-    if (e instanceof HTMLInputElement) e.disabled = true;
-  }
 
   const appName = document.getElementsByClassName('app-name');
   for (let i = 0; i < appName.length; i++) {
@@ -167,33 +148,10 @@ window.addEventListener('load', () => {
   // nicommons ID
   new ClipboardJS('#copy-nicommons-id-textarea');
 
-  // settings
-  const setDataUrlBtn = document.getElementById('set-data-url');
-  const dataURL = document.getElementById('data-url') as HTMLInputElement;
-  const extraDataURL = document.getElementById(
-    'extra-data-url',
-  ) as HTMLInputElement;
-  setDataUrlBtn.addEventListener('click', async () => {
-    await setting.setDataUrl(dataURL, extraDataURL.value);
-  });
-
-  const zoomFactorSelect = document.getElementById(
-    'zoom-factor-select',
-  ) as HTMLInputElement;
-  zoomFactorSelect.addEventListener('input', async () => {
-    await setting.changeZoomFactor(zoomFactorSelect.value);
-  });
-
+  // settings(UI は React 化済み。手動更新まわりのみ残る)
   const checkApmUpdateBtn = document.getElementById('check-apm-update');
   checkApmUpdateBtn.addEventListener('click', async () => {
     await checkUpdate();
-  });
-
-  const autoUpdateRadios = document.getElementsByName('auto-update');
-  autoUpdateRadios.forEach((element: HTMLInputElement) => {
-    element.addEventListener('change', () => {
-      config.setAutoUpdate(element.value as 'download' | 'notify' | 'disable');
-    });
   });
 
   // About / Others

--- a/src/renderer/main/renderer.tsx
+++ b/src/renderer/main/renderer.tsx
@@ -6,6 +6,9 @@ import '../../../node_modules/bootstrap-icons/font/bootstrap-icons.css';
 import '../main.css';
 import './index.css';
 import { MonacoEditorRenderer } from './monacoEditorRenderer';
+import DataUrlSettings from './settings/DataUrlSettings';
+import PreferencesSettings from './settings/PreferencesSettings';
+import { SettingsProvider } from './settings/SettingsProvider';
 
 window.addEventListener('DOMContentLoaded', () => {
   const root = createRoot(document.getElementById('container'));
@@ -15,5 +18,16 @@ window.addEventListener('DOMContentLoaded', () => {
         document.getElementById('save-editor-data') as HTMLButtonElement
       }
     />,
+  );
+
+  createRoot(document.getElementById('settings-data-url-root')).render(
+    <SettingsProvider>
+      <DataUrlSettings />
+    </SettingsProvider>,
+  );
+  createRoot(document.getElementById('settings-preferences-root')).render(
+    <SettingsProvider>
+      <PreferencesSettings />
+    </SettingsProvider>,
   );
 });

--- a/src/renderer/main/setting.ts
+++ b/src/renderer/main/setting.ts
@@ -1,85 +1,31 @@
 import log from 'electron-log/renderer';
-import * as buttonTransition from '../../lib/buttonTransition';
 import { openDialog } from '../../lib/ipcWrapper';
 import * as modList from '../../lib/modList';
 import { trpc } from '../../lib/trpcClient';
 
 /**
  * Initializes settings
+ * 初回起動時にデフォルトのデータ取得先を設定する(UI は React 側)。
  */
 async function initSettings() {
   const { hasMain, extra } = await trpc.settings.ensureExtraDataUrl.mutate();
-  if (!hasMain) await setDataUrl({ value: '' }, extra);
-}
-
-/**
- * Sets a data files URL.
- * @param {HTMLInputElement} dataUrl - An input element that contains a data files URL to set.
- * @param {string} dataUrl.value - value
- * @param {string} extraDataUrls - Data files URLs to set.
- */
-async function setDataUrl(dataUrl: { value: string }, extraDataUrls: string) {
-  const btn = document.getElementById('set-data-url');
-  const { enableButton } =
-    btn instanceof HTMLButtonElement
-      ? buttonTransition.loading(btn, '設定')
-      : { enableButton: undefined };
-
-  const { mainUrl, errors } = await trpc.settings.setDataUrls.mutate({
-    mainUrl: dataUrl.value,
-    extraDataUrls,
-  });
-  dataUrl.value = mainUrl;
-  for (const message of errors) {
-    await openDialog('エラー', message, 'error');
-  }
-
-  if (errors.length === 0) {
-    await modList.updateInfo();
-
-    if (btn instanceof HTMLButtonElement) {
-      buttonTransition.message(btn, '設定完了', 'success');
-      setTimeout(() => {
-        enableButton();
-      }, 3000);
+  if (!hasMain) {
+    const { errors } = await trpc.settings.setDataUrls.mutate({
+      mainUrl: '',
+      extraDataUrls: extra,
+    });
+    for (const message of errors) {
+      await openDialog('エラー', message, 'error');
     }
-  } else {
-    log.error('An error has occurred while setting data URL.');
-    if (btn instanceof HTMLButtonElement) {
-      buttonTransition.message(btn, 'エラーが発生しました。', 'danger');
-      setTimeout(() => {
-        enableButton();
-      }, 3000);
+    if (errors.length === 0) {
+      await modList.updateInfo();
+    } else {
+      log.error('An error has occurred while setting data URL.');
     }
   }
-}
-
-/**
- * Sets a zoom factor.
- * @param {HTMLSelectElement} zoomFactorSelect - A zoom factor select to change value.
- */
-async function setZoomFactor(zoomFactorSelect: HTMLSelectElement) {
-  const zoomFactor = await trpc.settings.getZoomFactor.query();
-  for (const optionElement of Array.from(zoomFactorSelect.options)) {
-    if (optionElement.getAttribute('value') === zoomFactor) {
-      optionElement.selected = true;
-      break;
-    }
-  }
-}
-
-/**
- * Changes a zoom factor.
- * @param {string} zoomFactor - A zoom factor to change.
- */
-async function changeZoomFactor(zoomFactor: string) {
-  await trpc.settings.changeZoomFactor.mutate(zoomFactor);
 }
 
 const setting = {
   initSettings,
-  setDataUrl,
-  setZoomFactor,
-  changeZoomFactor,
 };
 export default setting;

--- a/src/renderer/main/settings/DataUrlSettings.tsx
+++ b/src/renderer/main/settings/DataUrlSettings.tsx
@@ -1,0 +1,125 @@
+import React, { type JSX, useState } from 'react';
+import { TRPCReact } from '../../trpc';
+
+type ButtonPhase = 'idle' | 'loading' | 'success' | 'danger';
+
+/**
+ * The data files URL settings form (データ取得先・追加データ取得先).
+ * 旧 setting.ts の setDataUrl と同じ流れ: 検証+保存(tRPC)→ エラーは
+ * ダイアログ表示、成功時は modList.updateInfo とボタンの完了表示。
+ * @returns {JSX.Element} The rendered component.
+ */
+function DataUrlSettings() {
+  const { data } = TRPCReact.settings.getDataUrls.useQuery();
+  const [mainUrl, setMainUrl] = useState<string | null>(null);
+  const [extraUrls, setExtraUrls] = useState<string | null>(null);
+  const [phase, setPhase] = useState<ButtonPhase>('idle');
+
+  const setDataUrls = TRPCReact.settings.setDataUrls.useMutation();
+  const updateInfo = TRPCReact.modList.updateInfo.useMutation();
+  const openDialog = TRPCReact.openDialog.useMutation();
+  const utils = TRPCReact.useContext();
+
+  const mainValue = mainUrl ?? data?.main ?? '';
+  const extraValue = extraUrls ?? data?.extra ?? '';
+
+  const onSet = async () => {
+    setPhase('loading');
+    try {
+      const result = await setDataUrls.mutateAsync({
+        mainUrl: mainValue,
+        extraDataUrls: extraValue,
+      });
+      setMainUrl(result.mainUrl);
+      for (const message of result.errors) {
+        await openDialog.mutateAsync({
+          title: 'エラー',
+          message,
+          type: 'error',
+        });
+      }
+      if (result.errors.length === 0) {
+        await updateInfo.mutateAsync();
+        await utils.settings.getDataUrls.invalidate();
+        setPhase('success');
+      } else {
+        setPhase('danger');
+      }
+    } catch {
+      setPhase('danger');
+    }
+    setTimeout(() => setPhase('idle'), 3000);
+  };
+
+  const buttonClass =
+    phase === 'success'
+      ? 'btn btn-success w-100'
+      : phase === 'danger'
+        ? 'btn btn-danger w-100'
+        : 'btn btn-primary w-100';
+
+  return (
+    <>
+      <div className="row mb-3">
+        <label htmlFor="data-url" className="col-sm-3 col-form-label">
+          データ取得先
+        </label>
+        <div className="col-sm-6">
+          <input
+            className="form-control"
+            id="data-url"
+            type="text"
+            placeholder="空白でデフォルト"
+            aria-label="Data URL"
+            value={mainValue}
+            onChange={(e) => setMainUrl(e.target.value)}
+          />
+        </div>
+        <div className="col-sm-3">
+          <button
+            type="button"
+            className={buttonClass}
+            id="set-data-url"
+            disabled={phase === 'loading'}
+            onClick={onSet}
+          >
+            {phase === 'loading' ? (
+              <>
+                <span
+                  className="spinner-border spinner-border-sm"
+                  role="status"
+                  aria-hidden="true"
+                ></span>
+                <span className="visually-hidden">Loading...</span>
+              </>
+            ) : phase === 'success' ? (
+              '設定完了'
+            ) : phase === 'danger' ? (
+              'エラーが発生しました。'
+            ) : (
+              '設定'
+            )}
+          </button>
+        </div>
+      </div>
+      <div className="row mb-3">
+        <label htmlFor="extra-data-url" className="col-sm-3 col-form-label">
+          追加データ取得先
+        </label>
+        <div className="col-sm-6">
+          <textarea
+            className="form-control"
+            id="extra-data-url"
+            placeholder="例: https://example.com/packages.json"
+            aria-label="Extra Data URL"
+            value={extraValue}
+            onChange={(e) => setExtraUrls(e.target.value)}
+          ></textarea>
+        </div>
+        <div className="col-sm-3"></div>
+      </div>
+    </>
+  );
+}
+
+export default DataUrlSettings;

--- a/src/renderer/main/settings/PreferencesSettings.tsx
+++ b/src/renderer/main/settings/PreferencesSettings.tsx
@@ -1,0 +1,106 @@
+import React, { type JSX, useState } from 'react';
+import { TRPCReact } from '../../trpc';
+
+const ZOOM_OPTIONS = [
+  ['50', '50%'],
+  ['67', '67%'],
+  ['75', '75%'],
+  ['80', '80%'],
+  ['90', '90%'],
+  ['100', '100%（標準）'],
+  ['110', '110%'],
+  ['125', '125%'],
+  ['150', '150%'],
+  ['175', '175%'],
+  ['200', '200%'],
+] as const;
+
+const AUTO_UPDATE_OPTIONS = [
+  ['disable', '自動更新しない'],
+  ['notify', '更新があれば通知する'],
+  ['download', '自動で更新をダウンロードし、インストール前に通知する'],
+] as const;
+
+/**
+ * The zoom factor and auto-update preferences (拡大率・apmの自動更新).
+ * @returns {JSX.Element} The rendered component.
+ */
+function PreferencesSettings() {
+  const { data: storedZoomFactor } =
+    TRPCReact.settings.getZoomFactor.useQuery();
+  const { data: storedAutoUpdate } =
+    TRPCReact.settings.getAutoUpdate.useQuery();
+  const { data: exeVersion } = TRPCReact.isExeVersion.useQuery();
+  const changeZoomFactor = TRPCReact.settings.changeZoomFactor.useMutation();
+  const setAutoUpdate = TRPCReact.settings.setAutoUpdate.useMutation();
+
+  const [zoomFactor, setZoomFactor] = useState<string | null>(null);
+  const [autoUpdate, setAutoUpdateValue] = useState<string | null>(null);
+
+  const zoomValue = zoomFactor ?? storedZoomFactor ?? '100';
+  const autoUpdateValue = autoUpdate ?? storedAutoUpdate ?? 'notify';
+
+  return (
+    <>
+      <div className="row mb-3">
+        <label htmlFor="zoom-factor-select" className="col-sm-3 col-form-label">
+          拡大率
+        </label>
+        <div className="col-sm-6">
+          <select
+            className="form-select"
+            id="zoom-factor-select"
+            aria-label="Zoom level select"
+            value={zoomValue}
+            onChange={(e) => {
+              setZoomFactor(e.target.value);
+              changeZoomFactor.mutate(e.target.value);
+            }}
+          >
+            {ZOOM_OPTIONS.map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="col-sm-3"></div>
+      </div>
+      <div className="row mb-3">
+        <label htmlFor="zoom-factor-select" className="col-sm-3 col-form-label">
+          apmの自動更新
+        </label>
+        <div className="col-sm-6">
+          <div className="col">
+            {AUTO_UPDATE_OPTIONS.map(([value, label]) => (
+              <div className="form-check" key={value}>
+                <input
+                  className="form-check-input"
+                  type="radio"
+                  name="auto-update"
+                  id={`auto-update-${value}`}
+                  value={value}
+                  checked={autoUpdateValue === value}
+                  disabled={value === 'download' && exeVersion === false}
+                  onChange={() => {
+                    setAutoUpdateValue(value);
+                    setAutoUpdate.mutate(value);
+                  }}
+                />
+                <label
+                  className="form-check-label"
+                  htmlFor={`auto-update-${value}`}
+                >
+                  {label}
+                </label>
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="col-sm-3"></div>
+      </div>
+    </>
+  );
+}
+
+export default PreferencesSettings;

--- a/src/renderer/main/settings/SettingsProvider.tsx
+++ b/src/renderer/main/settings/SettingsProvider.tsx
@@ -1,0 +1,24 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ipcLink } from 'electron-trpc/renderer';
+import React, { type JSX, type ReactNode } from 'react';
+import { TRPCReact } from '../../trpc';
+
+// main 窓には React root が複数あるため、client は共有のモジュールレベルで 1 つ持つ
+const queryClient = new QueryClient();
+const trpcClient = TRPCReact.createClient({
+  links: [ipcLink()],
+});
+
+/**
+ * Provides tRPC and react-query contexts for the settings components.
+ * @param {object} props - Props.
+ * @param {ReactNode} props.children - Children to render.
+ * @returns {JSX.Element} The provider tree.
+ */
+export function SettingsProvider({ children }: { children: ReactNode }) {
+  return (
+    <TRPCReact.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </TRPCReact.Provider>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,17 +1645,18 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
-"@tanstack/query-core@5.101.1":
-  version "5.101.1"
-  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.101.1.tgz#a6cfa8b94b23f65bd95a2d61bf737c2e4c9b0518"
-  integrity sha512-Y6Y92dkXtNqx67m2pMSxUsA3zOCwv862JexZRP8/EPwvKXMPu9m8rv43spiXWzOUIggQ3SQApttALStzhA8B4g==
+"@tanstack/query-core@4.44.0":
+  version "4.44.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.44.0.tgz#c507e55f2e2c9a4a49fd2a9fcb1eda449e6c77ef"
+  integrity sha512-swSgb7OiPRR3UuIL7NuDrZNSMGmQD+wdtHxPD7j60SvBEnxbXurl5XOirtGEX2gm2hbK6mC8kMV1I+uO3l0UOw==
 
-"@tanstack/react-query@^5.101.1":
-  version "5.101.1"
-  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.101.1.tgz#357f2037ed4a5c0c85ee695f6d7c60ab549c8e24"
-  integrity sha512-ZnONUuQKJe1bJMStXUL1s5uKN9FcfC28j5cK+iDZcdSHtUv1wtin1cGc/Oewhf2Oc4eKY7lggtpvT/AbMmhHew==
+"@tanstack/react-query@^4.36.1":
+  version "4.44.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.44.0.tgz#8e6b93cbf08dc19e1ab8b1b97a9451ba82069d19"
+  integrity sha512-RuIqHYrS98LrK/8kJJOJMMSQ/BCpojwsXDh7p0fBmp38ZOz6dlk+uyFRRusH+V+t3POoCsDOQ2zhomEYOeReXw==
   dependencies:
-    "@tanstack/query-core" "5.101.1"
+    "@tanstack/query-core" "4.44.0"
+    use-sync-external-store "^1.6.0"
 
 "@tootallnate/once@2":
   version "2.0.0"
@@ -10175,6 +10176,11 @@ url-join@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-5.0.0.tgz#c2f1e5cbd95fa91082a93b58a1f42fecb4bdbcf1"
   integrity sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==
+
+use-sync-external-store@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
 
 username@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
## 概要

Phase 3(Settings タブ移行)の仕上げスライスです。設定タブの UI 4 ブロック(データ取得先・追加データ取得先・拡大率・自動更新)を React コンポーネント(tRPC + react-query、About 窓パターン)に置き換えました。**Settings タブに関して preload のビジネスロジックは初回起動時のデフォルト設定(`initSettings`)を残して消滅**しました。

Monaco データエディタ(既に React)と手動更新テーブル(core/package のロジック)は対象外で、それぞれのスライスで扱います。

## 変更内容

- **`src/renderer/main/settings/`(新規)**: `DataUrlSettings`(検証+保存 → エラーはダイアログ、成功で updateInfo + 3 秒間の「設定完了」表示 — 旧 buttonTransition の挙動を state で再現)/ `PreferencesSettings`(拡大率 select・自動更新ラジオ、非 exe 版では download を disabled)/ `SettingsProvider`
- **`src/main/api.ts`**: `getDataUrls` / `getAutoUpdate` / `setAutoUpdate` / `isExeVersion` / `openDialog` procedure 追加
- **`index.html`**: 該当 4 ブロックをマウントポイント 2 つに置換
- **`preload.ts`**: `exposeElectronTRPC()` 追加(メインワールドの React 用)、Settings の DOM 配線を削除
- **`setting.ts`**: `initSettings`(初回起動時のデフォルト書き込み)のみに縮小
- **旧コード削除**: `IS_EXE_VERSION` チャンネル・`ipcWrapper.isExeVersion`・`modList.getExtraDataUrl`(呼び出し元ゼロ化のため)

## 潜在バグ修正(重要)

`@tanstack/react-query` を v5 → **v4** に変更しました。`@trpc/react-query` 10.x の peer 要求は v4 で、v5 では `useMutation` が実行時エラーになります(About 窓は `useQuery` のみだったため偶然動いていました)。tRPC 11 化(Phase 6)までは v4 を維持するよう dependabot の major ignore にも追加済み。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(64 件)緑
- macOS `yarn package` + CDP スモーク **7 項目 PASS**(React 描画された data-url / zoom select / 自動更新ラジオの反映、zoom 変更の実適用、設定ボタン → 検証 → updateInfo →「設定完了」、About 窓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)