### PR TITLE
refactor(package): packageUtil の計算部分を shared へ移設し特性化テストを追加

### DIFF
--- a/src/renderer/main/packageUtil.ts
+++ b/src/renderer/main/packageUtil.ts
@@ -4,99 +4,20 @@ import path from 'node:path';
 import ApmJson from '../../lib/ApmJson';
 import { download, existsTempFile, openDialog } from '../../lib/ipcWrapper';
 import * as parseJson from '../../lib/parseJson';
-import { compareVersionOp } from '../../shared/compareVersion';
+import {
+  computePackagesStatus,
+  detectPackageTypes,
+  getInstalledVersionOfPackage,
+  getManuallyInstalledFiles,
+  parsePackageType,
+  states,
+} from '../../shared/packageUtil';
 import { ApmJsonObject } from '../../types/apmJson';
 import { PackageItem } from '../../types/packageItem';
-import { verifyFilesByCount } from './common';
 
-const typeForExtention = {
-  '.auf': 'filter',
-  '.aui': 'input',
-  '.auo': 'output',
-  '.auc': 'color',
-  '.aul': 'language',
-  '.anm': 'animation',
-  '.obj': 'object',
-  '.cam': 'camera',
-  '.tra': 'track',
-  '.scn': 'scene',
-};
-type aviutlExtention = keyof typeof typeForExtention;
-
-/** Installation state of packages */
-const states = {
-  installed: 'インストール済み',
-  installedButBroken: 'インストール済み（未導入ファイルあり）',
-  manuallyInstalled: '手動インストール済み',
-  otherInstalled: '他バージョンがインストール済み',
-  notInstalled: '未インストール',
-};
-
-/**
- * Convert type from internal expression to display
- * @param {string[]} packageType - A list of package types
- * @returns {string[]} Parsed package types
- */
-function parsePackageType(packageType: string[]) {
-  const result = [];
-  for (const type of packageType) {
-    switch (type) {
-      // plugin
-      case 'plugin':
-        result.push('入力', '出力', 'フィルター', '色変換', '言語');
-        break;
-      case 'input':
-        result.push('入力');
-        break;
-      case 'output':
-        result.push('出力');
-        break;
-      case 'filter':
-        result.push('フィルター');
-        break;
-      case 'color':
-        result.push('色変換');
-        break;
-      case 'language':
-        result.push('言語');
-        break;
-      // script
-      case 'script':
-        result.push(
-          'アニメーション効果',
-          'カスタムオブジェクト',
-          'シーンチェンジ',
-          'カメラ制御',
-          'トラックバー',
-          'スクリプト配布サイト',
-        );
-        break;
-      case 'animation':
-        result.push('アニメーション効果');
-        break;
-      case 'object':
-        result.push('カスタムオブジェクト');
-        break;
-      case 'scene':
-        result.push('シーンチェンジ');
-        break;
-      case 'camera':
-        result.push('カメラ制御');
-        break;
-      case 'track':
-        result.push('トラックバー');
-        break;
-      // script distribution sites
-      case 'script-dist':
-        result.push('スクリプト配布サイト');
-        break;
-      default:
-        result.push('不明');
-        break;
-    }
-  }
-  return result;
-}
+// 計算部分(states / parsePackageType / detectPackageTypes /
+// getManuallyInstalledFiles / getInstalledVersionOfPackage /
+// computePackagesStatus)は src/shared/packageUtil.ts へ移設済み
 
 /**
  * Returns an object parsed from packages.json
@@ -131,20 +52,10 @@ async function getPackages(packageDataUrls: string[]) {
   const packages = [];
   for (const packagesInfo of jsonList) {
     for (const packageInfo of packagesInfo) {
-      // Detect package type
-      const types = packageInfo.files.flatMap((f) => {
-        const extention = path.extname(f.filename);
-        if (extention in typeForExtention) {
-          return [typeForExtention[extention as aviutlExtention]];
-        } else {
-          return [];
-        }
-      });
-
       packages.push({
         id: packageInfo.id,
         info: packageInfo,
-        type: Array.from(new Set(types)),
+        type: detectPackageTypes(packageInfo.files),
       } as PackageItem);
     }
   }
@@ -206,90 +117,6 @@ async function getInstalledFiles(instPath: string) {
 }
 
 /**
- * Returns a list of files that were manually installed.
- * @param {string[]} files - List of installed files
- * @param {object[]} installedPackages - A list of object from apmJson
- * @param {object[]} packages - A list of object parsed from packages.json
- * @returns {string[]} List of manually installed files
- */
-function getManuallyInstalledFiles(
-  files: string[],
-  installedPackages: ApmJsonObject['packages'],
-  packages: PackageItem[],
-) {
-  let retFiles = [...files];
-  for (const packageItem of packages) {
-    for (const installedId of Object.keys(installedPackages)) {
-      if (installedId === packageItem.id) {
-        for (const file of packageItem.info.files) {
-          if (!file.isDirectory) {
-            retFiles = retFiles.filter((ef) => ef !== file.filename);
-          } else {
-            retFiles = retFiles.filter((ef) => !ef.startsWith(file.filename));
-          }
-        }
-      }
-    }
-  }
-  return retFiles;
-}
-
-/**
- * Returns the installed version or installation status of the package.
- * @param {object} packageItem - A Package
- * @param {string[]} installedFiles - List of installed files
- * @param {string[]} manuallyInstalledFiles - List of manually installed files
- * @param {object[]} installedPackages - A list of object from apmJson
- * @param {string} instPath - An installation path
- * @returns {object} Installed version or installation status of the package
- */
-function getInstalledVersionOfPackage(
-  packageItem: PackageItem,
-  installedFiles: string[],
-  manuallyInstalledFiles: string[],
-  installedPackages: ApmJsonObject['packages'],
-  instPath: string,
-) {
-  let installationStatus;
-  let version;
-  let isInstalledPackage = false;
-  let isManuallyInstalledPackage = false;
-  for (const file of packageItem.info.files) {
-    if (file.isInstallOnly) continue; // isInstallOnly is not used to determine installation status because the file is often shared by multiple packages.
-    if (installedFiles.includes(file.filename)) isInstalledPackage = true;
-    if (manuallyInstalledFiles.includes(file.filename))
-      isManuallyInstalledPackage = true;
-  }
-  installationStatus = isManuallyInstalledPackage
-    ? states.manuallyInstalled
-    : isInstalledPackage
-      ? states.otherInstalled // Still an assumption in this line.
-      : states.notInstalled;
-
-  for (const [installedId, installedPackage] of Object.entries(
-    installedPackages,
-  )) {
-    if (installedId === packageItem.id) {
-      if (packageItem.info.files.some((file) => file.isObsolete)) {
-        // There is no way to determine if a package that contains obsolete files is corrupt.
-        installationStatus = states.installed;
-        version = installedPackage.version;
-      } else {
-        // Determine if the package has been installed properly.
-        if (verifyFilesByCount(instPath, packageItem.info.files)) {
-          installationStatus = states.installed;
-          version = installedPackage.version;
-        } else {
-          installationStatus = states.installedButBroken;
-        }
-      }
-    }
-  }
-
-  return [installationStatus, version];
-}
-
-/**
  * Updates the installedVersion of the packages given as argument and returns a list of manually installed files
  * @param {object[]} _packages - A list of object parsed from packages.json
  * @param {string} instPath - An installation path
@@ -331,13 +158,8 @@ async function getPackagesExtra(_packages: PackageItem[], instPath: string) {
  * @returns {object[]} - packages
  */
 async function getPackagesStatus(instPath: string, _packages: PackageItem[]) {
-  const packages = [..._packages].map((p) => {
-    return { ...p };
-  });
   let aviUtlVer = '';
   let exeditVer = '';
-  const aviUtlR = /aviutl\d/;
-  const exeditR = /exedit\d/;
   try {
     const apmJson = await ApmJson.load(instPath);
     aviUtlVer = (await apmJson.get('core.' + 'aviutl', '')) as string;
@@ -346,92 +168,8 @@ async function getPackagesStatus(instPath: string, _packages: PackageItem[]) {
     log.info(e);
   }
 
-  const isInstallable = (id: string): boolean => {
-    const thisPackage = packages.filter((p) => p.id === id).find(() => true);
-    if (thisPackage) {
-      const isDepsInstallable = (): boolean =>
-        (thisPackage.info.dependencies ?? []) // [].every((x) => x) :true
-          .map((orOfID) =>
-            orOfID
-              .split('|')
-              .map((id2) => isInstallable(id2))
-              .some((x) => x),
-          )
-          .every((x) => x);
-      const otherInstalled =
-        thisPackage.installationStatus === states.otherInstalled;
-      const conflictsInstalled = (): boolean =>
-        (thisPackage.info.conflicts ?? []) // [].some((x) => x) :false
-          .map((andOfID) =>
-            andOfID
-              .split('&')
-              .map((id2) => isInstalled(id2))
-              .every((x) => x),
-          )
-          .some((x) => x);
-      const isConflicted = () => otherInstalled || conflictsInstalled();
-      return isDepsInstallable() && !isConflicted();
-    } else if (aviUtlR.test(id)) {
-      return id === 'aviutl' + aviUtlVer;
-    } else if (exeditR.test(id)) {
-      return id === 'exedit' + exeditVer;
-    } else {
-      return false;
-    }
-  };
-  const isInstalled = (rawId: string): boolean => {
-    const [, id, operator, version] =
-      rawId.match(
-        /^((?:[A-Za-z0-9]+\/[A-Za-z0-9]+)|(?:aviutl[A-Za-z0-9.]+)|(?:exedit[A-Za-z0-9.]+))(?:(<|<=|=|>=|>)([^<=>&|\n]+))?$/u,
-      ) ?? [];
-    const thisPackage = packages.filter((p) => p.id === id).find(() => true);
-    if (thisPackage) {
-      const statusInstalled =
-        thisPackage.installationStatus !== states.installedButBroken &&
-        thisPackage.installationStatus !== states.notInstalled &&
-        thisPackage.installationStatus !== states.otherInstalled;
-      const satisfiesVersion =
-        operator && thisPackage.version
-          ? compareVersionOp(thisPackage.version, version, operator)
-          : true;
-      return statusInstalled && satisfiesVersion;
-    } else if (aviUtlR.test(id)) {
-      return id === 'aviutl' + aviUtlVer;
-    } else if (exeditR.test(id)) {
-      return id === 'exedit' + exeditVer;
-    } else {
-      return false;
-    }
-  };
-  const missingDeps = (id: string): string[] => {
-    const thisPackage = packages.filter((p) => p.id === id).find(() => true);
-    if (thisPackage && isInstalled(id)) {
-      return (thisPackage.info.dependencies ?? [])
-        .filter(
-          // If any of these are not installed
-          (orOfID) =>
-            !orOfID
-              .split('|')
-              .map((id2) => isInstalled(id2))
-              .some((x) => x),
-        )
-        .flatMap((orOfID): string[] => {
-          const candidate = orOfID
-            .split('|')
-            .filter((id2) => isInstallable(id2))
-            .find(() => true);
-          return candidate ? [candidate] : [];
-        });
-    } else return [];
-  };
-
-  packages.forEach((p) => {
-    p.doNotInstall = !isInstallable(p.id);
-    p.detached = missingDeps(p.id).map((depsID) =>
-      packages.filter((pp) => pp.id === depsID).find(() => true),
-    );
-  });
-  return packages;
+  // 依存関係・競合の解決は shared/packageUtil.ts へ移設済み
+  return computePackagesStatus(_packages, aviUtlVer, exeditVer);
 }
 
 const packageUtil = {

--- a/src/shared/packageUtil.test.ts
+++ b/src/shared/packageUtil.test.ts
@@ -1,0 +1,371 @@
+import { mkdtemp, remove, writeFile } from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { PackageItem } from '../types/packageItem';
+import {
+  computePackagesStatus,
+  detectPackageTypes,
+  getInstalledVersionOfPackage,
+  getManuallyInstalledFiles,
+  parsePackageType,
+  states,
+} from './packageUtil';
+
+// 旧 src/renderer/main/packageUtil.ts の計算部分の特性化テスト
+
+/**
+ * Creates a package item for testing.
+ * @param {string} id - The package ID.
+ * @param {object} [overrides] - Overrides of the package info and status.
+ * @param {object[]} [overrides.files] - Files of the package.
+ * @param {string[]} [overrides.dependencies] - Dependencies of the package.
+ * @param {string[]} [overrides.conflicts] - Conflicts of the package.
+ * @param {string} [overrides.installationStatus] - An installation status.
+ * @param {string} [overrides.version] - An installed version.
+ * @returns {PackageItem} The created package item.
+ */
+function makePackage(
+  id: string,
+  overrides: {
+    files?: object[];
+    dependencies?: string[];
+    conflicts?: string[];
+    installationStatus?: string;
+    version?: string;
+  } = {},
+): PackageItem {
+  return {
+    id,
+    info: {
+      id,
+      files: overrides.files ?? [
+        { filename: `plugins/${id.split('/')[1] ?? id}.auf` },
+      ],
+      dependencies: overrides.dependencies,
+      conflicts: overrides.conflicts,
+    },
+    installationStatus: overrides.installationStatus ?? states.installed,
+    version: overrides.version,
+  } as unknown as PackageItem;
+}
+
+describe('parsePackageType', () => {
+  it('plugin は 5 種の表示名に展開される', () => {
+    expect(parsePackageType(['plugin'])).toEqual([
+      '入力',
+      '出力',
+      'フィルター',
+      '色変換',
+      '言語',
+    ]);
+  });
+
+  it('script は 6 種の表示名に展開される', () => {
+    expect(parsePackageType(['script'])).toHaveLength(6);
+  });
+
+  it('個別タイプはそれぞれの表示名になり、未知のタイプは不明になる', () => {
+    expect(parsePackageType(['filter', 'animation', 'unknown-type'])).toEqual([
+      'フィルター',
+      'アニメーション効果',
+      '不明',
+    ]);
+  });
+});
+
+describe('detectPackageTypes', () => {
+  it('拡張子からタイプを判定し重複を除く', () => {
+    expect(
+      detectPackageTypes([
+        { filename: 'plugins/a.auf' },
+        { filename: 'plugins/b.auf' },
+        { filename: 'script/c.anm' },
+      ] as Parameters<typeof detectPackageTypes>[0]),
+    ).toEqual(['filter', 'animation']);
+  });
+
+  it('対象外の拡張子は無視される', () => {
+    expect(
+      detectPackageTypes([{ filename: 'readme.txt' }] as Parameters<
+        typeof detectPackageTypes
+      >[0]),
+    ).toEqual([]);
+  });
+});
+
+describe('getManuallyInstalledFiles', () => {
+  it('apm.json 管理下のパッケージのファイルを除外する', () => {
+    const packages = [
+      makePackage('author/pkg', {
+        files: [{ filename: 'plugins/pkg.auf' }],
+      }),
+    ];
+    expect(
+      getManuallyInstalledFiles(
+        ['plugins/pkg.auf', 'plugins/manual.auf'],
+        { 'author/pkg': { id: 'author/pkg', version: '1.0' } },
+        packages,
+      ),
+    ).toEqual(['plugins/manual.auf']);
+  });
+
+  it('isDirectory のファイルは前方一致で除外する', () => {
+    const packages = [
+      makePackage('author/pkg', {
+        files: [{ filename: 'script/pkgdir', isDirectory: true }],
+      }),
+    ];
+    expect(
+      getManuallyInstalledFiles(
+        ['script/pkgdir/a.anm', 'script/other.anm'],
+        { 'author/pkg': { id: 'author/pkg', version: '1.0' } },
+        packages,
+      ),
+    ).toEqual(['script/other.anm']);
+  });
+
+  it('apm.json に無いパッケージのファイルは除外しない', () => {
+    const packages = [
+      makePackage('author/pkg', {
+        files: [{ filename: 'plugins/pkg.auf' }],
+      }),
+    ];
+    expect(
+      getManuallyInstalledFiles(['plugins/pkg.auf'], {}, packages),
+    ).toEqual(['plugins/pkg.auf']);
+  });
+});
+
+describe('getInstalledVersionOfPackage', () => {
+  const tempDirs: string[] = [];
+
+  /**
+   * Creates a temporary directory removed after each test.
+   * @param {string} prefix - A prefix of the directory name.
+   * @returns {Promise<string>} The created directory.
+   */
+  async function makeTempDir(prefix: string) {
+    const dir = await mkdtemp(path.join(os.tmpdir(), prefix));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => remove(dir)));
+  });
+
+  it('apm.json に無くファイルも無ければ未インストール', async () => {
+    const inst = await makeTempDir('apm-pkgstatus-');
+    const p = makePackage('author/pkg', {
+      files: [{ filename: 'pkg.auf' }],
+    });
+    expect(getInstalledVersionOfPackage(p, [], [], {}, inst)).toEqual([
+      states.notInstalled,
+      undefined,
+    ]);
+  });
+
+  it('ファイルが手動インストール扱いなら手動インストール済み', async () => {
+    const inst = await makeTempDir('apm-pkgstatus-');
+    const p = makePackage('author/pkg', {
+      files: [{ filename: 'pkg.auf' }],
+    });
+    expect(
+      getInstalledVersionOfPackage(p, ['pkg.auf'], ['pkg.auf'], {}, inst),
+    ).toEqual([states.manuallyInstalled, undefined]);
+  });
+
+  it('ファイルはあるが apm.json に無ければ他バージョンがインストール済み', async () => {
+    const inst = await makeTempDir('apm-pkgstatus-');
+    const p = makePackage('author/pkg', {
+      files: [{ filename: 'pkg.auf' }],
+    });
+    expect(getInstalledVersionOfPackage(p, ['pkg.auf'], [], {}, inst)).toEqual([
+      states.otherInstalled,
+      undefined,
+    ]);
+  });
+
+  it('apm.json にあり実ファイルの検証が通ればインストール済み + バージョン', async () => {
+    const inst = await makeTempDir('apm-pkgstatus-');
+    await writeFile(path.join(inst, 'pkg.auf'), '');
+    const p = makePackage('author/pkg', {
+      files: [{ filename: 'pkg.auf' }],
+    });
+    expect(
+      getInstalledVersionOfPackage(
+        p,
+        ['pkg.auf'],
+        [],
+        { 'author/pkg': { id: 'author/pkg', version: '1.2' } },
+        inst,
+      ),
+    ).toEqual([states.installed, '1.2']);
+  });
+
+  it('apm.json にあるが実ファイルが欠けていれば未導入ファイルあり', async () => {
+    const inst = await makeTempDir('apm-pkgstatus-');
+    const p = makePackage('author/pkg', {
+      files: [{ filename: 'pkg.auf' }],
+    });
+    expect(
+      getInstalledVersionOfPackage(
+        p,
+        [],
+        [],
+        { 'author/pkg': { id: 'author/pkg', version: '1.2' } },
+        inst,
+      ),
+    ).toEqual([states.installedButBroken, undefined]);
+  });
+
+  it('isObsolete を含むパッケージは検証せずインストール済みになる', async () => {
+    const inst = await makeTempDir('apm-pkgstatus-');
+    const p = makePackage('author/pkg', {
+      files: [
+        { filename: 'pkg.auf' },
+        { filename: 'old.auf', isObsolete: true },
+      ],
+    });
+    expect(
+      getInstalledVersionOfPackage(
+        p,
+        [],
+        [],
+        { 'author/pkg': { id: 'author/pkg', version: '1.2' } },
+        inst,
+      ),
+    ).toEqual([states.installed, '1.2']);
+  });
+
+  it('isInstallOnly のファイルは判定に使わない', async () => {
+    const inst = await makeTempDir('apm-pkgstatus-');
+    const p = makePackage('author/pkg', {
+      files: [
+        { filename: 'shared.dll', isInstallOnly: true },
+        { filename: 'pkg.auf' },
+      ],
+    });
+    // shared.dll が存在しても otherInstalled にはならない
+    expect(
+      getInstalledVersionOfPackage(p, ['shared.dll'], [], {}, inst),
+    ).toEqual([states.notInstalled, undefined]);
+  });
+});
+
+describe('computePackagesStatus', () => {
+  it('依存の無いパッケージはインストール可能', () => {
+    const result = computePackagesStatus(
+      [makePackage('author/a', { installationStatus: states.notInstalled })],
+      '1.10',
+      '0.92',
+    );
+    expect(result[0].doNotInstall).toBe(false);
+    expect(result[0].detached).toEqual([]);
+  });
+
+  it('aviutl 疑似 ID はインストール中のバージョンと一致すれば満たされる', () => {
+    const result = computePackagesStatus(
+      [
+        makePackage('author/a', {
+          installationStatus: states.notInstalled,
+          dependencies: ['aviutl1.10'],
+        }),
+        makePackage('author/b', {
+          installationStatus: states.notInstalled,
+          dependencies: ['aviutl1.00'],
+        }),
+      ],
+      '1.10',
+      '0.92',
+    );
+    expect(result[0].doNotInstall).toBe(false);
+    expect(result[1].doNotInstall).toBe(true);
+  });
+
+  it('依存の or 指定(|)はどれか 1 つ満たせばよい', () => {
+    const result = computePackagesStatus(
+      [
+        makePackage('author/a', {
+          installationStatus: states.notInstalled,
+          dependencies: ['aviutl9.99|exedit0.92'],
+        }),
+      ],
+      '1.10',
+      '0.92',
+    );
+    expect(result[0].doNotInstall).toBe(false);
+  });
+
+  it('他バージョンがインストール済みのパッケージはインストール不可', () => {
+    const result = computePackagesStatus(
+      [makePackage('author/a', { installationStatus: states.otherInstalled })],
+      '1.10',
+      '0.92',
+    );
+    expect(result[0].doNotInstall).toBe(true);
+  });
+
+  it('conflicts に指定した相手がインストール済みならインストール不可', () => {
+    const result = computePackagesStatus(
+      [
+        makePackage('author/a', {
+          installationStatus: states.notInstalled,
+          conflicts: ['author/b'],
+        }),
+        makePackage('author/b', {
+          installationStatus: states.installed,
+          version: '1.0',
+        }),
+      ],
+      '1.10',
+      '0.92',
+    );
+    expect(result[0].doNotInstall).toBe(true);
+  });
+
+  it('インストール済みで依存が未導入なら detached に依存候補が入る', () => {
+    const result = computePackagesStatus(
+      [
+        makePackage('author/a', {
+          installationStatus: states.installed,
+          version: '1.0',
+          dependencies: ['author/dep'],
+        }),
+        makePackage('author/dep', {
+          installationStatus: states.notInstalled,
+        }),
+      ],
+      '1.10',
+      '0.92',
+    );
+    expect(result[0].detached.map((p) => p.id)).toEqual(['author/dep']);
+  });
+
+  it('依存のバージョン指定(>=)は compareVersionOp で判定される', () => {
+    // 注: isInstallable はバージョン指定付き ID をパッケージに解決しないため、
+    // detached の候補になるのは or 指定のうちバージョン指定の無い ID だけ
+    const base = (depVersion: string) => [
+      makePackage('author/a', {
+        installationStatus: states.installed,
+        version: '1.0',
+        dependencies: ['author/dep>=2.0|author/alt'],
+      }),
+      makePackage('author/dep', {
+        installationStatus: states.installed,
+        version: depVersion,
+      }),
+      makePackage('author/alt', {
+        installationStatus: states.notInstalled,
+      }),
+    ];
+    // 1.5 < 2.0 なので未充足 → or 内でインストール可能な author/alt が候補になる
+    const withOld = computePackagesStatus(base('1.5'), '1.10', '0.92');
+    expect(withOld[0].detached.map((p) => p.id)).toEqual(['author/alt']);
+
+    // 2.1 >= 2.0 で充足 → detached なし
+    const withNew = computePackagesStatus(base('2.1'), '1.10', '0.92');
+    expect(withNew[0].detached).toEqual([]);
+  });
+});

--- a/src/shared/packageUtil.ts
+++ b/src/shared/packageUtil.ts
@@ -1,0 +1,308 @@
+import type { Packages } from 'apm-schema';
+import path from 'node:path';
+import { ApmJsonObject } from '../types/apmJson';
+import { PackageItem } from '../types/packageItem';
+import { compareVersionOp } from './compareVersion';
+import { verifyFilesByCount } from './install';
+
+// 旧 src/renderer/main/packageUtil.ts から electron 非依存の計算部分を移設
+
+const typeForExtention = {
+  '.auf': 'filter',
+  '.aui': 'input',
+  '.auo': 'output',
+  '.auc': 'color',
+  '.aul': 'language',
+  '.anm': 'animation',
+  '.obj': 'object',
+  '.cam': 'camera',
+  '.tra': 'track',
+  '.scn': 'scene',
+};
+type aviutlExtention = keyof typeof typeForExtention;
+
+/** Installation state of packages */
+export const states = {
+  installed: 'インストール済み',
+  installedButBroken: 'インストール済み（未導入ファイルあり）',
+  manuallyInstalled: '手動インストール済み',
+  otherInstalled: '他バージョンがインストール済み',
+  notInstalled: '未インストール',
+};
+
+/**
+ * Convert type from internal expression to display
+ * @param {string[]} packageType - A list of package types
+ * @returns {string[]} Parsed package types
+ */
+export function parsePackageType(packageType: string[]) {
+  const result = [];
+  for (const type of packageType) {
+    switch (type) {
+      // plugin
+      case 'plugin':
+        result.push('入力', '出力', 'フィルター', '色変換', '言語');
+        break;
+      case 'input':
+        result.push('入力');
+        break;
+      case 'output':
+        result.push('出力');
+        break;
+      case 'filter':
+        result.push('フィルター');
+        break;
+      case 'color':
+        result.push('色変換');
+        break;
+      case 'language':
+        result.push('言語');
+        break;
+      // script
+      case 'script':
+        result.push(
+          'アニメーション効果',
+          'カスタムオブジェクト',
+          'シーンチェンジ',
+          'カメラ制御',
+          'トラックバー',
+          'スクリプト配布サイト',
+        );
+        break;
+      case 'animation':
+        result.push('アニメーション効果');
+        break;
+      case 'object':
+        result.push('カスタムオブジェクト');
+        break;
+      case 'scene':
+        result.push('シーンチェンジ');
+        break;
+      case 'camera':
+        result.push('カメラ制御');
+        break;
+      case 'track':
+        result.push('トラックバー');
+        break;
+      // script distribution sites
+      case 'script-dist':
+        result.push('スクリプト配布サイト');
+        break;
+      default:
+        result.push('不明');
+        break;
+    }
+  }
+  return result;
+}
+
+/**
+ * Detects package types from the extensions of the files.
+ * @param {object[]} files - A list of files of the package.
+ * @returns {string[]} Detected package types (duplicates removed).
+ */
+export function detectPackageTypes(
+  files: Packages['packages'][number]['files'],
+) {
+  const types = files.flatMap((f) => {
+    const extention = path.extname(f.filename);
+    if (extention in typeForExtention) {
+      return [typeForExtention[extention as aviutlExtention]];
+    } else {
+      return [];
+    }
+  });
+  return Array.from(new Set(types));
+}
+
+/**
+ * Returns a list of files that were manually installed.
+ * @param {string[]} files - List of installed files
+ * @param {object[]} installedPackages - A list of object from apmJson
+ * @param {object[]} packages - A list of object parsed from packages.json
+ * @returns {string[]} List of manually installed files
+ */
+export function getManuallyInstalledFiles(
+  files: string[],
+  installedPackages: ApmJsonObject['packages'],
+  packages: PackageItem[],
+) {
+  let retFiles = [...files];
+  for (const packageItem of packages) {
+    for (const installedId of Object.keys(installedPackages)) {
+      if (installedId === packageItem.id) {
+        for (const file of packageItem.info.files) {
+          if (!file.isDirectory) {
+            retFiles = retFiles.filter((ef) => ef !== file.filename);
+          } else {
+            retFiles = retFiles.filter((ef) => !ef.startsWith(file.filename));
+          }
+        }
+      }
+    }
+  }
+  return retFiles;
+}
+
+/**
+ * Returns the installed version or installation status of the package.
+ * @param {object} packageItem - A Package
+ * @param {string[]} installedFiles - List of installed files
+ * @param {string[]} manuallyInstalledFiles - List of manually installed files
+ * @param {object[]} installedPackages - A list of object from apmJson
+ * @param {string} instPath - An installation path
+ * @returns {object} Installed version or installation status of the package
+ */
+export function getInstalledVersionOfPackage(
+  packageItem: PackageItem,
+  installedFiles: string[],
+  manuallyInstalledFiles: string[],
+  installedPackages: ApmJsonObject['packages'],
+  instPath: string,
+) {
+  let installationStatus;
+  let version;
+  let isInstalledPackage = false;
+  let isManuallyInstalledPackage = false;
+  for (const file of packageItem.info.files) {
+    if (file.isInstallOnly) continue; // isInstallOnly is not used to determine installation status because the file is often shared by multiple packages.
+    if (installedFiles.includes(file.filename)) isInstalledPackage = true;
+    if (manuallyInstalledFiles.includes(file.filename))
+      isManuallyInstalledPackage = true;
+  }
+  installationStatus = isManuallyInstalledPackage
+    ? states.manuallyInstalled
+    : isInstalledPackage
+      ? states.otherInstalled // Still an assumption in this line.
+      : states.notInstalled;
+
+  for (const [installedId, installedPackage] of Object.entries(
+    installedPackages,
+  )) {
+    if (installedId === packageItem.id) {
+      if (packageItem.info.files.some((file) => file.isObsolete)) {
+        // There is no way to determine if a package that contains obsolete files is corrupt.
+        installationStatus = states.installed;
+        version = installedPackage.version;
+      } else {
+        // Determine if the package has been installed properly.
+        if (verifyFilesByCount(instPath, packageItem.info.files)) {
+          installationStatus = states.installed;
+          version = installedPackage.version;
+        } else {
+          installationStatus = states.installedButBroken;
+        }
+      }
+    }
+  }
+
+  return [installationStatus, version];
+}
+
+/**
+ * Computes doNotInstall / detached of the packages from the dependency and
+ * conflict information.
+ * 旧 getPackagesStatus の計算部分(apm.json の読み出しを除く)と同一の挙動。
+ * @param {object[]} _packages - A list of object parsed from packages.json and getPackagesExtra()
+ * @param {string} aviUtlVer - An installed version of AviUtl.
+ * @param {string} exeditVer - An installed version of 拡張編集.
+ * @returns {object[]} - packages
+ */
+export function computePackagesStatus(
+  _packages: PackageItem[],
+  aviUtlVer: string,
+  exeditVer: string,
+) {
+  const packages = [..._packages].map((p) => {
+    return { ...p };
+  });
+  const aviUtlR = /aviutl\d/;
+  const exeditR = /exedit\d/;
+
+  const isInstallable = (id: string): boolean => {
+    const thisPackage = packages.filter((p) => p.id === id).find(() => true);
+    if (thisPackage) {
+      const isDepsInstallable = (): boolean =>
+        (thisPackage.info.dependencies ?? []) // [].every((x) => x) :true
+          .map((orOfID) =>
+            orOfID
+              .split('|')
+              .map((id2) => isInstallable(id2))
+              .some((x) => x),
+          )
+          .every((x) => x);
+      const otherInstalled =
+        thisPackage.installationStatus === states.otherInstalled;
+      const conflictsInstalled = (): boolean =>
+        (thisPackage.info.conflicts ?? []) // [].some((x) => x) :false
+          .map((andOfID) =>
+            andOfID
+              .split('&')
+              .map((id2) => isInstalled(id2))
+              .every((x) => x),
+          )
+          .some((x) => x);
+      const isConflicted = () => otherInstalled || conflictsInstalled();
+      return isDepsInstallable() && !isConflicted();
+    } else if (aviUtlR.test(id)) {
+      return id === 'aviutl' + aviUtlVer;
+    } else if (exeditR.test(id)) {
+      return id === 'exedit' + exeditVer;
+    } else {
+      return false;
+    }
+  };
+  const isInstalled = (rawId: string): boolean => {
+    const [, id, operator, version] =
+      rawId.match(
+        /^((?:[A-Za-z0-9]+\/[A-Za-z0-9]+)|(?:aviutl[A-Za-z0-9.]+)|(?:exedit[A-Za-z0-9.]+))(?:(<|<=|=|>=|>)([^<=>&|\n]+))?$/u,
+      ) ?? [];
+    const thisPackage = packages.filter((p) => p.id === id).find(() => true);
+    if (thisPackage) {
+      const statusInstalled =
+        thisPackage.installationStatus !== states.installedButBroken &&
+        thisPackage.installationStatus !== states.notInstalled &&
+        thisPackage.installationStatus !== states.otherInstalled;
+      const satisfiesVersion =
+        operator && thisPackage.version
+          ? compareVersionOp(thisPackage.version, version, operator)
+          : true;
+      return statusInstalled && satisfiesVersion;
+    } else if (aviUtlR.test(id)) {
+      return id === 'aviutl' + aviUtlVer;
+    } else if (exeditR.test(id)) {
+      return id === 'exedit' + exeditVer;
+    } else {
+      return false;
+    }
+  };
+  const missingDeps = (id: string): string[] => {
+    const thisPackage = packages.filter((p) => p.id === id).find(() => true);
+    if (thisPackage && isInstalled(id)) {
+      return (thisPackage.info.dependencies ?? [])
+        .filter(
+          // If any of these are not installed
+          (orOfID) =>
+            !orOfID
+              .split('|')
+              .map((id2) => isInstalled(id2))
+              .some((x) => x),
+        )
+        .flatMap((orOfID): string[] => {
+          const candidate = orOfID
+            .split('|')
+            .filter((id2) => isInstallable(id2))
+            .find(() => true);
+          return candidate ? [candidate] : [];
+        });
+    } else return [];
+  };
+
+  packages.forEach((p) => {
+    p.doNotInstall = !isInstallable(p.id);
+    p.detached = missingDeps(p.id).map((depsID) =>
+      packages.filter((pp) => pp.id === depsID).find(() => true),
+    );
+  });
+  return packages;
+}


### PR DESCRIPTION
## 概要

Phase 3 Plugins タブのスライス 1。AviUtl タブ(#2311〜#2317)と同じ手順で、まず packageUtil.ts の electron 非依存な計算部分を `src/shared/` へ移設し、特性化テストで現行動作を固定します。

## 変更内容

- **`src/shared/packageUtil.ts` を新設**し、以下を移設(挙動は不変):
  - `states`(インストール状態の表示文字列。ロジックの比較値としても使われる)
  - `parsePackageType` / `detectPackageTypes`(拡張子 → タイプ判定。旧 getPackages 内のインライン処理を関数化)
  - `getManuallyInstalledFiles`(手動インストールファイルの抽出。isDirectory の前方一致除外)
  - `getInstalledVersionOfPackage`(インストール状態判定。isInstallOnly 除外・isObsolete 特例・verifyFilesByCount 検証)
  - `computePackagesStatus`(旧 getPackagesStatus の計算部分: 依存 `|`・競合 `&`・バージョン演算子・aviutl/exedit 疑似 ID の解決)
- **renderer 側 packageUtil.ts は IO と委譲のみ**: getPackages(temp ファイル + ダイアログ)、downloadRepository、getInstalledFiles(fs 走査)、getPackagesExtra、getPackagesStatus(apm.json 読み出し + computePackagesStatus 委譲)
- **特性化テスト 22 件**(tmpdir によるインストール状態判定 7 件を含む)。`isInstallable` がバージョン指定付き ID(`author/dep>=2.0`)をパッケージに解決しないため detached 候補にはならない、という現行挙動もコメント付きで固定

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(110 件)すべて緑
- macOS で `yarn package` + CDP スモーク: AviUtl タブ 6 項目 PASS + **Plugins タブ 4 項目 PASS**(一覧 294 件描画・インストール状況・タイプ表示・おすすめプラグイン一覧)

次: パッケージ系 IO(getPackages / downloadRepository / getInstalledFiles / getPackagesExtra)の main プロセス移設

🤖 Generated with [Claude Code](https://claude.com/claude-code)