### PR TITLE
refactor(core): displayInstalledVersion の計算部分を main プロセスへ移設

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -7,6 +7,7 @@ import { isExeVersion } from './services/appUpdate';
 import {
   checkCoreLatestVersion,
   getCoreInfo,
+  getInstalledVersionTexts,
   installCoreProgram,
 } from './services/core';
 import { updateInfo } from './services/modList';
@@ -148,6 +149,13 @@ export const router = t.router({
       if (!win) throw new Error('The calling window was not found.');
       return await getCoreInfo(win, getConfig());
     }),
+    getInstalledVersionTexts: procedure
+      .input(stringInput)
+      .query(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        return await getInstalledVersionTexts(win, getConfig(), input);
+      }),
     checkLatestVersion: procedure.mutation(async ({ ctx }) => {
       const win = BrowserWindow.fromWebContents(ctx.event.sender);
       if (!win) throw new Error('The calling window was not found.');

--- a/src/main/services/core.ts
+++ b/src/main/services/core.ts
@@ -1,12 +1,14 @@
 import type { Core, Program } from 'apm-schema';
-import { type BrowserWindow, dialog } from 'electron';
+import { app, type BrowserWindow, dialog } from 'electron';
 import log from 'electron-log/main';
-import { readJson } from 'fs-extra';
+import { existsSync, readJson } from 'fs-extra';
 import path from 'node:path';
 import ApmJson from '../../lib/ApmJson';
 import type Config from '../../lib/Config';
-import { install } from '../../shared/install';
-import { verifyFile } from '../../shared/integrity';
+import { addAviUtlShortcut, removeAviUtlShortcut } from '../../lib/shortcut';
+import { installedVersionText } from '../../shared/coreVersionText';
+import { install, verifyFilesByCount } from '../../shared/install';
+import { checkIntegrity, verifyFile } from '../../shared/integrity';
 import unzip from '../../shared/unzip';
 import { downloadFile } from './download';
 import { getCoreDataUrl, getInfo, updateInfo } from './modList';
@@ -55,6 +57,66 @@ export async function checkCoreLatestVersion(
   config.checkDate.setCore(Date.now());
   const modInfo = await getInfo(win, config);
   config.modDate.setCore(new Date(modInfo.core.modified).getTime());
+}
+
+/**
+ * Returns the installed-version texts of AviUtl and 拡張編集.
+ * 旧 src/renderer/main/core.ts の displayInstalledVersion の計算部分と同一の挙動。
+ * 表示テキストの算出に加えて、整合性検証による apm.json の補正書き込みと
+ * Start メニューショートカットの更新(win32 のみ)という副作用を持つ。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @returns {Promise<{ aviutl: string; exedit: string }>} The texts to display.
+ */
+export async function getInstalledVersionTexts(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+): Promise<{ aviutl: string; exedit: string }> {
+  const coreInfo = await getCoreInfo(win, config);
+  const texts = { aviutl: '未取得', exedit: '未取得' };
+  if (instPath && coreInfo) {
+    for (const program of ['aviutl', 'exedit'] as const) {
+      const progInfo: Program = coreInfo[program];
+
+      // Set the version of the manually installed program
+      const apmJson = await ApmJson.load(instPath);
+      if (!(await apmJson.has('core.' + program))) {
+        for (const release of progInfo.releases) {
+          if (await checkIntegrity(instPath, release.integrity.file))
+            await apmJson.setCore(program, release.version);
+        }
+      }
+
+      const installedVersion = (await apmJson.has('core.' + program))
+        ? ((await apmJson.get('core.' + program)) as string)
+        : null;
+      const filesVerified = verifyFilesByCount(instPath, progInfo.files);
+      texts[program] = installedVersionText(
+        installedVersion,
+        progInfo.latestVersion,
+        filesVerified,
+      );
+    }
+  }
+
+  // Add a shortcut to the Start menu
+  if (process.platform === 'win32') {
+    const appDataPath = app.getPath('appData');
+    const apmPath = app.getPath('exe');
+    const aviutlPath = path.join(instPath, 'aviutl.exe');
+    if (
+      existsSync(aviutlPath) &&
+      apmPath.includes(path.dirname(appDataPath)) // Verify that it is the installed version of apm
+    ) {
+      addAviUtlShortcut(appDataPath, aviutlPath);
+    } else {
+      removeAviUtlShortcut(appDataPath);
+    }
+  }
+
+  return texts;
 }
 
 export type InstallCoreResult =

--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -1,4 +1,4 @@
-import { Core, Program } from 'apm-schema';
+import { Core } from 'apm-schema';
 import log from 'electron-log/renderer';
 import fs from 'fs-extra';
 import path from 'node:path';
@@ -9,15 +9,10 @@ import { convertId } from '../../lib/convertId';
 import { app, openDialog, openDirDialog } from '../../lib/ipcWrapper';
 import * as modList from '../../lib/modList';
 import replaceText from '../../lib/replaceText';
-import { addAviUtlShortcut, removeAviUtlShortcut } from '../../lib/shortcut';
 import { trpc } from '../../lib/trpcClient';
 import migration2to3 from '../../migration/migration2to3';
-import {
-  installedVersionText,
-  releaseLabel,
-} from '../../shared/coreVersionText';
-import { checkIntegrity } from '../../shared/integrity';
-import { programs, verifyFilesByCount } from './common';
+import { releaseLabel } from '../../shared/coreVersionText';
+import { programs } from './common';
 import packageMain from './package';
 import packageUtil from './packageUtil';
 
@@ -41,39 +36,14 @@ async function initCore() {
  * @param {string} instPath - An installation path.
  */
 async function displayInstalledVersion(instPath: string) {
-  const coreInfo = await getCoreInfo();
-  const isInstalled = { aviutl: false, exedit: false };
-  if (instPath && coreInfo) {
-    for (const program of programs) {
-      const progInfo: Program = coreInfo[program];
-
-      // Set the version of the manually installed program
-      const apmJson = await ApmJson.load(instPath);
-      if (!(await apmJson.has('core.' + program))) {
-        for (const release of progInfo.releases) {
-          if (await checkIntegrity(instPath, release.integrity.file))
-            await apmJson.setCore(program, release.version);
-        }
-      }
-
-      const installedVersion = (await apmJson.has('core.' + program))
-        ? ((await apmJson.get('core.' + program)) as string)
-        : null;
-      const filesVerified = verifyFilesByCount(instPath, progInfo.files);
-      replaceText(
-        `${program}-installed-version`,
-        installedVersionText(
-          installedVersion,
-          progInfo.latestVersion,
-          filesVerified,
-        ),
-      );
-      if (filesVerified) isInstalled[program] = true;
-    }
-  } else {
-    for (const program of programs) {
-      replaceText(`${program}-installed-version`, '未取得');
-    }
+  // 表示テキストの算出・apm.json の補正・ショートカット更新は
+  // main プロセス側(services/core.ts)へ移設済み
+  const texts = (await trpc.core.getInstalledVersionTexts.query(instPath)) as {
+    aviutl: string;
+    exedit: string;
+  };
+  for (const program of programs) {
+    replaceText(`${program}-installed-version`, texts[program]);
   }
 
   if (config.modDate.hasCore()) {
@@ -86,21 +56,6 @@ async function displayInstalledVersion(instPath: string) {
     replaceText('core-mod-date', '未取得');
 
     replaceText('core-check-date', '未確認');
-  }
-
-  // Add a shortcut to the Start menu
-  if (process.platform === 'win32') {
-    const appDataPath = await app.getPath('appData');
-    const apmPath = await app.getPath('exe');
-    const aviutlPath = path.join(instPath, 'aviutl.exe');
-    if (
-      fs.existsSync(aviutlPath) &&
-      apmPath.includes(path.dirname(appDataPath)) // Verify that it is the installed version of apm
-    ) {
-      addAviUtlShortcut(appDataPath, aviutlPath);
-    } else {
-      removeAviUtlShortcut(appDataPath);
-    }
   }
 }
 


### PR DESCRIPTION
## 概要

Phase 3 AviUtl タブのスライス 5 の前段。#2315(installProgram / checkLatestVersion の main 化)に続き、AviUtl タブに残る最後の計算ロジック `displayInstalledVersion` を main プロセスへ移設します。これで AviUtl タブの React UI 化(次スライス)は「tRPC を呼ぶ UI を書く」作業に純化されます。

## 変更内容

- **`src/main/services/core.ts` に `getInstalledVersionTexts` を追加**し、tRPC の `core.getInstalledVersionTexts` query として公開(instPath 入力検証付き)
  - インストール状況テキストの算出(`shared/coreVersionText` の `installedVersionText`)
  - 整合性検証による手動インストール版の apm.json への補正書き込み(旧挙動どおり)
  - Start メニューショートカットの追加・削除(win32 のみ、`lib/shortcut` を main から使用)
- **renderer 側 `displayInstalledVersion` は薄いラッパー化**: query 結果の `replaceText` と更新日時表示(config 読み出し)のみ
- 旧コードで代入されるだけで未使用だったローカル変数 `isInstalled` は移設時に削除(挙動差なし)

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(88 件)すべて緑
- macOS で `yarn package` + CDP スモーク 6 項目 PASS(インストール状況表示「未インストール」= 新 query の実走、「最新版を確認」→「更新完了」)

次: スライス 5 本体 = AviUtl タブのプログラム行(インストール状況 + バージョン選択インストール)の React 化

🤖 Generated with [Claude Code](https://claude.com/claude-code)