### PR TITLE
feat(aviutl): プログラム行(AviUtl・拡張編集)を React コンポーネント化

### DIFF
--- a/src/renderer/main/aviutl/ProgramRow.tsx
+++ b/src/renderer/main/aviutl/ProgramRow.tsx
@@ -1,0 +1,181 @@
+import type { Core } from 'apm-schema';
+import React, { type JSX, useEffect, useState } from 'react';
+import { releaseLabel } from '../../../shared/coreVersionText';
+import { TRPCReact } from '../../trpc';
+
+type ButtonPhase = 'idle' | 'loading' | 'success' | 'danger';
+
+export type ProgramRowProps = {
+  program: 'aviutl' | 'exedit';
+  label: string;
+  iconClass: string;
+  buttonRoundedClass: string;
+};
+
+/**
+ * A row of the AviUtl tab showing the installed version and the version
+ * dropdown of AviUtl / 拡張編集.
+ * 旧 core.ts の displayInstalledVersion(表示部分)+ setCoreVersions +
+ * installProgram(ボタン表示部分)に相当する。計算は tRPC 経由で main プロセス。
+ * レガシー側の再描画通知(apm-core-changed イベント)で自動更新する。
+ * @param {ProgramRowProps} props - Props.
+ * @returns {JSX.Element} The rendered component.
+ */
+function ProgramRow({
+  program,
+  label,
+  iconClass,
+  buttonRoundedClass,
+}: ProgramRowProps) {
+  const [instPath, setInstPath] = useState(
+    () => window.coreBridge?.getInstallationPath() ?? '',
+  );
+  const [phase, setPhase] = useState<ButtonPhase>('idle');
+  const [buttonMessage, setButtonMessage] = useState('');
+
+  const utils = TRPCReact.useContext();
+  const coreInfoQuery = TRPCReact.core.getCoreInfo.useQuery();
+  const installedTextsQuery =
+    TRPCReact.core.getInstalledVersionTexts.useQuery(instPath);
+  const installProgram = TRPCReact.core.installProgram.useMutation();
+
+  // レガシー側(preload の core.ts)からの再描画通知を受けて最新化する
+  useEffect(() => {
+    const listener = () => {
+      setInstPath(window.coreBridge?.getInstallationPath() ?? '');
+      void utils.core.getCoreInfo.invalidate();
+      void utils.core.getInstalledVersionTexts.invalidate();
+    };
+    window.addEventListener('apm-core-changed', listener);
+    return () => window.removeEventListener('apm-core-changed', listener);
+  }, [utils]);
+
+  // tRPC の Serialize 型はプロパティを optional 化するため元の型に戻す
+  const coreInfo = (coreInfoQuery.data ?? null) as Core | null;
+  const releases = coreInfo?.[program]?.releases ?? [];
+  const latestVersion = coreInfo?.[program]?.latestVersion ?? '';
+  const installedText = installedTextsQuery.data?.[program] ?? '';
+
+  const showError = (message: string) => {
+    setPhase('danger');
+    setButtonMessage(message);
+    setTimeout(() => setPhase('idle'), 3000);
+  };
+
+  const onInstall = async (version: string) => {
+    if (phase === 'loading') return;
+    setPhase('loading');
+
+    if (!instPath) {
+      showError('インストール先フォルダを指定してください。');
+      return;
+    }
+
+    let result: Awaited<ReturnType<typeof installProgram.mutateAsync>>;
+    try {
+      result = await installProgram.mutateAsync({
+        program,
+        version,
+        instPath,
+      });
+    } catch {
+      showError('エラーが発生しました。');
+      return;
+    }
+
+    if (result === 'noVersionData') {
+      showError('バージョンデータが存在しません。');
+      return;
+    }
+    if (result === 'downloadFailed') {
+      showError('ダウンロード中にエラーが発生しました。');
+      return;
+    }
+    if (result === 'corrupt') {
+      showError('ダウンロードされたファイルは破損しています。');
+      return;
+    }
+    if (result === 'redownloadFailed') {
+      showError('ファイルのダウンロードに失敗しました。');
+      return;
+    }
+    if (result !== 'success') {
+      // installFailed: エラー内容は main プロセス側でログ済み
+      showError('エラーが発生しました。');
+      return;
+    }
+
+    await utils.core.getInstalledVersionTexts.invalidate();
+    // レガシーのパッケージ一覧・ニコニ・コモンズ ID 一覧を再描画する
+    await window.coreBridge?.onProgramInstalled();
+    setPhase('success');
+    setButtonMessage('インストール完了');
+    setTimeout(() => setPhase('idle'), 3000);
+  };
+
+  const buttonClass = `btn dropdown-toggle ${buttonRoundedClass} ${
+    phase === 'success'
+      ? 'btn-success'
+      : phase === 'danger'
+        ? 'btn-danger'
+        : 'btn-primary'
+  }`;
+
+  return (
+    <>
+      <div className="d-flex align-items-center flex-grow-1">
+        <i className={`bi ${iconClass} me-3`}></i> {label}
+      </div>
+      <div>
+        <span id={`${program}-installed-version`}>{installedText}</span>
+        <button
+          type="button"
+          className={buttonClass}
+          id={`install-${program}`}
+          data-bs-toggle="dropdown"
+          aria-expanded="false"
+          disabled={phase === 'loading'}
+        >
+          {phase === 'loading' ? (
+            <>
+              <span
+                className="spinner-border spinner-border-sm"
+                role="status"
+                aria-hidden="true"
+              ></span>
+              <span className="visually-hidden">Loading...</span>
+            </>
+          ) : phase === 'idle' ? (
+            ''
+          ) : (
+            buttonMessage
+          )}
+        </button>
+        <div className="dropdown bg-body">
+          <ul
+            className="dropdown-menu dropdown-menu-end"
+            id={`${program}-version-select`}
+            aria-labelledby={`install-${program}`}
+          >
+            {releases.map((release) => (
+              <li key={release.version}>
+                <a
+                  className="dropdown-item"
+                  href="#"
+                  onClick={(e) => {
+                    e.preventDefault();
+                    void onInstall(release.version);
+                  }}
+                >
+                  {releaseLabel(release.version, latestVersion)}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default ProgramRow;

--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -11,7 +11,6 @@ import * as modList from '../../lib/modList';
 import replaceText from '../../lib/replaceText';
 import { trpc } from '../../lib/trpcClient';
 import migration2to3 from '../../migration/migration2to3';
-import { releaseLabel } from '../../shared/coreVersionText';
 import { programs } from './common';
 import packageMain from './package';
 import packageUtil from './packageUtil';
@@ -33,19 +32,10 @@ async function initCore() {
 
 /**
  * Displays installed version.
- * @param {string} instPath - An installation path.
  */
-async function displayInstalledVersion(instPath: string) {
-  // 表示テキストの算出・apm.json の補正・ショートカット更新は
-  // main プロセス側(services/core.ts)へ移設済み
-  const texts = (await trpc.core.getInstalledVersionTexts.query(instPath)) as {
-    aviutl: string;
-    exedit: string;
-  };
-  for (const program of programs) {
-    replaceText(`${program}-installed-version`, texts[program]);
-  }
-
+async function displayInstalledVersion() {
+  // AviUtl・拡張編集行の表示は React(ProgramRow)が tRPC 経由で行う。
+  // ここでは日付表示の更新と React への再描画通知のみ行う。
   if (config.modDate.hasCore()) {
     const modDate = new Date(config.modDate.getCore());
     replaceText('core-mod-date', modDate.toLocaleString());
@@ -57,6 +47,8 @@ async function displayInstalledVersion(instPath: string) {
 
     replaceText('core-check-date', '未確認');
   }
+
+  window.dispatchEvent(new Event('apm-core-changed'));
 }
 
 /**
@@ -70,76 +62,9 @@ async function getCoreInfo() {
 }
 
 /**
- * Sets versions of each program in selects.
- * @param {string} instPath - An installation path.
- */
-async function setCoreVersions(instPath: string) {
-  const aviutlVersionSelect = document.getElementById('aviutl-version-select');
-  const exeditVersionSelect = document.getElementById('exedit-version-select');
-  while (aviutlVersionSelect.childElementCount > 0) {
-    aviutlVersionSelect.removeChild(aviutlVersionSelect.lastChild);
-  }
-  while (exeditVersionSelect.childElementCount > 0) {
-    exeditVersionSelect.removeChild(exeditVersionSelect.lastChild);
-  }
-
-  const coreInfo = await getCoreInfo();
-  if (!coreInfo) {
-    for (const program of programs) {
-      replaceText(`${program}-latest-version`, '未取得');
-    }
-    return;
-  }
-
-  const installAviutlBtn = document.getElementById(
-    'install-aviutl',
-  ) as HTMLButtonElement;
-  const installExeditBtn = document.getElementById(
-    'install-exedit',
-  ) as HTMLButtonElement;
-
-  for (const program of programs) {
-    for (const release of coreInfo[program].releases) {
-      const li = document.createElement('li');
-      const anchor = document.createElement('a');
-      anchor.classList.add('dropdown-item');
-      anchor.href = '#';
-      anchor.innerText = releaseLabel(
-        release.version,
-        coreInfo[program].latestVersion,
-      );
-      li.appendChild(anchor);
-
-      if (program === 'aviutl') {
-        anchor.addEventListener('click', async () => {
-          await installProgram(
-            installAviutlBtn,
-            program,
-            release.version,
-            instPath,
-          );
-        });
-        aviutlVersionSelect.appendChild(li);
-      } else if (program === 'exedit') {
-        anchor.addEventListener('click', async () => {
-          await installProgram(
-            installExeditBtn,
-            program,
-            release.version,
-            instPath,
-          );
-        });
-        exeditVersionSelect.appendChild(li);
-      }
-    }
-  }
-}
-
-/**
  * Checks the latest versionof programs.
- * @param {string} instPath - An installation path.
  */
-async function checkLatestVersion(instPath: string) {
+async function checkLatestVersion() {
   const btn = document.getElementById(
     'check-core-version',
   ) as HTMLButtonElement;
@@ -148,8 +73,7 @@ async function checkLatestVersion(instPath: string) {
   try {
     // ダウンロードと日付更新は main プロセス側(services/core.ts)へ移設済み
     await trpc.core.checkLatestVersion.mutate();
-    await displayInstalledVersion(instPath);
-    await setCoreVersions(instPath);
+    await displayInstalledVersion();
     buttonTransition.message(btn, '更新完了', 'success');
   } catch (e) {
     log.error(e);
@@ -184,6 +108,8 @@ async function selectInstallationPath(input: HTMLInputElement) {
     const instPath = selectedPath[0];
     await changeInstallationPath(instPath);
     input.value = instPath;
+    // インストール先の確定を React(ProgramRow)へ通知する
+    window.dispatchEvent(new Event('apm-core-changed'));
   }
 }
 
@@ -226,7 +152,7 @@ async function changeInstallationPath(instPath: string) {
     await packageMain.getScriptsList(true);
   }
   if (oldCoreMod.getTime() < new Date(currentMod.core.modified).getTime()) {
-    await checkLatestVersion(instPath);
+    await checkLatestVersion();
   }
   if (
     oldPackagesMod.getTime() <
@@ -236,8 +162,7 @@ async function changeInstallationPath(instPath: string) {
   }
 
   // redraw
-  await displayInstalledVersion(instPath);
-  await setCoreVersions(instPath);
+  await displayInstalledVersion();
   await packageMain.setPackagesList(instPath);
   await packageMain.displayNicommonsIdList(instPath);
 }
@@ -322,7 +247,7 @@ async function installProgram(
 
   try {
     if (result === 'success') {
-      await displayInstalledVersion(instPath);
+      await displayInstalledVersion();
       await packageMain.setPackagesList(instPath);
       await packageMain.displayNicommonsIdList(instPath);
 
@@ -408,7 +333,6 @@ const core = {
   initCore,
   displayInstalledVersion,
   getCoreInfo,
-  setCoreVersions,
   checkLatestVersion,
   selectInstallationPath,
   changeInstallationPath,

--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -151,50 +151,15 @@
 								</button>
 							</div>
 							<ul class="list-group mb-3" id="batch-install-packages">
-								<li class="list-group-item py-0 pe-0 d-flex">
-									<div class="d-flex align-items-center flex-grow-1">
-										<i class="bi bi-film me-3"></i> AviUtl
-									</div>
-									<div>
-										<span id="aviutl-installed-version"></span>
-										<button
-											type="button"
-											class="btn btn-primary dropdown-toggle rounded-start-0 rounded-bottom-0"
-											id="install-aviutl"
-											data-bs-toggle="dropdown"
-											aria-expanded="false"
-										></button>
-										<div class="dropdown bg-body">
-											<ul
-												class="dropdown-menu dropdown-menu-end"
-												id="aviutl-version-select"
-												aria-labelledby="install-aviutl"
-											></ul>
-										</div>
-									</div>
-								</li>
-								<li class="list-group-item py-0 pe-0 d-flex">
-									<div class="d-flex align-items-center flex-grow-1">
-										<i class="bi bi-calendar3-range me-3"></i> 拡張編集
-									</div>
-									<div>
-										<span id="exedit-installed-version"></span>
-										<button
-											type="button"
-											class="btn btn-primary dropdown-toggle rounded-0"
-											id="install-exedit"
-											data-bs-toggle="dropdown"
-											aria-expanded="false"
-										></button>
-										<div class="dropdown bg-body">
-											<ul
-												class="dropdown-menu dropdown-menu-end"
-												id="exedit-version-select"
-												aria-labelledby="install-exedit"
-											></ul>
-										</div>
-									</div>
-								</li>
+								<!-- 中身は React(ProgramRow)が描画する -->
+								<li
+									class="list-group-item py-0 pe-0 d-flex"
+									id="aviutl-program-root"
+								></li>
+								<li
+									class="list-group-item py-0 pe-0 d-flex"
+									id="exedit-program-root"
+								></li>
 							</ul>
 							<div class="d-none">
 								<li

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -1,4 +1,5 @@
 import ClipboardJS from 'clipboard/src/clipboard';
+import { contextBridge } from 'electron';
 import log from 'electron-log/renderer';
 import { exposeElectronTRPC } from 'electron-trpc/main';
 import 'source-map-support/register';
@@ -18,6 +19,24 @@ log.errorHandler.startCatching({
   },
 });
 const editorContextBridge = new EditorContextBridge();
+
+// メインワールドの React(AviUtl タブ ProgramRow)とレガシーの橋渡し
+contextBridge.exposeInMainWorld('coreBridge', {
+  getInstallationPath: () => {
+    const input = document.getElementById(
+      'installation-path',
+    ) as HTMLInputElement | null;
+    return input?.value ?? '';
+  },
+  onProgramInstalled: async () => {
+    const input = document.getElementById(
+      'installation-path',
+    ) as HTMLInputElement | null;
+    const instPath = input?.value ?? '';
+    await packageMain.setPackagesList(instPath);
+    await packageMain.displayNicommonsIdList(instPath);
+  },
+});
 
 // メインワールドの React(Settings ほか)から tRPC を使うための bridge
 process.once('loaded', () => {
@@ -64,6 +83,8 @@ window.addEventListener('DOMContentLoaded', async () => {
     'installation-path',
   ) as HTMLInputElement;
   installationPath.value = instPath;
+  // インストール先確定後に React(ProgramRow)へ再描画を通知する
+  window.dispatchEvent(new Event('apm-core-changed'));
   await editorContextBridge.setInstPath(installationPath);
 
   const appName = document.getElementsByClassName('app-name');
@@ -81,7 +102,7 @@ window.addEventListener('load', () => {
   // core
   const checkCoreVersionBtn = document.getElementById('check-core-version');
   checkCoreVersionBtn.addEventListener('click', async () => {
-    await core.checkLatestVersion(installationPath.value);
+    await core.checkLatestVersion();
   });
 
   const selectInstallationPathBtn = document.getElementById(

--- a/src/renderer/main/renderer.tsx
+++ b/src/renderer/main/renderer.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client';
 import '../../../node_modules/bootstrap-icons/font/bootstrap-icons.css';
 import '../main.css';
 import './index.css';
+import ProgramRow from './aviutl/ProgramRow';
 import { MonacoEditorRenderer } from './monacoEditorRenderer';
 import OthersTab from './others/OthersTab';
 import DataUrlSettings from './settings/DataUrlSettings';
@@ -34,6 +35,26 @@ window.addEventListener('DOMContentLoaded', () => {
   createRoot(document.getElementById('others-root')).render(
     <TrpcProvider>
       <OthersTab />
+    </TrpcProvider>,
+  );
+  createRoot(document.getElementById('aviutl-program-root')).render(
+    <TrpcProvider>
+      <ProgramRow
+        program="aviutl"
+        label="AviUtl"
+        iconClass="bi-film"
+        buttonRoundedClass="rounded-start-0 rounded-bottom-0"
+      />
+    </TrpcProvider>,
+  );
+  createRoot(document.getElementById('exedit-program-root')).render(
+    <TrpcProvider>
+      <ProgramRow
+        program="exedit"
+        label="拡張編集"
+        iconClass="bi-calendar3-range"
+        buttonRoundedClass="rounded-0"
+      />
     </TrpcProvider>,
   );
 });

--- a/src/types/mainRenderer.d.ts
+++ b/src/types/mainRenderer.d.ts
@@ -8,5 +8,9 @@ declare global {
       ) => void;
       save: (packages: Packages['packages']) => Promise<void>;
     };
+    coreBridge: {
+      getInstallationPath: () => string;
+      onProgramInstalled: () => Promise<void>;
+    };
   }
 }


### PR DESCRIPTION
## 概要

Phase 3 AviUtl タブのスライス 5b(#2316 スタック)。AviUtl・拡張編集の 2 行(インストール状況表示 + バージョン選択インストール)を React コンポーネント化します。計算はすべて #2312〜#2316 で main プロセスに移設済みのため、このスライスは UI の置き換えのみです。

**ベースは #2316 です。#2316 マージ後に main へ retarget + rebase して CI を発火させます。**

## 変更内容

- **`src/renderer/main/aviutl/ProgramRow.tsx` を新設**: 旧 `setCoreVersions`(ドロップダウン構築)+ `displayInstalledVersion`(プログラム行表示)+ `installProgram`(ボタン遷移)に相当する UI。データは `core.getCoreInfo` / `core.getInstalledVersionTexts` query、インストールは `core.installProgram` mutation を直接使用。エラーメッセージの文言・3 秒での復帰は旧 buttonTransition と同一
- **index.html**: 2 つの `li` を React root に置換。`aviutl-installed-version` / `install-aviutl` / `aviutl-version-select` 等の ID は React 側で維持(CDP スモーク互換)。おすすめプラグイン一覧(`batch-install-package`)は従来どおり package.ts が同じ `ul` に追記し、共存を確認済み
- **preload に `coreBridge`(contextBridge)を追加**: `getInstallationPath()`(input 値の取得)と `onProgramInstalled()`(インストール完了後のレガシーパッケージ一覧・ニコニ・コモンズ ID 一覧の再描画)を React から呼べるようにする(EditorContextBridge と同じパターン)
- **レガシー → React の再描画通知**: `apm-core-changed` イベント(isolated world から dispatch した DOM イベントはメインワールドにも届く)。`displayInstalledVersion` / `selectInstallationPath` / preload 初期化時に発火し、React 側は instPath 再取得 + query invalidate
- **renderer core.ts の縮小**: `setCoreVersions` を削除、`displayInstalledVersion` は日付表示 + 通知のみに。`checkLatestVersion` は引数不要に

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(88 件)すべて緑
- macOS で `yarn package` + CDP スモーク 6 項目 PASS(React 化後も同一 ID・同一表示)
- スクリーンショットで React 行とレガシー追記のおすすめプラグイン一覧の共存を目視確認

AviUtl タブで残るレガシー: インストール先選択・batch-install・おすすめ一覧(package.ts の DOM 関数依存のため Plugins タブ移行時に回収)

🤖 Generated with [Claude Code](https://claude.com/claude-code)