### PR TITLE
refactor(package): インストール状態の判定パイプラインを main プロセスへ移設

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -11,7 +11,12 @@ import {
   installCoreProgram,
 } from './services/core';
 import { updateInfo } from './services/modList';
-import { downloadRepository, getPackages } from './services/packages';
+import {
+  downloadRepository,
+  getPackages,
+  getPackagesExtra,
+  getPackagesWithStatus,
+} from './services/packages';
 import { ensureExtraDataUrl, setDataUrls } from './services/settings';
 
 export type Context = {
@@ -58,6 +63,19 @@ const autoUpdateInput = (value: unknown): 'download' | 'notify' | 'disable' => {
   )
     throw new TypeError('One of download, notify, or disable is expected.');
   return value as 'download' | 'notify' | 'disable';
+};
+
+const packagesWithStatusInput = (
+  value: unknown,
+): { instPath: string; fixIntegrity: boolean } => {
+  if (typeof value !== 'object' || value === null)
+    throw new TypeError('An object is expected.');
+  const { instPath, fixIntegrity } = value as Record<string, unknown>;
+  if (typeof instPath !== 'string' || typeof fixIntegrity !== 'boolean')
+    throw new TypeError(
+      'instPath is expected to be a string and fixIntegrity a boolean.',
+    );
+  return { instPath, fixIntegrity };
 };
 
 const installProgramInput = (
@@ -156,6 +174,25 @@ export const router = t.router({
         const win = BrowserWindow.fromWebContents(ctx.event.sender);
         if (!win) throw new Error('The calling window was not found.');
         await downloadRepository(win, getConfig(), input);
+      }),
+    getPackagesExtra: procedure
+      .input(stringInput)
+      .query(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        return await getPackagesExtra(win, getConfig(), input);
+      }),
+    getPackagesWithStatus: procedure
+      .input(packagesWithStatusInput)
+      .query(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        return await getPackagesWithStatus(
+          win,
+          getConfig(),
+          input.instPath,
+          input.fixIntegrity,
+        );
       }),
   }),
   core: t.router({

--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -1,10 +1,19 @@
 import type { Packages } from 'apm-schema';
 import { type BrowserWindow, dialog } from 'electron';
 import log from 'electron-log/main';
-import { existsSync, readJson } from 'fs-extra';
+import { existsSync, readdir as fsReaddir, readJson } from 'fs-extra';
 import path from 'node:path';
+import ApmJson from '../../lib/ApmJson';
 import type Config from '../../lib/Config';
-import { detectPackageTypes } from '../../shared/packageUtil';
+import { checkIntegrity } from '../../shared/integrity';
+import {
+  computePackagesStatus,
+  detectPackageTypes,
+  getInstalledVersionOfPackage,
+  getManuallyInstalledFiles,
+  states,
+} from '../../shared/packageUtil';
+import { ApmJsonObject } from '../../types/apmJson';
 import { PackageItem } from '../../types/packageItem';
 import { downloadFile } from './download';
 import { getConvertDataUrl } from './modList';
@@ -114,6 +123,151 @@ export async function getPackages(
     }
   }
   return packages;
+}
+
+/**
+ * Returns a list of installed files.
+ * 旧 src/renderer/main/packageUtil.ts の getInstalledFiles と同一の挙動。
+ * @param {string} instPath - An installation path
+ * @returns {Promise<string[]>} List of installed files
+ */
+async function getInstalledFiles(instPath: string) {
+  const regex = /^(?!exedit).*\.(auf|aui|auo|auc|aul|anm|obj|cam|tra|scn|lua)$/;
+  const safeReaddir = async (path: string) => {
+    try {
+      return await fsReaddir(path, { withFileTypes: true });
+    } catch (e) {
+      if (e.code === 'ENOENT') return [];
+      log.error(e);
+      throw e;
+    }
+  };
+  // https://zenn.dev/repomn/scraps/d80ccd5c9183f0
+  const asyncFlatMap = async <Item, Res>(
+    arr: Item[],
+    callback: (value: Item, index: number, array: Item[]) => Promise<Res>,
+  ) => {
+    const a = await Promise.all(arr.map(callback));
+    return a.flat();
+  };
+  const readdir = async (dir: string) =>
+    (await safeReaddir(dir))
+      .filter((i) => i.isFile() && regex.test(i.name))
+      .map((i) => i.name);
+  return (await readdir(instPath)).concat(
+    (await readdir(path.join(instPath, 'plugins'))).map((i) => 'plugins/' + i),
+    (await readdir(path.join(instPath, 'script'))).map((i) => 'script/' + i),
+    await asyncFlatMap(
+      (await safeReaddir(path.join(instPath, 'script')))
+        .filter((i) => i.isDirectory())
+        .map((i) => 'script/' + i.name),
+      async (i) =>
+        (await readdir(path.join(instPath, i))).map((j) => i + '/' + j),
+    ),
+  );
+}
+
+/**
+ * Updates the installedVersion of the packages and returns a list of
+ * manually installed files.
+ * 旧 src/renderer/main/packageUtil.ts の getPackagesExtra と同一の挙動
+ * (パッケージ一覧は main 側の getPackages から取得する)。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @returns {Promise<object>} List of manually installed files and packages.
+ */
+export async function getPackagesExtra(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+): Promise<{ manuallyInstalledFiles: string[]; packages: PackageItem[] }> {
+  const packages = await getPackages(win, config, instPath);
+  const apmJson = await ApmJson.load(instPath);
+  const tmpInstalledPackages = (await apmJson.get(
+    'packages',
+  )) as ApmJsonObject['packages'];
+  const tmpInstalledFiles = await getInstalledFiles(instPath);
+  const tmpManuallyInstalledFiles = getManuallyInstalledFiles(
+    tmpInstalledFiles,
+    tmpInstalledPackages,
+    packages,
+  );
+  packages.forEach((p) => {
+    [p.installationStatus, p.version] = getInstalledVersionOfPackage(
+      p,
+      tmpInstalledFiles,
+      tmpManuallyInstalledFiles,
+      tmpInstalledPackages,
+      instPath,
+    );
+  });
+  return {
+    manuallyInstalledFiles: tmpManuallyInstalledFiles,
+    packages: packages,
+  };
+}
+
+/**
+ * Returns the packages with their status (doNotInstall / detached) computed.
+ * 旧 src/renderer/main/package.ts の setPackagesList 前半
+ * (getPackages → getPackagesExtra → 整合性による apm.json 補正 →
+ * getPackagesStatus)と同一の挙動。fixIntegrity = false の場合は
+ * 補正を行わない(旧 installScript の redirect 解決と同一)。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @param {boolean} fixIntegrity - Whether to guess installed packages from integrity.
+ * @returns {Promise<object>} List of manually installed files and packages.
+ */
+export async function getPackagesWithStatus(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+  fixIntegrity: boolean,
+): Promise<{ manuallyInstalledFiles: string[]; packages: PackageItem[] }> {
+  let { manuallyInstalledFiles, packages } = await getPackagesExtra(
+    win,
+    config,
+    instPath,
+  );
+
+  if (fixIntegrity) {
+    // guess which packages are installed from integrity
+    const apmJson = await ApmJson.load(instPath);
+    let modified = false;
+    apmJson.begin();
+    for (const p of packages.filter(
+      (p) =>
+        p.info.releases && p.installationStatus === states.manuallyInstalled,
+    )) {
+      for (const release of p.info.releases) {
+        if (await checkIntegrity(instPath, release.integrity.file)) {
+          await apmJson.addPackage(p.id, release.version);
+          modified = true;
+        }
+      }
+    }
+    await apmJson.commit();
+    if (modified) {
+      const packagesExtraMod = await getPackagesExtra(win, config, instPath);
+      manuallyInstalledFiles = packagesExtraMod.manuallyInstalledFiles;
+      packages = packagesExtraMod.packages;
+    }
+  }
+
+  let aviUtlVer = '';
+  let exeditVer = '';
+  try {
+    const apmJson = await ApmJson.load(instPath);
+    aviUtlVer = (await apmJson.get('core.' + 'aviutl', '')) as string;
+    exeditVer = (await apmJson.get('core.' + 'exedit', '')) as string;
+  } catch (e) {
+    log.info(e);
+  }
+  packages = computePackagesStatus(packages, aviUtlVer, exeditVer);
+
+  return { manuallyInstalledFiles, packages };
 }
 
 /**

--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -300,12 +300,7 @@ async function batchInstall(instPath: string) {
       const progInfo = coreInfo[program];
       await installProgram(null, program, progInfo.latestVersion, instPath);
     }
-    const allPackages = (
-      await packageUtil.getPackagesExtra(
-        await packageMain.getPackages(instPath),
-        instPath,
-      )
-    ).packages;
+    const allPackages = (await packageUtil.getPackagesExtra(instPath)).packages;
     const packages = allPackages.filter(
       (p) =>
         p.info.directURL &&

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -31,7 +31,7 @@ import replaceText from '../../lib/replaceText';
 import createList, { UpdatableList } from '../../lib/updatableList';
 import { compareVersion } from '../../shared/compareVersion';
 import { getHash } from '../../shared/getHash';
-import { checkIntegrity, verifyFile } from '../../shared/integrity';
+import { verifyFile } from '../../shared/integrity';
 import { safeRemove } from '../../shared/safeRemove';
 import unzip from '../../shared/unzip';
 import { PackageItem } from '../../types/packageItem';
@@ -110,8 +110,6 @@ async function setPackagesList(instPath: string) {
     'リンク',
     '依存関係',
   ];
-  let packages = await getPackages(instPath);
-
   // sort-buttons
   if (!packagesSort.hasChildNodes()) {
     const sortButtons = Array.from(columns.entries())
@@ -130,40 +128,14 @@ async function setPackagesList(instPath: string) {
   }
 
   // prepare a package list
+  // 取得 → インストール状態付与 → 整合性による apm.json 補正 → 依存解決は
+  // main プロセス側(services/packages.ts)へ移設済み
+  const packagesExtra = await packageUtil.getPackagesWithStatus(instPath, true);
+  const manuallyInstalledFiles = packagesExtra.manuallyInstalledFiles;
+  const packages = packagesExtra.packages;
 
-  let manuallyInstalledFiles;
-  const packagesExtra = await packageUtil.getPackagesExtra(packages, instPath);
-  manuallyInstalledFiles = packagesExtra.manuallyInstalledFiles;
-  packages = packagesExtra.packages;
-
+  // 検索コールバックが apm.json のコアバージョンを参照するために使う
   const apmJson = await ApmJson.load(instPath);
-
-  // guess which packages are installed from integrity
-  let modified = false;
-  apmJson.begin();
-  for (const p of packages.filter(
-    (p) =>
-      p.info.releases &&
-      p.installationStatus === packageUtil.states.manuallyInstalled,
-  )) {
-    for (const release of p.info.releases) {
-      if (await checkIntegrity(instPath, release.integrity.file)) {
-        await apmJson.addPackage(p.id, release.version);
-        modified = true;
-      }
-    }
-  }
-  await apmJson.commit();
-  if (modified) {
-    const packagesExtraMod = await packageUtil.getPackagesExtra(
-      packages,
-      instPath,
-    );
-    manuallyInstalledFiles = packagesExtraMod.manuallyInstalledFiles;
-    packages = packagesExtraMod.packages;
-  }
-
-  packages = await packageUtil.getPackagesStatus(instPath, packages);
 
   // show the package list
   const makeLiFromArray = (columnList: string[]) => {
@@ -1074,10 +1046,8 @@ async function installScript(instPath: string) {
 
   if ('redirect' in matchInfo) {
     // Determine which of the redirections can be installed and install them.
-    let packages = await getPackages(instPath);
-    packages = (await packageUtil.getPackagesExtra(packages, instPath))
+    const packages = (await packageUtil.getPackagesWithStatus(instPath))
       .packages;
-    packages = await packageUtil.getPackagesStatus(instPath, packages);
     const packageId = matchInfo.redirect
       .split('|')
       .find((candidate: string) =>
@@ -1518,9 +1488,7 @@ async function sharePackages(instPath: string) {
     const currentVersion = (await apmJson.get('core.' + program)) as string;
     ver[program] = currentVersion;
   }
-  ver.packages = (
-    await packageUtil.getPackagesExtra(await getPackages(instPath), instPath)
-  ).packages
+  ver.packages = (await packageUtil.getPackagesExtra(instPath)).packages
     .filter(
       (p) =>
         p.installationStatus === packageUtil.states.installed ||

--- a/src/renderer/main/packageUtil.ts
+++ b/src/renderer/main/packageUtil.ts
@@ -1,16 +1,5 @@
-import log from 'electron-log/renderer';
-import * as fs from 'fs-extra';
-import path from 'node:path';
-import ApmJson from '../../lib/ApmJson';
 import { trpc } from '../../lib/trpcClient';
-import {
-  computePackagesStatus,
-  getInstalledVersionOfPackage,
-  getManuallyInstalledFiles,
-  parsePackageType,
-  states,
-} from '../../shared/packageUtil';
-import { ApmJsonObject } from '../../types/apmJson';
+import { parsePackageType, states } from '../../shared/packageUtil';
 import { PackageItem } from '../../types/packageItem';
 
 // 計算部分(states / parsePackageType / detectPackageTypes /
@@ -38,100 +27,37 @@ async function downloadRepository(instPath: string) {
 }
 
 /**
- * Returns a list of installed files.
+ * Updates the installedVersion of the packages and returns a list of
+ * manually installed files.
+ * 実装は main プロセス側(src/main/services/packages.ts)へ移設済み。
+ * パッケージ一覧は main 側で取得するため引数は instPath のみ。
  * @param {string} instPath - An installation path
- * @returns {string[]} List of installed files
+ * @returns {Promise<object>} List of manually installed files and packages
  */
-async function getInstalledFiles(instPath: string) {
-  const regex = /^(?!exedit).*\.(auf|aui|auo|auc|aul|anm|obj|cam|tra|scn|lua)$/;
-  const safeReaddir = async (path: string) => {
-    try {
-      return await fs.readdir(path, { withFileTypes: true });
-    } catch (e) {
-      if (e.code === 'ENOENT') return [];
-      log.error(e);
-      throw e;
-    }
-  };
-  // https://zenn.dev/repomn/scraps/d80ccd5c9183f0
-  const asyncFlatMap = async <Item, Res>(
-    arr: Item[],
-    callback: (value: Item, index: number, array: Item[]) => Promise<Res>,
-  ) => {
-    const a = await Promise.all(arr.map(callback));
-    return a.flat();
-  };
-  const readdir = async (dir: string) =>
-    (await safeReaddir(dir))
-      .filter((i) => i.isFile() && regex.test(i.name))
-      .map((i) => i.name);
-  return (await readdir(instPath)).concat(
-    (await readdir(path.join(instPath, 'plugins'))).map((i) => 'plugins/' + i),
-    (await readdir(path.join(instPath, 'script'))).map((i) => 'script/' + i),
-    await asyncFlatMap(
-      (await safeReaddir(path.join(instPath, 'script')))
-        .filter((i) => i.isDirectory())
-        .map((i) => 'script/' + i.name),
-      async (i) =>
-        (await readdir(path.join(instPath, i))).map((j) => i + '/' + j),
-    ),
-  );
-}
-
-/**
- * Updates the installedVersion of the packages given as argument and returns a list of manually installed files
- * @param {object[]} _packages - A list of object parsed from packages.json
- * @param {string} instPath - An installation path
- * @returns {object} List of manually installed files
- */
-async function getPackagesExtra(_packages: PackageItem[], instPath: string) {
-  const packages = [..._packages].map((p) => {
-    return { ...p };
-  });
-  const apmJson = await ApmJson.load(instPath);
-  const tmpInstalledPackages = (await apmJson.get(
-    'packages',
-  )) as ApmJsonObject['packages'];
-  const tmpInstalledFiles = await getInstalledFiles(instPath);
-  const tmpManuallyInstalledFiles = getManuallyInstalledFiles(
-    tmpInstalledFiles,
-    tmpInstalledPackages,
-    packages,
-  );
-  packages.forEach((p) => {
-    [p.installationStatus, p.version] = getInstalledVersionOfPackage(
-      p,
-      tmpInstalledFiles,
-      tmpManuallyInstalledFiles,
-      tmpInstalledPackages,
-      instPath,
-    );
-  });
-  return {
-    manuallyInstalledFiles: tmpManuallyInstalledFiles,
-    packages: packages,
+async function getPackagesExtra(instPath: string) {
+  // tRPC の Serialize 型はプロパティを optional 化するため元の型に戻す
+  return (await trpc.packages.getPackagesExtra.query(instPath)) as {
+    manuallyInstalledFiles: string[];
+    packages: PackageItem[];
   };
 }
 
 /**
- * Updates the installedVersion of the packages given as argument and returns a list of manually installed files
+ * Returns the packages with their status (doNotInstall / detached) computed.
+ * 実装は main プロセス側(src/main/services/packages.ts)へ移設済み。
  * @param {string} instPath - An installation path
- * @param {object[]} _packages - A list of object parsed from packages.json and getPackagesExtra()
- * @returns {object[]} - packages
+ * @param {boolean} fixIntegrity - Whether to guess installed packages from integrity
+ * @returns {Promise<object>} List of manually installed files and packages
  */
-async function getPackagesStatus(instPath: string, _packages: PackageItem[]) {
-  let aviUtlVer = '';
-  let exeditVer = '';
-  try {
-    const apmJson = await ApmJson.load(instPath);
-    aviUtlVer = (await apmJson.get('core.' + 'aviutl', '')) as string;
-    exeditVer = (await apmJson.get('core.' + 'exedit', '')) as string;
-  } catch (e) {
-    log.info(e);
-  }
-
-  // 依存関係・競合の解決は shared/packageUtil.ts へ移設済み
-  return computePackagesStatus(_packages, aviUtlVer, exeditVer);
+async function getPackagesWithStatus(instPath: string, fixIntegrity = false) {
+  // tRPC の Serialize 型はプロパティを optional 化するため元の型に戻す
+  return (await trpc.packages.getPackagesWithStatus.query({
+    instPath,
+    fixIntegrity,
+  })) as {
+    manuallyInstalledFiles: string[];
+    packages: PackageItem[];
+  };
 }
 
 const packageUtil = {
@@ -140,6 +66,6 @@ const packageUtil = {
   getPackages,
   downloadRepository,
   getPackagesExtra,
-  getPackagesStatus,
+  getPackagesWithStatus,
 };
 export default packageUtil;


### PR DESCRIPTION
## 概要

Phase 3 Plugins タブのスライス 3(#2319 スタック)。パッケージのインストール状態判定パイプライン(installed files 走査 → 状態付与 → 整合性による apm.json 補正 → 依存解決)を main プロセスへ移設します。

**ベースは #2319 です。ベースのマージ後に main へ retarget + rebase して CI を発火させます。**

## 変更内容

- **`services/packages.ts` に 3 関数を追加**(挙動は不変):
  - `getInstalledFiles`: instPath 配下の導入ファイル走査(旧 renderer packageUtil から移設)
  - `getPackagesExtra`: インストール状態・バージョンの付与。**パッケージ一覧は main 側の getPackages から取得するため引数は instPath のみ**(全呼び出し元が `getPackages(instPath)` の新鮮な結果を渡していたことを確認済み)
  - `getPackagesWithStatus(instPath, fixIntegrity)`: 旧 setPackagesList 前半と同一(fixIntegrity=true で整合性からのインストール済み推定 + apm.json 補正)。fixIntegrity=false は旧 installScript の redirect 解決経路と同一
- **tRPC に `packages.getPackagesExtra` / `packages.getPackagesWithStatus` query を追加**
- **renderer の呼び出し 4 箇所を更新**: setPackagesList(整合性補正ループごと置換。検索コールバックが使う apmJson 変数は残置)/ installScript / displayNicommonsIdList / core.ts batchInstall
- これで **Plugins タブの一覧データはワンクエリで main から取得できる状態**になり、React 化の準備が整いました

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(110 件)すべて緑
- macOS で `yarn package` + CDP スモーク: Plugins タブ 4 項目 + AviUtl タブ 6 項目 すべて PASS

次: installPackage / uninstallPackage の main 化、または Plugins タブ React 一覧

🤖 Generated with [Claude Code](https://claude.com/claude-code)