### PR TITLE
refactor(core): getCoreInfo を main プロセスへ移設し tRPC 化(AviUtl タブ スライス 2)

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -4,6 +4,7 @@ import type { CreateContextOptions } from 'electron-trpc/main';
 import { getConfig } from '../lib/Config';
 import { openAboutWindow } from './aboutWindow';
 import { isExeVersion } from './services/appUpdate';
+import { getCoreInfo } from './services/core';
 import { updateInfo } from './services/modList';
 import { ensureExtraDataUrl, setDataUrls } from './services/settings';
 
@@ -122,6 +123,13 @@ export const router = t.router({
       const win = BrowserWindow.fromWebContents(ctx.event.sender);
       if (!win) throw new Error('The calling window was not found.');
       await updateInfo(win, getConfig());
+    }),
+  }),
+  core: t.router({
+    getCoreInfo: procedure.query(async ({ ctx }) => {
+      const win = BrowserWindow.fromWebContents(ctx.event.sender);
+      if (!win) throw new Error('The calling window was not found.');
+      return await getCoreInfo(win, getConfig());
     }),
   }),
 });

--- a/src/main/services/core.ts
+++ b/src/main/services/core.ts
@@ -1,0 +1,33 @@
+import type { Core } from 'apm-schema';
+import type { BrowserWindow } from 'electron';
+import log from 'electron-log/main';
+import { readJson } from 'fs-extra';
+import path from 'node:path';
+import type Config from '../../lib/Config';
+import { getCoreDataUrl } from './modList';
+import { existsTempFile } from './tempFile';
+
+/**
+ * Returns an object parsed from core.json.
+ * 旧 src/renderer/main/core.ts の getCoreInfo と同一の挙動
+ * (未取得なら null、パース失敗はログして null)。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @returns {Promise<Core | null>} An object parsed from core.json.
+ */
+export async function getCoreInfo(
+  win: BrowserWindow,
+  config: Config,
+): Promise<Core | null> {
+  const coreFile = existsTempFile(
+    path.join('core', path.basename(await getCoreDataUrl(win, config))),
+  );
+  if (!coreFile.exists) return null;
+
+  try {
+    return (await readJson(coreFile.path)) as Core;
+  } catch (e) {
+    log.error(e);
+    return null;
+  }
+}

--- a/src/main/services/modList.ts
+++ b/src/main/services/modList.ts
@@ -31,3 +31,37 @@ export async function updateInfo(win: BrowserWindow, config: Config) {
   );
   config.dataURL.setPackages(packages);
 }
+
+/**
+ * Returns an object parsed from list.json, downloading it if not cached.
+ * 旧 src/lib/modList.ts の getInfo と同一の挙動(読めなければ null)。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @returns {Promise<List | null>} An object parsed from list.json.
+ */
+export async function getInfo(
+  win: BrowserWindow,
+  config: Config,
+): Promise<List | null> {
+  if (!existsTempFile('list.json').exists) {
+    await updateInfo(win, config);
+  }
+  const modFile = existsTempFile('list.json');
+  if (!modFile.exists) return null;
+  try {
+    return (await readJson(modFile.path)) as List;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns a core data file URL.
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @returns {Promise<string>} A core data file URL.
+ */
+export async function getCoreDataUrl(win: BrowserWindow, config: Config) {
+  const info = await getInfo(win, config);
+  return resolvePath(config.dataURL.getMain(), info.core.path);
+}

--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -9,15 +9,14 @@ import { convertId } from '../../lib/convertId';
 import {
   app,
   download,
-  existsTempFile,
   openDialog,
   openDirDialog,
   openYesNoDialog,
 } from '../../lib/ipcWrapper';
 import * as modList from '../../lib/modList';
-import * as parseJson from '../../lib/parseJson';
 import replaceText from '../../lib/replaceText';
 import { addAviUtlShortcut, removeAviUtlShortcut } from '../../lib/shortcut';
+import { trpc } from '../../lib/trpcClient';
 import unzip from '../../lib/unzip';
 import migration2to3 from '../../migration/migration2to3';
 import {
@@ -114,20 +113,12 @@ async function displayInstalledVersion(instPath: string) {
 
 /**
  * Returns an object parsed from core.json.
+ * 実装は main プロセス側(src/main/services/core.ts)へ移設済み。
  * @returns {Promise<Core>} - An object parsed from core.json.
  */
 async function getCoreInfo() {
-  const coreFile = await existsTempFile(
-    path.join('core', path.basename(await modList.getCoreDataUrl())),
-  );
-  if (!coreFile.exists) return null;
-
-  try {
-    return await parseJson.getCore(coreFile.path);
-  } catch (e) {
-    log.error(e);
-    return null;
-  }
+  // tRPC の Serialize 型はプロパティを optional 化するため元の型に戻す
+  return (await trpc.core.getCoreInfo.query()) as Core | null;
 }
 
 /**


### PR DESCRIPTION
## 概要

AviUtl タブ移行のスライス 2。core.json の読み込み(`getCoreInfo`)を main プロセスの service に移設し、tRPC `core.getCoreInfo` クエリとして公開しました。#2311(スライス 1)ベースなので、そちらのマージ後に base を main に変更してください。

## 変更内容

- `src/main/services/modList.ts` に `getInfo` / `getCoreDataUrl` を追加(旧 `src/lib/modList.ts` と同一挙動。parseJson は import 連鎖が renderer 依存(convertId → ipcWrapper)のため、#2308 と同じく `readJson` で再実装)
- `src/main/services/core.ts` 新設 — `getCoreInfo`(未取得なら null、パース失敗はログして null)
- api.ts に `core.getCoreInfo` クエリを追加(ctx から呼び出し元ウィンドウを取得するパターン)
- renderer の `core.ts#getCoreInfo` は委譲シムに縮小。tRPC の Serialize 型がプロパティを optional 化するため `as Core | null` で元の型に戻す(呼び出し側は不変)

## 検証

- [x] `yarn lint` / `yarn lint:ts` / `yarn test`(78 件)緑
- [x] `yarn package` + CDP スモーク 6 項目 PASS(バージョンドロップダウン 2 件表示・（最新版）ラベル・インストール状況表示・「最新版を確認」ボタンで更新完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)