### PR TITLE
refactor(package): installScript の計算部分を main プロセスへ移設

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -17,6 +17,7 @@ import {
   getPackagesExtra,
   getPackagesWithStatus,
   installPackageArchive,
+  installScriptArchive,
   uninstallPackageFiles,
 } from './services/packages';
 import { ensureExtraDataUrl, setDataUrls } from './services/settings';
@@ -108,6 +109,60 @@ const uninstallPackageInput = (
   if (typeof instPath !== 'string')
     throw new TypeError('instPath is expected to be a string.');
   return { instPath, packageItem: packageItemInput(packageItem) };
+};
+
+const installScriptInput = (
+  value: unknown,
+): {
+  instPath: string;
+  archivePath: string;
+  url: string;
+  matchInfo: { folder: string; developer?: string; dependencies?: string[] };
+} => {
+  if (typeof value !== 'object' || value === null)
+    throw new TypeError('An object is expected.');
+  const { instPath, archivePath, url, matchInfo } = value as Record<
+    string,
+    unknown
+  >;
+  if (
+    typeof instPath !== 'string' ||
+    typeof archivePath !== 'string' ||
+    typeof url !== 'string'
+  )
+    throw new TypeError(
+      'instPath, archivePath, and url are expected to be strings.',
+    );
+  if (typeof matchInfo !== 'object' || matchInfo === null)
+    throw new TypeError('matchInfo is expected to be an object.');
+  const { folder, developer, dependencies } = matchInfo as Record<
+    string,
+    unknown
+  >;
+  if (typeof folder !== 'string')
+    throw new TypeError('matchInfo.folder is expected to be a string.');
+  if (developer !== undefined && typeof developer !== 'string')
+    throw new TypeError('matchInfo.developer is expected to be a string.');
+  if (
+    dependencies !== undefined &&
+    !(
+      Array.isArray(dependencies) &&
+      dependencies.every((d) => typeof d === 'string')
+    )
+  )
+    throw new TypeError(
+      'matchInfo.dependencies is expected to be an array of strings.',
+    );
+  return {
+    instPath,
+    archivePath,
+    url,
+    matchInfo: {
+      folder,
+      developer: developer as string | undefined,
+      dependencies: dependencies as string[] | undefined,
+    },
+  };
 };
 
 const packagesWithStatusInput = (
@@ -254,6 +309,20 @@ export const router = t.router({
         return await uninstallPackageFiles(
           input.instPath,
           input.packageItem as Parameters<typeof uninstallPackageFiles>[1],
+        );
+      }),
+    installScriptArchive: procedure
+      .input(installScriptInput)
+      .mutation(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        return await installScriptArchive(
+          win,
+          getConfig(),
+          input.instPath,
+          input.archivePath,
+          input.url,
+          input.matchInfo,
         );
       }),
   }),

--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -2,16 +2,21 @@ import type { Packages } from 'apm-schema';
 import { type BrowserWindow, dialog } from 'electron';
 import log from 'electron-log/main';
 import {
+  copy,
   existsSync,
   readdir as fsReaddir,
   mkdir,
   readJson,
   rename,
+  rm,
+  writeJson,
 } from 'fs-extra';
+import * as matcher from 'matcher';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import ApmJson from '../../lib/ApmJson';
 import type Config from '../../lib/Config';
+import { getHash } from '../../shared/getHash';
 import { install, verifyFilesByCount } from '../../shared/install';
 import { checkIntegrity } from '../../shared/integrity';
 import {
@@ -449,4 +454,210 @@ export async function uninstallPackageFiles(
   const apmJson = await ApmJson.load(instPath);
   await apmJson.removePackage(packageItem.id);
   return filesCount === notExistCount ? 'success' : 'filesRemain';
+}
+
+// To avoid a bug in the library
+// https://github.com/sindresorhus/matcher/issues/32
+const isMatch = (
+  input: string | readonly string[],
+  pattern: readonly string[],
+) => pattern.some((p) => matcher.isMatch(input, p));
+
+export type InstallScriptResult =
+  | 'success'
+  | 'noScript'
+  | 'containsPlugin'
+  | 'installFailed';
+
+/**
+ * Unzips the downloaded script archive, verifies and copies the script files,
+ * and records the generated package in the local packages.json and apm.json.
+ * 旧 src/renderer/main/package.ts の installScript 後半
+ * (展開 → スクリプト有無の検証 → 配置 → パッケージ情報の生成と保存)と
+ * 同一の挙動。ローカル packages.json への追記は旧 parseJson.addPackage 相当
+ * (データ v1 互換の ID 変換込み)。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @param {string} archivePath - Path to the downloaded archive.
+ * @param {string} url - The URL of the script distribution page.
+ * @param {object} matchInfo - The matched script information.
+ * @param {string} matchInfo.folder - A folder name to copy the scripts into.
+ * @param {string} [matchInfo.developer] - The developer of the script.
+ * @param {string[]} [matchInfo.dependencies] - Dependencies of the script.
+ * @returns {Promise<InstallScriptResult>} The result of the installation.
+ */
+export async function installScriptArchive(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+  archivePath: string,
+  url: string,
+  matchInfo: { folder: string; developer?: string; dependencies?: string[] },
+): Promise<InstallScriptResult> {
+  const pluginExtRegex = /\.(auf|aui|auo|auc|aul)$/;
+  const scriptExtRegex = /\.(anm|obj|cam|tra|scn)$/;
+
+  // https://zenn.dev/repomn/scraps/d80ccd5c9183f0
+  const asyncFlatMap = async <Item, Res>(
+    arr: Item[],
+    callback: (value: Item, index: number, array: Item[]) => Promise<Res>,
+  ) => {
+    const a = await Promise.all(arr.map(callback));
+    return a.flat();
+  };
+
+  const searchScriptRoot = async (dirName: string): Promise<string[]> => {
+    const dirents = await fsReaddir(dirName, {
+      withFileTypes: true,
+    });
+    return dirents.find((i) => i.isFile() && scriptExtRegex.test(i.name))
+      ? [dirName]
+      : await asyncFlatMap(
+          dirents.filter((i) => i.isDirectory()),
+          (i) => searchScriptRoot(path.join(dirName, i.name)),
+        );
+  };
+
+  const extExists = async (
+    dirName: string,
+    regex: RegExp,
+  ): Promise<boolean> => {
+    const dirents = await fsReaddir(dirName, {
+      withFileTypes: true,
+    });
+    return dirents.filter((i) => i.isFile() && regex.test(i.name)).length > 0
+      ? true
+      : (
+          await asyncFlatMap(
+            dirents.filter((i) => i.isDirectory()),
+            (i) => extExists(path.join(dirName, i.name), regex),
+          )
+        ).some((e) => e);
+  };
+
+  try {
+    const getUnzippedPath = async () => {
+      if (['.zip', '.lzh', '.7z', '.rar'].includes(path.extname(archivePath))) {
+        return await unzip(archivePath);
+      } else {
+        // In this line, path.dirname(archivePath) always refers to the 'Data/package' folder.
+        const newFolder = path.join(
+          path.dirname(archivePath),
+          'tmp_' + path.basename(archivePath),
+        );
+        await mkdir(newFolder, { recursive: true });
+        await rename(
+          archivePath,
+          path.join(newFolder, path.basename(archivePath)),
+        );
+        return newFolder;
+      }
+    };
+    const unzippedPath = await getUnzippedPath();
+
+    if (!(await extExists(unzippedPath, scriptExtRegex))) {
+      log.error('No script files are included.');
+      return 'noScript';
+    }
+    if (await extExists(unzippedPath, pluginExtRegex)) {
+      log.error('Plugin files are included.');
+      return 'containsPlugin';
+    }
+
+    // Copying files
+    const denyList = [
+      '*readme*',
+      '*copyright*',
+      '*.txt',
+      '*.zip',
+      '*.aup',
+      '*.md',
+      'doc',
+      'old',
+      'old_*',
+    ];
+    const scriptRoot = (await searchScriptRoot(unzippedPath))[0];
+    const entriesToCopy = (
+      await fsReaddir(scriptRoot, {
+        withFileTypes: true,
+      })
+    )
+      .filter((p) => !isMatch([p.name], denyList))
+      .map((p) => {
+        return {
+          src: path.join(scriptRoot, p.name),
+          dest: path.join(instPath, 'script', matchInfo.folder, p.name),
+          filename: path
+            .join('script', matchInfo.folder, p.name)
+            .replaceAll('\\', '/'),
+          isDirectory: p.isDirectory(),
+        };
+      });
+    await mkdir(path.join(instPath, 'script', matchInfo.folder), {
+      recursive: true,
+    });
+    await Promise.all(
+      entriesToCopy.map((filePath) => copy(filePath.src, filePath.dest)),
+    );
+
+    // Constructing package information
+    const files = entriesToCopy.map((i) => {
+      return { filename: i.filename, isDirectory: i.isDirectory };
+    });
+
+    const filteredFiles = files.filter((f) => scriptExtRegex.test(f.filename));
+    const name = path.basename(
+      filteredFiles[0].filename,
+      path.extname(filteredFiles[0].filename),
+    );
+    const id = 'script_' + getHash(name);
+
+    // Rename the extracted folder
+    const newPath = path.join(path.dirname(unzippedPath), id);
+    if (existsSync(newPath)) await rm(newPath, { recursive: true });
+    await rename(unzippedPath, newPath);
+
+    // Save package information
+    const packageItem = {
+      id: id,
+      name: name,
+      overview: 'スクリプト',
+      description:
+        'スクリプト一覧: ' +
+        filteredFiles.map((f) => path.basename(f.filename)).join(', '),
+      developer: matchInfo?.developer ?? '-',
+      dependencies: matchInfo?.dependencies,
+      pageURL: url,
+      downloadURLs: [url] as [string, ...string[]],
+      latestVersion: getDate(),
+      files: files,
+    };
+
+    // 旧 parseJson.addPackage と同一の挙動(既存一覧の ID 変換込み)
+    const localPackagesPath = path.join(instPath, 'packages.json');
+    const localPackages: Packages['packages'] = existsSync(localPackagesPath)
+      ? ((await readJson(localPackagesPath)) as Packages).packages
+      : [];
+    const convDict = await getIdDict(win, config);
+    for (const localPackage of localPackages) {
+      // For compatibility with data v1
+      if (Object.prototype.hasOwnProperty.call(convDict, localPackage.id)) {
+        localPackage.id = convDict[localPackage.id];
+      }
+    }
+    const newLocalPackages = localPackages.filter((p) => p.id !== id);
+    newLocalPackages.push(packageItem as Packages['packages'][number]);
+    await writeJson(localPackagesPath, {
+      version: 3,
+      packages: newLocalPackages,
+    });
+
+    const apmJson = await ApmJson.load(instPath);
+    await apmJson.addPackage(packageItem.id, packageItem.latestVersion);
+    return 'success';
+  } catch (e) {
+    log.error(e);
+    return 'installFailed';
+  }
 }

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -1,17 +1,8 @@
 import { Scripts } from 'apm-schema';
 import log from 'electron-log/renderer';
-import {
-  copy,
-  existsSync,
-  mkdir,
-  readdir,
-  readJson,
-  rename,
-  rm,
-} from 'fs-extra';
+import { readJson } from 'fs-extra';
 import { ListItem } from 'list.js';
 import * as matcher from 'matcher';
-import path from 'node:path';
 import ApmJson from '../../lib/ApmJson';
 import * as buttonTransition from '../../lib/buttonTransition';
 import { getConfig } from '../../lib/Config';
@@ -30,9 +21,7 @@ import replaceText from '../../lib/replaceText';
 import { trpc } from '../../lib/trpcClient';
 import createList, { UpdatableList } from '../../lib/updatableList';
 import { compareVersion } from '../../shared/compareVersion';
-import { getHash } from '../../shared/getHash';
 import { verifyFile } from '../../shared/integrity';
-import unzip from '../../shared/unzip';
 import { PackageItem } from '../../types/packageItem';
 import { programs, programsDisp } from './common';
 import packageUtil from './packageUtil';
@@ -51,18 +40,6 @@ let selectedEntryType: string;
 const entryType = { package: 'package', scriptSite: 'script' };
 let listJS: UpdatableList;
 const shareStringVersion = '1.0';
-
-/**
- * Get the date today
- * @returns {string} Today's date
- */
-function getDate() {
-  const d = new Date();
-  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(
-    2,
-    '0',
-  )}/${String(d.getDate()).padStart(2, '0')}`;
-}
 
 // Functions to be exported
 
@@ -997,168 +974,39 @@ async function installScript(instPath: string) {
     return;
   }
 
-  const pluginExtRegex = /\.(auf|aui|auo|auc|aul)$/;
-  const scriptExtRegex = /\.(anm|obj|cam|tra|scn)$/;
-
-  // https://zenn.dev/repomn/scraps/d80ccd5c9183f0
-  const asyncFlatMap = async <Item, Res>(
-    arr: Item[],
-    callback: (value: Item, index: number, array: Item[]) => Promise<Res>,
-  ) => {
-    const a = await Promise.all(arr.map(callback));
-    return a.flat();
-  };
-
-  const searchScriptRoot = async (dirName: string): Promise<string[]> => {
-    const dirents = await readdir(dirName, {
-      withFileTypes: true,
-    });
-    return dirents.find((i) => i.isFile() && scriptExtRegex.test(i.name))
-      ? [dirName]
-      : await asyncFlatMap(
-          dirents.filter((i) => i.isDirectory()),
-          (i) => searchScriptRoot(path.join(dirName, i.name)),
-        );
-  };
-
-  const extExists = async (
-    dirName: string,
-    regex: RegExp,
-  ): Promise<boolean> => {
-    const dirents = await readdir(dirName, {
-      withFileTypes: true,
-    });
-    return dirents.filter((i) => i.isFile() && regex.test(i.name)).length > 0
-      ? true
-      : (
-          await asyncFlatMap(
-            dirents.filter((i) => i.isDirectory()),
-            (i) => extExists(path.join(dirName, i.name), regex),
-          )
-        ).some((e) => e);
-  };
-
+  // 展開 → スクリプト検証 → 配置 → パッケージ情報の生成と保存は
+  // main プロセス側(services/packages.ts)へ移設済み
+  let result: Awaited<
+    ReturnType<typeof trpc.packages.installScriptArchive.mutate>
+  >;
   try {
-    const getUnzippedPath = async () => {
-      if (['.zip', '.lzh', '.7z', '.rar'].includes(path.extname(archivePath))) {
-        return await unzip(archivePath);
-      } else {
-        // In this line, path.dirname(archivePath) always refers to the 'Data/package' folder.
-        const newFolder = path.join(
-          path.dirname(archivePath),
-          'tmp_' + path.basename(archivePath),
-        );
-        await mkdir(newFolder, { recursive: true });
-        await rename(
-          archivePath,
-          path.join(newFolder, path.basename(archivePath)),
-        );
-        return newFolder;
-      }
-    };
-    const unzippedPath = await getUnzippedPath();
-
-    if (!(await extExists(unzippedPath, scriptExtRegex))) {
-      log.error('No script files are included.');
-      buttonTransition.message(btn, 'スクリプトが含まれていません。', 'danger');
-      setTimeout(() => {
-        enableButton();
-      }, 3000);
-      return;
-    }
-    if (await extExists(unzippedPath, pluginExtRegex)) {
-      log.error('Plugin files are included.');
-      buttonTransition.message(
-        btn,
-        'プラグインが含まれているためインストールできません。',
-        'danger',
-      );
-      setTimeout(() => {
-        enableButton();
-      }, 3000);
-      return;
-    }
-
-    // Copying files
-    const denyList = [
-      '*readme*',
-      '*copyright*',
-      '*.txt',
-      '*.zip',
-      '*.aup',
-      '*.md',
-      'doc',
-      'old',
-      'old_*',
-    ];
-    const scriptRoot = (await searchScriptRoot(unzippedPath))[0];
-    const entriesToCopy = (
-      await readdir(scriptRoot, {
-        withFileTypes: true,
-      })
-    )
-      .filter((p) => !isMatch([p.name], denyList))
-      .map((p) => {
-        return {
-          src: path.join(scriptRoot, p.name),
-          dest: path.join(instPath, 'script', matchInfo.folder, p.name),
-          filename: path
-            .join('script', matchInfo.folder, p.name)
-            .replaceAll('\\', '/'),
-          isDirectory: p.isDirectory(),
-        };
-      });
-    await mkdir(path.join(instPath, 'script', matchInfo.folder), {
-      recursive: true,
+    result = await trpc.packages.installScriptArchive.mutate({
+      instPath,
+      archivePath,
+      url,
+      matchInfo: {
+        folder: matchInfo.folder,
+        developer: matchInfo.developer,
+        dependencies: matchInfo.dependencies,
+      },
     });
-    await Promise.all(
-      entriesToCopy.map((filePath) => copy(filePath.src, filePath.dest)),
-    );
-
-    // Constructing package information
-    const files = entriesToCopy.map((i) => {
-      return { filename: i.filename, isDirectory: i.isDirectory };
-    });
-
-    const filteredFiles = files.filter((f) => scriptExtRegex.test(f.filename));
-    const name = path.basename(
-      filteredFiles[0].filename,
-      path.extname(filteredFiles[0].filename),
-    );
-    const id = 'script_' + getHash(name);
-
-    // Rename the extracted folder
-    const newPath = path.join(path.dirname(unzippedPath), id);
-    if (existsSync(newPath)) await rm(newPath, { recursive: true });
-    await rename(unzippedPath, newPath);
-
-    // Save package information
-    const packageItem = {
-      id: id,
-      name: name,
-      overview: 'スクリプト',
-      description:
-        'スクリプト一覧: ' +
-        filteredFiles.map((f) => path.basename(f.filename)).join(', '),
-      developer: matchInfo?.developer ?? '-',
-      dependencies: matchInfo?.dependencies,
-      pageURL: url,
-      downloadURLs: [url] as [string, ...string[]],
-      latestVersion: getDate(),
-      files: files,
-    };
-
-    await parseJson.addPackage(
-      modList.getLocalPackagesDataUrl(instPath),
-      packageItem,
-    );
-    const apmJson = await ApmJson.load(instPath);
-    await apmJson.addPackage(packageItem.id, packageItem.latestVersion);
-    await checkPackagesList(instPath);
-
-    buttonTransition.message(btn, 'インストール完了', 'success');
   } catch (e) {
     log.error(e);
+    result = 'installFailed';
+  }
+
+  if (result === 'noScript') {
+    buttonTransition.message(btn, 'スクリプトが含まれていません。', 'danger');
+  } else if (result === 'containsPlugin') {
+    buttonTransition.message(
+      btn,
+      'プラグインが含まれているためインストールできません。',
+      'danger',
+    );
+  } else if (result === 'success') {
+    await checkPackagesList(instPath);
+    buttonTransition.message(btn, 'インストール完了', 'success');
+  } else {
     buttonTransition.message(btn, 'エラーが発生しました。', 'danger');
   }
 


### PR DESCRIPTION
## 概要

Phase 3 Plugins タブのスライス 5。#2321(installPackage / uninstallPackage)に続き、スクリプト配布サイトからのインストール(installScript)の計算部分を main プロセスへ移設します。

## 変更内容

- **`services/packages.ts` に `installScriptArchive` を追加**(挙動は不変):
  - 展開(zip/lzh/7z/rar 以外は tmp_ フォルダへ移動)
  - スクリプト有無の検証: スクリプト拡張子なし → `'noScript'`、プラグイン拡張子あり → `'containsPlugin'`
  - denyList(readme 等)を除いた `script/<folder>` への配置
  - パッケージ情報の生成(`script_<hash>` ID・インストール日をバージョンに)と展開フォルダのリネーム
  - **ローカル packages.json への追記は旧 `parseJson.addPackage` 相当を main 側で再実装**(parseJson は convertId → ipcWrapper の renderer 専用連鎖を含むため。#2308・#2319 と同じ判断。データ v1 互換の ID 変換込み)
  - apm.json への記録
- **tRPC に `packages.installScriptArchive` mutation を追加**(matchInfo.folder 必須の入力検証付き)
- **renderer 残留**: openBrowser ダウンロード・scripts.json からの matchInfo 解決・redirect 分岐(installPackage 呼び出し)・ボタン遷移・checkPackagesList 再描画
- 不要になった unzip / getHash / getDate / path / fs 系の import を整理

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(110 件)すべて緑
- macOS で `yarn package` + CDP スモーク: Plugins タブ 4 項目 + AviUtl タブ 6 項目 PASS
- スクリプトインストールの実走はブラウザ操作依存のため、配置・検証ロジックは移設元と行単位で同一(コードレビューで対照可能)

これで package.ts の fs / 展開系処理はすべて main に移り、残る renderer ロジックは UI オーケストレーション(一覧描画・選択状態・ボタン遷移・共有文字列)になりました。次: Plugins タブの React 化(一覧 → 詳細・アクションの順で分割予定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)