### PR TITLE
refactor(package): パッケージデータの取得を main プロセスへ移設

### DIFF
--- a/src/lib/modList.ts
+++ b/src/lib/modList.ts
@@ -1,4 +1,3 @@
-import fs from 'fs-extra';
 import path from 'node:path';
 import { resolvePath } from '../shared/resolvePath';
 import { getConfig } from './Config';
@@ -51,23 +50,7 @@ export async function getCoreDataUrl() {
   return resolvePath(getDataUrl(), (await getInfo()).core.path);
 }
 
-/**
- * Returns package data files URLs.
- * @param {string} instPath - An installation path.
- * @returns {Array.<string>} -Package data files URLs.
- */
-export function getPackagesDataUrl(instPath: string) {
-  return config.dataURL
-    .getPackages()
-    .concat(
-      instPath && instPath.length > 0
-        ? [
-            getLocalPackagesDataUrl(instPath),
-            getEditorPackagesDataUrl(instPath),
-          ].filter((p) => fs.existsSync(p))
-        : [],
-    );
-}
+// getPackagesDataUrl は main プロセス側(src/main/services/packages.ts)へ移設済み
 
 /**
  * Returns a local package data file URL.

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -11,6 +11,7 @@ import {
   installCoreProgram,
 } from './services/core';
 import { updateInfo } from './services/modList';
+import { downloadRepository, getPackages } from './services/packages';
 import { ensureExtraDataUrl, setDataUrls } from './services/settings';
 
 export type Context = {
@@ -142,6 +143,20 @@ export const router = t.router({
       if (!win) throw new Error('The calling window was not found.');
       await updateInfo(win, getConfig());
     }),
+  }),
+  packages: t.router({
+    getPackages: procedure.input(stringInput).query(async ({ input, ctx }) => {
+      const win = BrowserWindow.fromWebContents(ctx.event.sender);
+      if (!win) throw new Error('The calling window was not found.');
+      return await getPackages(win, getConfig(), input);
+    }),
+    downloadRepository: procedure
+      .input(stringInput)
+      .mutation(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        await downloadRepository(win, getConfig(), input);
+      }),
   }),
   core: t.router({
     getCoreInfo: procedure.query(async ({ ctx }) => {

--- a/src/main/services/modList.ts
+++ b/src/main/services/modList.ts
@@ -65,3 +65,15 @@ export async function getCoreDataUrl(win: BrowserWindow, config: Config) {
   const info = await getInfo(win, config);
   return resolvePath(config.dataURL.getMain(), info.core.path);
 }
+
+/**
+ * Returns a convert data file URL.
+ * 旧 src/lib/modList.ts の getConvertDataUrl と同一の挙動。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @returns {Promise<string>} A convert data file URL.
+ */
+export async function getConvertDataUrl(win: BrowserWindow, config: Config) {
+  const info = await getInfo(win, config);
+  return resolvePath(config.dataURL.getMain(), info.convert.path);
+}

--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -1,0 +1,138 @@
+import type { Packages } from 'apm-schema';
+import { type BrowserWindow, dialog } from 'electron';
+import log from 'electron-log/main';
+import { existsSync, readJson } from 'fs-extra';
+import path from 'node:path';
+import type Config from '../../lib/Config';
+import { detectPackageTypes } from '../../shared/packageUtil';
+import { PackageItem } from '../../types/packageItem';
+import { downloadFile } from './download';
+import { getConvertDataUrl } from './modList';
+import { existsTempFile } from './tempFile';
+
+/**
+ * Returns package data files URLs.
+ * 旧 src/lib/modList.ts の getPackagesDataUrl と同一の挙動
+ * (設定の取得先 + instPath 直下の packages.json / editorPackages.json)。
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @returns {string[]} Package data files URLs.
+ */
+export function getPackagesDataUrl(config: Config, instPath: string) {
+  return config.dataURL
+    .getPackages()
+    .concat(
+      instPath && instPath.length > 0
+        ? [
+            path.join(instPath, 'packages.json'),
+            path.join(instPath, 'editorPackages.json'),
+          ].filter((p) => existsSync(p))
+        : [],
+    );
+}
+
+/**
+ * Returns the id conversion dictionary.
+ * 旧 src/lib/convertId.ts の getIdDict(update = false)と同一の挙動。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @returns {Promise<{ [key: string]: string }>} Dictionary of id relationships.
+ */
+async function getIdDict(
+  win: BrowserWindow,
+  config: Config,
+): Promise<{ [key: string]: string }> {
+  const dictUrl = await getConvertDataUrl(win, config);
+  const convertJson = existsTempFile(
+    path.join('package', path.basename(dictUrl)),
+    dictUrl,
+  );
+  if (convertJson.exists) {
+    return await readJson(convertJson.path);
+  } else {
+    return {};
+  }
+}
+
+/**
+ * Returns an object parsed from packages.json
+ * 旧 src/renderer/main/packageUtil.ts の getPackages
+ * (+ src/lib/parseJson.ts の getPackages の ID 変換)と同一の挙動。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @returns {Promise<PackageItem[]>} - A list of object parsed from packages.json
+ */
+export async function getPackages(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+): Promise<PackageItem[]> {
+  const jsonList: Packages['packages'][] = [];
+
+  for (const packageRepository of getPackagesDataUrl(config, instPath)) {
+    const packagesListFile = existsTempFile(
+      `package/${path.basename(packageRepository)}`,
+      packageRepository,
+    );
+    if (packagesListFile.exists) {
+      try {
+        const packagesInfo = (
+          (await readJson(packagesListFile.path)) as Packages
+        ).packages;
+        const convDict = await getIdDict(win, config);
+        for (const packageInfo of packagesInfo) {
+          // For compatibility with data v1
+          if (Object.prototype.hasOwnProperty.call(convDict, packageInfo.id)) {
+            packageInfo.id = convDict[packageInfo.id];
+          }
+        }
+        jsonList.push(packagesInfo);
+      } catch {
+        log.error('Failed data processing.');
+        await dialog.showMessageBox({
+          title: 'データ解析エラー',
+          message:
+            '取得したデータの処理に失敗しました。' +
+            '\n' +
+            'URL: ' +
+            packageRepository,
+          type: 'error',
+        });
+      }
+    }
+  }
+
+  const packages: PackageItem[] = [];
+  for (const packagesInfo of jsonList) {
+    for (const packageInfo of packagesInfo) {
+      packages.push({
+        id: packageInfo.id,
+        info: packageInfo,
+        type: detectPackageTypes(packageInfo.files),
+      } as PackageItem);
+    }
+  }
+  return packages;
+}
+
+/**
+ * Downloads the package data files.
+ * 旧 src/renderer/main/packageUtil.ts の downloadRepository と同一の挙動。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ */
+export async function downloadRepository(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+) {
+  // 'electron-dl' does not download all files when downloading them asynchronously.
+  for (const packageRepository of getPackagesDataUrl(config, instPath)) {
+    await downloadFile(win, packageRepository, {
+      subDir: 'package',
+      keyText: packageRepository,
+    });
+  }
+}

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -73,7 +73,7 @@ function getDate() {
  * @returns {Promise.<object[]>} An object of packages
  */
 async function getPackages(instPath: string) {
-  return await packageUtil.getPackages(modList.getPackagesDataUrl(instPath));
+  return await packageUtil.getPackages(instPath);
 }
 
 /**
@@ -505,7 +505,7 @@ async function checkPackagesList(instPath: string) {
 
   try {
     await modList.updateInfo();
-    await packageUtil.downloadRepository(modList.getPackagesDataUrl(instPath));
+    await packageUtil.downloadRepository(instPath);
     config.checkDate.setPackages(Date.now());
     const modInfo = await modList.getInfo();
     config.modDate.setPackages(

--- a/src/renderer/main/packageUtil.ts
+++ b/src/renderer/main/packageUtil.ts
@@ -2,11 +2,9 @@ import log from 'electron-log/renderer';
 import * as fs from 'fs-extra';
 import path from 'node:path';
 import ApmJson from '../../lib/ApmJson';
-import { download, existsTempFile, openDialog } from '../../lib/ipcWrapper';
-import * as parseJson from '../../lib/parseJson';
+import { trpc } from '../../lib/trpcClient';
 import {
   computePackagesStatus,
-  detectPackageTypes,
   getInstalledVersionOfPackage,
   getManuallyInstalledFiles,
   parsePackageType,
@@ -21,58 +19,22 @@ import { PackageItem } from '../../types/packageItem';
 
 /**
  * Returns an object parsed from packages.json
- * @param {string[]} packageDataUrls - URLs of the repository
+ * 実装は main プロセス側(src/main/services/packages.ts)へ移設済み。
+ * @param {string} instPath - An installation path
  * @returns {Promise<object[]>} - A list of object parsed from packages.json
  */
-async function getPackages(packageDataUrls: string[]) {
-  const jsonList = [];
-
-  for (const packageRepository of packageDataUrls) {
-    const packagesListFile = await existsTempFile(
-      `package/${path.basename(packageRepository)}`,
-      packageRepository,
-    );
-    if (packagesListFile.exists) {
-      try {
-        jsonList.push(await parseJson.getPackages(packagesListFile.path));
-      } catch {
-        log.error('Failed data processing.');
-        await openDialog(
-          'データ解析エラー',
-          '取得したデータの処理に失敗しました。' +
-            '\n' +
-            'URL: ' +
-            packageRepository,
-          'error',
-        );
-      }
-    }
-  }
-
-  const packages = [];
-  for (const packagesInfo of jsonList) {
-    for (const packageInfo of packagesInfo) {
-      packages.push({
-        id: packageInfo.id,
-        info: packageInfo,
-        type: detectPackageTypes(packageInfo.files),
-      } as PackageItem);
-    }
-  }
-  return packages;
+async function getPackages(instPath: string) {
+  // tRPC の Serialize 型はプロパティを optional 化するため元の型に戻す
+  return (await trpc.packages.getPackages.query(instPath)) as PackageItem[];
 }
 
 /**
- * @param {string[]} packageDataUrls - URLs of the repository
+ * Downloads the package data files.
+ * 実装は main プロセス側(src/main/services/packages.ts)へ移設済み。
+ * @param {string} instPath - An installation path
  */
-async function downloadRepository(packageDataUrls: string[]) {
-  // 'electron-dl' does not download all files when downloading them asynchronously.
-  for (const packageRepository of packageDataUrls) {
-    await download(packageRepository, {
-      subDir: 'package',
-      keyText: packageRepository,
-    });
-  }
+async function downloadRepository(instPath: string) {
+  await trpc.packages.downloadRepository.mutate(instPath);
 }
 
 /**


### PR DESCRIPTION
## 概要

Phase 3 Plugins タブのスライス 2(#2318 スタック)。パッケージデータの取得(temp ファイル読み出し + ID 変換 + タイプ判定 + リポジトリダウンロード)を main プロセスへ移設します(#2308 の modList.updateInfo と同じパターン)。

**ベースは #2318 です。#2318 マージ後に main へ retarget + rebase して CI を発火させます。**

## 変更内容

- **`src/main/services/packages.ts` を新設**(挙動は不変):
  - `getPackagesDataUrl`: 設定の取得先 + instPath 直下の packages.json / editorPackages.json(旧 lib/modList.ts から移設)
  - `getIdDict`: convert データによる ID 変換辞書(旧 lib/convertId.ts の update=false 相当)
  - `getPackages`: temp ファイル読み出し → データ v1 互換の ID 変換(旧 parseJson.getPackages 相当)→ `detectPackageTypes`(#2318 の shared)→ PackageItem[]。パースエラー時のダイアログは main の dialog.showMessageBox(文言同一)
  - `downloadRepository`: リポジトリの逐次ダウンロード(electron-dl の並列制限コメントも維持)
- **tRPC に `packages.getPackages` query / `packages.downloadRepository` mutation を追加**(instPath 入力検証付き)
- **renderer 側は tRPC 委譲**: packageUtil.getPackages / downloadRepository の引数が URL リスト → instPath に変わり、package.ts の呼び出し 2 箇所を更新
- lib/modList.ts の getPackagesDataUrl は削除(main へ移設)。getLocalPackagesDataUrl / getEditorPackagesDataUrl は package.ts・EditorContextBridge で使用中のため残置

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(110 件)すべて緑
- macOS で `yarn package` + CDP スモーク: Plugins タブ 4 項目 PASS(一覧 294 件が新 tRPC 経由で描画)+ AviUtl タブ 6 項目 PASS

次: getInstalledFiles / getPackagesExtra の main 移設(または React 一覧の準備)

🤖 Generated with [Claude Code](https://claude.com/claude-code)