### PR TITLE
refactor(packages): getScriptsList を main プロセスへ移設

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,4 +56,5 @@ PR 前に上記 3 つ(lint / lint:ts / test)がすべて緑であること。
 
 - `src/lib/compareVersion.ts` の `compareVersion` は比較不能時に `Number.NaN` を返す。NaN は全比較演算子で false になるため、呼び出し側は必ず `Number.isNaN()` で先に分岐する(`!== 0` 形式の分岐は意味が反転する)
 - `src/renderer/main/preload.ts` はビジネスロジックそのもの(`sandbox: false` 前提)。タブの React 化 = そのタブのロジックを main プロセス + tRPC へ移設する作業
+- electron-trpc は falsy なトップレベル入力(`false` / `0` / `''`)を `undefined` に変換する(main ハンドラが `input: g ? deserialize(g) : void 0` と真偽値評価しているため)。tRPC procedure の入力にプリミティブの boolean / number を直接渡さず、必ずオブジェクトで包む(`{ update: boolean }` 等)
 - `monaco-editor` は**型のみ**インポートする(`import type`)。実行時の Monaco は `@monaco-editor/loader` が CDN から読み込む。値インポートすると webpack が Monaco 全体をバンドルし、ビルドにヒープ拡大(`--max-old-space-size`)が必要になる。enum 値は onMount で渡される `monaco` インスタンスから取る

--- a/src/lib/modList.ts
+++ b/src/lib/modList.ts
@@ -78,12 +78,4 @@ export async function getConvertDataUrl() {
   return resolvePath(getDataUrl(), (await getInfo()).convert.path);
 }
 
-/**
- * Returns a scripts data file URL.
- * @returns {string[]} - A scripts data file URL.
- */
-export async function getScriptsDataUrl() {
-  return (await getInfo()).scripts.map((script) =>
-    resolvePath(getDataUrl(), script.path),
-  );
-}
+// getScriptsDataUrl は main プロセス側(src/main/services/modList.ts)へ移設済み

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -16,6 +16,7 @@ import {
   getPackages,
   getPackagesExtra,
   getPackagesWithStatus,
+  getScriptsList,
   installPackageArchive,
   installScriptArchive,
   uninstallPackageFiles,
@@ -43,6 +44,17 @@ const procedure = t.procedure;
 const stringInput = (value: unknown): string => {
   if (typeof value !== 'string') throw new TypeError('A string is expected.');
   return value;
+};
+
+// electron-trpc は falsy なトップレベル入力(false / 0 / '')を undefined に
+// 変換してしまうため、boolean はオブジェクトで包んで受け取る
+const scriptsListInput = (value: unknown): { update: boolean } => {
+  if (typeof value !== 'object' || value === null)
+    throw new TypeError('An object is expected.');
+  const { update } = value as Record<string, unknown>;
+  if (typeof update !== 'boolean')
+    throw new TypeError('update is expected to be a boolean.');
+  return { update };
 };
 
 const dataUrlsInput = (
@@ -281,6 +293,13 @@ export const router = t.router({
         const win = BrowserWindow.fromWebContents(ctx.event.sender);
         if (!win) throw new Error('The calling window was not found.');
         return await getPackagesExtra(win, getConfig(), input);
+      }),
+    getScriptsList: procedure
+      .input(scriptsListInput)
+      .query(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        return await getScriptsList(win, getConfig(), input.update);
       }),
     getPackagesWithStatus: procedure
       .input(packagesWithStatusInput)

--- a/src/main/services/modList.ts
+++ b/src/main/services/modList.ts
@@ -77,3 +77,17 @@ export async function getConvertDataUrl(win: BrowserWindow, config: Config) {
   const info = await getInfo(win, config);
   return resolvePath(config.dataURL.getMain(), info.convert.path);
 }
+
+/**
+ * Returns scripts data file URLs.
+ * 旧 src/lib/modList.ts の getScriptsDataUrl と同一の挙動。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @returns {Promise<string[]>} Scripts data file URLs.
+ */
+export async function getScriptsDataUrl(win: BrowserWindow, config: Config) {
+  const info = await getInfo(win, config);
+  return info.scripts.map((script) =>
+    resolvePath(config.dataURL.getMain(), script.path),
+  );
+}

--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -1,4 +1,4 @@
-import type { Packages } from 'apm-schema';
+import type { Packages, Scripts } from 'apm-schema';
 import { type BrowserWindow, dialog } from 'electron';
 import log from 'electron-log/main';
 import {
@@ -31,7 +31,7 @@ import unzip from '../../shared/unzip';
 import { ApmJsonObject } from '../../types/apmJson';
 import { PackageItem } from '../../types/packageItem';
 import { downloadFile } from './download';
-import { getConvertDataUrl } from './modList';
+import { getConvertDataUrl, getInfo, getScriptsDataUrl } from './modList';
 import { existsTempFile } from './tempFile';
 
 /**
@@ -304,6 +304,49 @@ export async function downloadRepository(
       keyText: packageRepository,
     });
   }
+}
+
+/**
+ * Returns an object parsed from scripts.json.
+ * 旧 src/renderer/main/package.ts の getScriptsList と同一の挙動。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @param {boolean} update - Download the json file.
+ * @returns {Promise<{webpage: Scripts['webpage']; scripts: Scripts['scripts']}>} An object parsed from scripts.json.
+ */
+export async function getScriptsList(
+  win: BrowserWindow,
+  config: Config,
+  update: boolean,
+) {
+  const dictUrl = await getScriptsDataUrl(win, config);
+  const result: { webpage: Scripts['webpage']; scripts: Scripts['scripts'] } = {
+    webpage: [],
+    scripts: [],
+  };
+
+  for (const url of dictUrl) {
+    const scriptsJson = await downloadFile(win, url, {
+      loadCache: !update,
+      subDir: 'package',
+      keyText: url,
+    });
+    if (!scriptsJson) continue;
+    const json: Scripts = await readJson(scriptsJson);
+    result.webpage = result.webpage.concat(json.webpage);
+    result.scripts = result.scripts.concat(json.scripts);
+  }
+
+  if (update) {
+    const currentMod = await getInfo(win, config);
+    config.modDate.setScripts(
+      Math.max(
+        ...currentMod.scripts.map((p) => new Date(p.modified).getTime()),
+      ),
+    );
+  }
+
+  return result;
 }
 
 /**

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -1,6 +1,5 @@
 import { Scripts } from 'apm-schema';
 import log from 'electron-log/renderer';
-import { readJson } from 'fs-extra';
 import { ListItem } from 'list.js';
 import * as matcher from 'matcher';
 import ApmJson from '../../lib/ApmJson';
@@ -482,38 +481,15 @@ async function checkPackagesList(instPath: string) {
 
 /**
  * Checks the scripts list.
+ * 取得・キャッシュ・更新日時の記録は main プロセス側(services/packages.ts)へ移設済み。
  * @param {boolean} update - Download the json file.
  * @returns {Promise<Scripts>} - An object parsed from scripts.json.
  */
 async function getScriptsList(update = false) {
-  const dictUrl = await modList.getScriptsDataUrl();
-  const result: { webpage: Scripts['webpage']; scripts: Scripts['scripts'] } = {
-    webpage: [],
-    scripts: [],
+  return (await trpc.packages.getScriptsList.query({ update })) as {
+    webpage: Scripts['webpage'];
+    scripts: Scripts['scripts'];
   };
-
-  for (const url of dictUrl) {
-    const scriptsJson = await download(url, {
-      loadCache: !update,
-      subDir: 'package',
-      keyText: url,
-    });
-    if (!scriptsJson) continue;
-    const json: Scripts = await readJson(scriptsJson);
-    result.webpage = result.webpage.concat(json.webpage);
-    result.scripts = result.scripts.concat(json.scripts);
-  }
-
-  if (update) {
-    const currentMod = await modList.getInfo();
-    config.modDate.setScripts(
-      Math.max(
-        ...currentMod.scripts.map((p) => new Date(p.modified).getTime()),
-      ),
-    );
-  }
-
-  return result;
 }
 
 /**


### PR DESCRIPTION
## 概要

Plugins タブ React 化の前提整備として、scripts.json の取得を main プロセスへ移設します(#2322 スタック)。

- `services/packages.ts` に `getScriptsList(win, config, update)` を追加(取得・キャッシュ・`modDate.setScripts` の記録まで旧 renderer 実装と同一挙動)
- `services/modList.ts` に `getScriptsDataUrl` を追加(lib 版から移設)
- tRPC `packages.getScriptsList` query を公開。renderer の `getScriptsList` は委譲のみに縮小
- `lib/modList.ts` の `getScriptsDataUrl` を削除(唯一の利用元が移設済みのため)

React 化する一覧はメインワールド(Node API 不可)で動くため、スクリプト配布サイト行のデータ取得を tRPC 経由にしておく必要があります。

## 知見(AGENTS.md に追記済み)

electron-trpc は falsy なトップレベル入力(`false` / `0` / `''`)を `undefined` に変換します(main ハンドラが `input: g ? deserialize(g) : void 0` と真偽値評価しているため)。素の boolean 入力で起動時エラーになったため、入力は `{ update: boolean }` オブジェクトで包んでいます。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(110 件)すべて緑
- `yarn package` + CDP スモーク: AviUtl タブ 6 項目・Plugins タブ 4 項目(一覧 294 件・スクリプト配布サイト行含む)ALL PASS

## 注意

#2322 マージ済みのため main ベースです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
