### PR TITLE
refactor(core): バージョン表示文字列を純関数に抽出(AviUtl タブ スライス 1)

### DIFF
--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -20,7 +20,10 @@ import replaceText from '../../lib/replaceText';
 import { addAviUtlShortcut, removeAviUtlShortcut } from '../../lib/shortcut';
 import unzip from '../../lib/unzip';
 import migration2to3 from '../../migration/migration2to3';
-import { compareVersion } from '../../shared/compareVersion';
+import {
+  installedVersionText,
+  releaseLabel,
+} from '../../shared/coreVersionText';
 import { checkIntegrity, verifyFile } from '../../shared/integrity';
 import { install, programs, verifyFilesByCount } from './common';
 import packageMain from './package';
@@ -61,44 +64,19 @@ async function displayInstalledVersion(instPath: string) {
         }
       }
 
-      if (await apmJson.has('core.' + program)) {
-        const installedVersion = (await apmJson.get(
-          'core.' + program,
-        )) as string;
-        const versionComparison = compareVersion(
+      const installedVersion = (await apmJson.has('core.' + program))
+        ? ((await apmJson.get('core.' + program)) as string)
+        : null;
+      const filesVerified = verifyFilesByCount(instPath, progInfo.files);
+      replaceText(
+        `${program}-installed-version`,
+        installedVersionText(
           installedVersion,
           progInfo.latestVersion,
-        );
-        const description = Number.isNaN(versionComparison)
-          ? ''
-          : versionComparison === -1
-            ? ` （最新版: ${progInfo.latestVersion}）`
-            : installedVersion.includes('rc')
-              ? '（テスト版）'
-              : ' （最新版）';
-        if (verifyFilesByCount(instPath, progInfo.files)) {
-          replaceText(
-            `${program}-installed-version`,
-            'バージョン: ' + installedVersion + description,
-          );
-          isInstalled[program] = true;
-        } else {
-          replaceText(
-            `${program}-installed-version`,
-            'バージョン: ' +
-              installedVersion +
-              description +
-              '（未導入ファイルあり）',
-          );
-        }
-      } else {
-        if (verifyFilesByCount(instPath, progInfo.files)) {
-          replaceText(`${program}-installed-version`, '手動インストール済み');
-          isInstalled[program] = true;
-        } else {
-          replaceText(`${program}-installed-version`, '未インストール');
-        }
-      }
+          filesVerified,
+        ),
+      );
+      if (filesVerified) isInstalled[program] = true;
     }
   } else {
     for (const program of programs) {
@@ -187,12 +165,10 @@ async function setCoreVersions(instPath: string) {
       const anchor = document.createElement('a');
       anchor.classList.add('dropdown-item');
       anchor.href = '#';
-      anchor.innerText =
-        release.version +
-        (release.version.includes('rc') ? '（テスト版）' : '') +
-        (release.version === coreInfo[program].latestVersion
-          ? '（最新版）'
-          : '');
+      anchor.innerText = releaseLabel(
+        release.version,
+        coreInfo[program].latestVersion,
+      );
       li.appendChild(anchor);
 
       if (program === 'aviutl') {

--- a/src/shared/coreVersionText.test.ts
+++ b/src/shared/coreVersionText.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  installedVersionDescription,
+  installedVersionText,
+  releaseLabel,
+} from './coreVersionText';
+
+// core.ts displayInstalledVersion / setCoreVersions の表示文字列の特性化テスト。
+// バージョン例は実在の AviUtl('1.00' 等)と拡張編集('0.92'・'0.93rc1' 等)。
+
+describe('installedVersionDescription', () => {
+  it('最新版より古ければ最新版を案内する', () => {
+    expect(installedVersionDescription('1.00', '1.10')).toBe(
+      ' （最新版: 1.10）',
+    );
+  });
+
+  it('最新版と一致すれば（最新版）', () => {
+    expect(installedVersionDescription('1.10', '1.10')).toBe(' （最新版）');
+  });
+
+  it('rc 版はテスト版と表示する', () => {
+    expect(installedVersionDescription('0.93rc1', '0.93rc1')).toBe(
+      '（テスト版）',
+    );
+  });
+
+  it('最新版より古い rc 版は最新版の案内を優先する', () => {
+    expect(installedVersionDescription('0.93rc1', '0.93')).toBe(
+      ' （最新版: 0.93）',
+    );
+  });
+
+  it('比較不能(日付形式 vs semver)なら説明なし', () => {
+    expect(installedVersionDescription('2022/02/02', '1.0.0')).toBe('');
+  });
+});
+
+describe('installedVersionText', () => {
+  it('ファイルが揃っていればバージョンと説明を表示する', () => {
+    expect(installedVersionText('1.00', '1.10', true)).toBe(
+      'バージョン: 1.00 （最新版: 1.10）',
+    );
+  });
+
+  it('ファイルが欠けていれば未導入ファイルありを付ける', () => {
+    expect(installedVersionText('1.10', '1.10', false)).toBe(
+      'バージョン: 1.10 （最新版）（未導入ファイルあり）',
+    );
+  });
+
+  it('apm.json に記録がなくてもファイルが揃っていれば手動インストール済み', () => {
+    expect(installedVersionText(null, '1.10', true)).toBe(
+      '手動インストール済み',
+    );
+  });
+
+  it('記録もファイルもなければ未インストール', () => {
+    expect(installedVersionText(null, '1.10', false)).toBe('未インストール');
+  });
+
+  it('比較不能でもバージョン自体は表示する', () => {
+    expect(installedVersionText('2022/02/02', '1.0.0', true)).toBe(
+      'バージョン: 2022/02/02',
+    );
+  });
+});
+
+describe('releaseLabel', () => {
+  it('最新版には（最新版）を付ける', () => {
+    expect(releaseLabel('1.10', '1.10')).toBe('1.10（最新版）');
+  });
+
+  it('旧版はバージョンのみ', () => {
+    expect(releaseLabel('1.00', '1.10')).toBe('1.00');
+  });
+
+  it('rc 版には（テスト版）を付ける', () => {
+    expect(releaseLabel('0.93rc1', '0.93')).toBe('0.93rc1（テスト版）');
+  });
+
+  it('rc 版が最新版なら両方付ける', () => {
+    expect(releaseLabel('0.93rc1', '0.93rc1')).toBe(
+      '0.93rc1（テスト版）（最新版）',
+    );
+  });
+});

--- a/src/shared/coreVersionText.ts
+++ b/src/shared/coreVersionText.ts
@@ -1,0 +1,64 @@
+import { compareVersion } from './compareVersion';
+
+/**
+ * Returns the description appended to an installed version.
+ * 比較不能(NaN)なら空文字、最新版より古ければ最新版の案内、
+ * それ以外は rc を含むかどうかでテスト版/最新版の表記を返す。
+ * @param {string} installedVersion - The installed version.
+ * @param {string} latestVersion - The latest version.
+ * @returns {string} The description.
+ */
+export function installedVersionDescription(
+  installedVersion: string,
+  latestVersion: string,
+) {
+  const versionComparison = compareVersion(installedVersion, latestVersion);
+  return Number.isNaN(versionComparison)
+    ? ''
+    : versionComparison === -1
+      ? ` （最新版: ${latestVersion}）`
+      : installedVersion.includes('rc')
+        ? '（テスト版）'
+        : ' （最新版）';
+}
+
+/**
+ * Returns the text displayed as the installed version of a program.
+ * @param {string | null} installedVersion - The installed version, or `null` if apm.json does not record one.
+ * @param {string} latestVersion - The latest version.
+ * @param {boolean} filesVerified - Whether all the program files exist.
+ * @returns {string} The display text.
+ */
+export function installedVersionText(
+  installedVersion: string | null,
+  latestVersion: string,
+  filesVerified: boolean,
+) {
+  if (installedVersion === null) {
+    return filesVerified ? '手動インストール済み' : '未インストール';
+  }
+  const description = installedVersionDescription(
+    installedVersion,
+    latestVersion,
+  );
+  return filesVerified
+    ? 'バージョン: ' + installedVersion + description
+    : 'バージョン: ' +
+        installedVersion +
+        description +
+        '（未導入ファイルあり）';
+}
+
+/**
+ * Returns the label of a release shown in the version select.
+ * @param {string} version - The version of the release.
+ * @param {string} latestVersion - The latest version.
+ * @returns {string} The label.
+ */
+export function releaseLabel(version: string, latestVersion: string) {
+  return (
+    version +
+    (version.includes('rc') ? '（テスト版）' : '') +
+    (version === latestVersion ? '（最新版）' : '')
+  );
+}


### PR DESCRIPTION
## 概要

Phase 3・AviUtl タブ移行の最初のスライス。core.ts の表示文字列生成ロジックを electron 非依存の純関数として `src/shared/coreVersionText.ts` へ抽出し、特性化テスト 14 件で現行動作を固定しました。

## 変更内容

- `installedVersionDescription(installedVersion, latestVersion)` — 説明サフィックス(最新版案内 / テスト版 / 最新版)。`compareVersion` が NaN(比較不能)を返すケースで説明なしになる現行分岐を含めて固定
- `installedVersionText(installedVersion | null, latestVersion, filesVerified)` — apm.json 記録の有無 × ファイル存否の 4 分岐(手動インストール済み / 未インストール / 未導入ファイルあり)
- `releaseLabel(version, latestVersion)` — バージョン選択ドロップダウンの表示名(rc 版が最新版のとき「（テスト版）（最新版）」と両方付く現行挙動も固定)
- core.ts の `displayInstalledVersion` / `setCoreVersions` を抽出関数の呼び出しに置き換え(挙動不変のリファクタ)

## 検証

- [x] `yarn lint` / `yarn lint:ts` / `yarn test`(78 件)緑
- 純粋なロジック抽出のため表示文字列はテストで同一性を担保(DOM 配線は不変)

## 次のスライス

`getCoreInfo` の main プロセス service 化(tRPC `core.getCoreInfo`)→ インストール系ロジックの移設 → React UI 化の順で進めます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)