### PR TITLE
feat(nicommons): ニコニ・コモンズ ID 一覧を React コンポーネント化

### DIFF
--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -9,7 +9,6 @@ export const IPC_CHANNELS = {
   OPEN_DIR_DIALOG: 'open-dir-dialog',
   OPEN_DIALOG: 'open-dialog',
   OPEN_YES_NO_DIALOG: 'open-yes-no-dialog',
-  GET_NICOMMONS_DATA: 'get-nicommons-data',
   CLIPBOARD_WRITE_TEXT: 'clipboard-write-text',
   MIGRATION1TO2_CONFIRM_DIALOG: 'migration1to2-confirm-dialog',
   MIGRATION1TO2_DATAURL_INPUT_DIALOG: 'migration1to2-dataurl-input-dialog',

--- a/src/lib/ipcWrapper.ts
+++ b/src/lib/ipcWrapper.ts
@@ -135,18 +135,6 @@ export async function openYesNoDialog(title: string, message: string) {
 }
 
 /**
- * Gets nicommons' data.
- * @param {string} id - A nicommons ID.
- * @returns {Promise<unknown>} The nicommons data.
- */
-export async function getNicommonsData(id: string) {
-  return (await ipcRenderer.invoke(
-    IPC_CHANNELS.GET_NICOMMONS_DATA,
-    id,
-  )) as unknown;
-}
-
-/**
  * Opens the confirm dialog for migration v1 to v2.
  * @returns {Promise<number>} The result of the dialog.
  */

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -12,8 +12,10 @@ import {
   installCoreProgram,
 } from './services/core';
 import { updateInfo } from './services/modList';
+import { getNicommonsData } from './services/nicommons';
 import {
   downloadRepository,
+  getApmJsonInstalledIds,
   getPackages,
   getPackagesExtra,
   getPackagesWithStatus,
@@ -178,6 +180,19 @@ const installScriptInput = (
   };
 };
 
+const installedIdsInput = (
+  value: unknown,
+): { instPath: string; ids: string[] } => {
+  if (typeof value !== 'object' || value === null)
+    throw new TypeError('An object is expected.');
+  const { instPath, ids } = value as Record<string, unknown>;
+  if (typeof instPath !== 'string')
+    throw new TypeError('instPath is expected to be a string.');
+  if (!(Array.isArray(ids) && ids.every((id) => typeof id === 'string')))
+    throw new TypeError('ids is expected to be an array of strings.');
+  return { instPath, ids: ids as string[] };
+};
+
 const packagesWithStatusInput = (
   value: unknown,
 ): { instPath: string; fixIntegrity: boolean } => {
@@ -295,6 +310,12 @@ export const router = t.router({
         if (!win) throw new Error('The calling window was not found.');
         return await getPackagesExtra(win, getConfig(), input);
       }),
+    getApmJsonInstalledIds: procedure
+      .input(installedIdsInput)
+      .query(
+        async ({ input }) =>
+          await getApmJsonInstalledIds(input.instPath, input.ids),
+      ),
     getScriptsList: procedure
       .input(scriptsListInput)
       .query(async ({ input, ctx }) => {
@@ -345,6 +366,11 @@ export const router = t.router({
           input.matchInfo,
         );
       }),
+  }),
+  nicommons: t.router({
+    getData: procedure
+      .input(stringInput)
+      .query(async ({ input }) => await getNicommonsData(input)),
   }),
   core: t.router({
     getCoreInfo: procedure.query(async ({ ctx }) => {

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -12,7 +12,6 @@ import path from 'node:path';
 import { IPC_CHANNELS } from '../common/ipc';
 import { isParent } from '../shared/apmPath';
 import { checkUpdate } from './services/appUpdate';
-import { getNicommonsData } from './services/nicommons';
 import { existsTempFile } from './services/tempFile';
 
 const APP_PATH_NAMES = new Set([
@@ -125,10 +124,6 @@ export function registerIpcHandlers() {
       }
     },
   );
-
-  ipcMain.handle(IPC_CHANNELS.GET_NICOMMONS_DATA, (event, id) => {
-    return getNicommonsData(id);
-  });
 
   ipcMain.handle(IPC_CHANNELS.CLIPBOARD_WRITE_TEXT, async (event, text) => {
     clipboard.writeText(text);

--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -350,6 +350,23 @@ export async function getScriptsList(
 }
 
 /**
+ * Returns the subset of the given package ids recorded in apm.json.
+ * 旧 displayNicommonsIdList の apmJson.has('packages.' + id) 判定と同一の挙動
+ * (dot-prop のパス解釈に依存するため判定ごと main 側で行う)。
+ * @param {string} instPath - An installation path.
+ * @param {string[]} ids - Package ids to check.
+ * @returns {Promise<string[]>} The ids recorded in apm.json.
+ */
+export async function getApmJsonInstalledIds(instPath: string, ids: string[]) {
+  const apmJson = await ApmJson.load(instPath);
+  const result: string[] = [];
+  for (const id of ids) {
+    if (await apmJson.has('packages.' + id)) result.push(id);
+  }
+  return result;
+}
+
+/**
  * Get the date today
  * 旧 src/renderer/main/package.ts の getDate と同一の挙動。
  * @returns {string} Today's date

--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -164,7 +164,6 @@ async function changeInstallationPath(instPath: string) {
   // redraw
   await displayInstalledVersion();
   await packageMain.setPackagesList(instPath);
-  await packageMain.displayNicommonsIdList(instPath);
 }
 
 /**
@@ -249,7 +248,6 @@ async function installProgram(
     if (result === 'success') {
       await displayInstalledVersion();
       await packageMain.setPackagesList(instPath);
-      await packageMain.displayNicommonsIdList(instPath);
 
       if (btn) buttonTransition.message(btn, 'インストール完了', 'success');
     } else {

--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -480,12 +480,6 @@
 													</div>
 												</div>
 											</div>
-											<div class="d-none">
-												<div
-													id="tag-template"
-													class="badge list-group-item-light d-block fw-normal"
-												></div>
-											</div>
 										</div>
 									</div>
 								</div>
@@ -532,38 +526,6 @@
 										id="nicommons-id-list"
 									></ul>
 								</div>
-							</div>
-							<div class="d-none">
-								<li
-									id="nicommons-id-template"
-									class="list-group-item list-group-item-action"
-								>
-									<label class="d-block">
-										<div class="row">
-											<div class="col-auto d-flex align-items-center">
-												<input
-													class="form-check-input m-0"
-													type="checkbox"
-													name="nicommons-id"
-												/>
-											</div>
-											<div
-												class="col-sm-1 d-flex align-items-center thumbnail"
-											></div>
-											<div class="col">
-												<h5 class="d-inline-block name"></h5>
-												<div
-													class="text-primary d-inline-block ms-2 developer"
-												></div>
-												<div class="d-inline-block ms-1 type"></div>
-												<br />
-												<div
-													class="d-inline-block text-break nicommons text-muted"
-												></div>
-											</div>
-										</div>
-									</label>
-								</li>
 							</div>
 						</div>
 					</div>

--- a/src/renderer/main/nicommons/NicommonsTab.tsx
+++ b/src/renderer/main/nicommons/NicommonsTab.tsx
@@ -1,0 +1,203 @@
+import React, { type JSX, useEffect, useMemo, useState } from 'react';
+import { parsePackageType } from '../../../shared/packageDisplay';
+import type { PackageItem } from '../../../types/packageItem';
+import { TRPCReact } from '../../trpc';
+
+type NicommonsItem = {
+  name: string;
+  developer: string;
+  originalDeveloper?: string;
+  typeBadges: string[];
+  nicommons: string;
+};
+
+/**
+ * A row of the nicommons ID list with its thumbnail from the nicommons API.
+ * @param {object} props - Props.
+ * @param {NicommonsItem} props.item - The item to display.
+ * @param {boolean} props.checked - Whether the checkbox is checked.
+ * @param {(checked: boolean) => void} props.onChange - Called when the checkbox changes.
+ * @returns {JSX.Element} The rendered row.
+ */
+function NicommonsRow({
+  item,
+  checked,
+  onChange,
+}: {
+  item: NicommonsItem;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}): JSX.Element {
+  const dataQuery = TRPCReact.nicommons.getData.useQuery(item.nicommons, {
+    refetchOnWindowFocus: false,
+  });
+  const nicommonsData = dataQuery.data as
+    | { node?: { thumbnailURL?: string } }
+    | false
+    | undefined;
+  const thumbnailURL =
+    nicommonsData && nicommonsData.node?.thumbnailURL
+      ? nicommonsData.node.thumbnailURL.replace('size=l', 'size=s')
+      : null;
+
+  return (
+    <li className="list-group-item list-group-item-action">
+      <label className="d-block">
+        <div className="row">
+          <div className="col-auto d-flex align-items-center">
+            <input
+              className="form-check-input m-0"
+              type="checkbox"
+              name="nicommons-id"
+              value={item.nicommons}
+              checked={checked}
+              onChange={(e) => onChange(e.target.checked)}
+            />
+          </div>
+          <div className="col-sm-1 d-flex align-items-center thumbnail">
+            {thumbnailURL && (
+              <img src={thumbnailURL} className="img-fluid" alt="" />
+            )}
+          </div>
+          <div className="col">
+            <h5 className="d-inline-block name">{item.name}</h5>
+            <div className="text-primary d-inline-block ms-2 developer">
+              {item.originalDeveloper
+                ? `${item.developer}（オリジナル：${item.originalDeveloper}）`
+                : item.developer}
+            </div>
+            <div className="d-inline-block ms-1 type">
+              {item.typeBadges.map((e, i) => (
+                <span
+                  key={i}
+                  className="badge list-group-item-light d-block fw-normal"
+                >
+                  {e}
+                </span>
+              ))}
+            </div>
+            <br />
+            <div className="d-inline-block text-break nicommons text-muted">
+              {item.nicommons}
+            </div>
+          </div>
+        </div>
+      </label>
+    </li>
+  );
+}
+
+/**
+ * The nicommons ID list: installed packages with a nicommons ID, with
+ * checkboxes that build the space-separated ID list in the textarea.
+ * 旧 package.ts の displayNicommonsIdList に相当する。データ取得は tRPC 経由で
+ * main プロセス。レガシー側からの再描画通知は apm-packages-changed イベント。
+ * @returns {JSX.Element} The rendered component.
+ */
+function NicommonsTab(): JSX.Element {
+  const [instPath, setInstPath] = useState(
+    () => window.coreBridge?.getInstallationPath() ?? '',
+  );
+  // 除外したもの(チェックを外したもの)だけを持つ。一覧の再取得時に全部
+  // チェック済みへ戻る旧挙動と同じにするため、checked の集合は持たない
+  const [uncheckedIds, setUncheckedIds] = useState<ReadonlySet<string>>(
+    new Set(),
+  );
+
+  const utils = TRPCReact.useContext();
+  const packagesQuery = TRPCReact.packages.getPackages.useQuery(instPath, {
+    refetchOnWindowFocus: false,
+  });
+  const packages = useMemo(
+    () => (packagesQuery.data ?? []) as PackageItem[],
+    [packagesQuery.data],
+  );
+
+  const candidateIds = useMemo(
+    () => packages.filter((p) => p.info.nicommons).map((p) => p.id),
+    [packages],
+  );
+  const installedIdsQuery = TRPCReact.packages.getApmJsonInstalledIds.useQuery(
+    { instPath, ids: candidateIds },
+    { refetchOnWindowFocus: false, enabled: packagesQuery.isSuccess },
+  );
+
+  useEffect(() => {
+    const onCoreChanged = () => {
+      setInstPath(window.coreBridge?.getInstallationPath() ?? '');
+    };
+    const onPackagesChanged = () => {
+      void utils.packages.getPackages.invalidate();
+      void utils.packages.getApmJsonInstalledIds.invalidate();
+      // 旧実装は再描画のたびに全チェック済みへ戻していた
+      setUncheckedIds(new Set());
+    };
+    window.addEventListener('apm-core-changed', onCoreChanged);
+    window.addEventListener('apm-packages-changed', onPackagesChanged);
+    return () => {
+      window.removeEventListener('apm-core-changed', onCoreChanged);
+      window.removeEventListener('apm-packages-changed', onPackagesChanged);
+    };
+  }, [utils]);
+
+  const items = useMemo<NicommonsItem[]>(() => {
+    const installedIds = new Set(installedIdsQuery.data ?? []);
+    return [
+      {
+        name: 'AviUtl',
+        developer: 'KENくん',
+        typeBadges: [],
+        nicommons: 'im1696493',
+      },
+      {
+        name: 'AviUtl Package Manager',
+        developer: 'Team apm',
+        typeBadges: [],
+        nicommons: 'nc251912',
+      },
+      ...packages
+        .filter((p) => installedIds.has(p.id) && p.info.nicommons)
+        .map((p) => ({
+          name: p.info.name,
+          developer: p.info.developer,
+          originalDeveloper: p.info.originalDeveloper,
+          typeBadges: parsePackageType(p.type ?? []),
+          nicommons: p.info.nicommons,
+        })),
+    ];
+  }, [packages, installedIdsQuery.data]);
+
+  // チェック状態に応じて textarea(レガシー DOM、コピーは ClipboardJS)を更新
+  useEffect(() => {
+    const textarea = document.getElementById(
+      'nicommons-id-textarea',
+    ) as HTMLTextAreaElement | null;
+    if (!textarea) return;
+    textarea.value = items
+      .filter((item) => !uncheckedIds.has(item.nicommons))
+      .map((item) => item.nicommons)
+      .join(' ');
+  }, [items, uncheckedIds]);
+
+  return (
+    <>
+      {items.map((item) => (
+        <NicommonsRow
+          key={item.nicommons}
+          item={item}
+          checked={!uncheckedIds.has(item.nicommons)}
+          onChange={(checked) =>
+            setUncheckedIds((prev) => {
+              const next = new Set(prev);
+              if (checked) next.delete(item.nicommons);
+              else next.add(item.nicommons);
+              return next;
+            })
+          }
+        />
+      ))}
+    </>
+  );
+}
+
+export default NicommonsTab;

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -8,7 +8,6 @@ import {
   app,
   clipboardWriteText,
   download,
-  getNicommonsData,
   openBrowser,
   openPath,
   openYesNoDialog,
@@ -175,7 +174,6 @@ async function checkPackagesList(instPath: string) {
       Math.max(...modInfo.packages.map((p) => new Date(p.modified).getTime())),
     );
     await setPackagesList(instPath);
-    await displayNicommonsIdList(instPath);
 
     if (btn) buttonTransition.message(btn, '更新完了', 'success');
   } catch (e) {
@@ -422,7 +420,6 @@ async function installPackage(
 
   if (installResult) {
     await setPackagesList(instPath);
-    await displayNicommonsIdList(instPath);
 
     if (btn) buttonTransition.message(btn, 'インストール完了', 'success');
   } else {
@@ -509,7 +506,6 @@ async function uninstallPackage(instPath: string) {
   if (result === 'success') {
     if (!uninstalledPackage.id.startsWith('script_')) {
       await setPackagesList(instPath);
-      await displayNicommonsIdList(instPath);
     } else {
       await parseJson.removePackage(
         modList.getLocalPackagesDataUrl(instPath),
@@ -711,139 +707,6 @@ async function installScript(instPath: string) {
  * Returns a nicommonsID list separated by space.
  * @param {string} instPath - An installation path.
  */
-async function displayNicommonsIdList(instPath: string) {
-  const packages = await getPackages(instPath);
-  type PackageItemWithNicommonsId = {
-    info: {
-      name: string;
-      developer: string;
-      originalDeveloper?: string;
-      nicommons: string;
-    };
-    type: string[];
-  };
-
-  const asyncFilter = async <T>(
-    array: T[],
-    predicate: (value: T, index: number, array: T[]) => Promise<unknown>,
-  ) => {
-    const bits = await Promise.all(array.map(predicate));
-    return array.filter((_, i) => bits[i]);
-  };
-
-  const apmJson = await ApmJson.load(instPath);
-
-  const packagesWithNicommonsId: [
-    PackageItemWithNicommonsId,
-    PackageItemWithNicommonsId,
-    ...PackageItem[],
-  ] = [
-    {
-      info: { name: 'AviUtl', developer: 'KENくん', nicommons: 'im1696493' },
-      type: [] as never[],
-    },
-    {
-      info: {
-        name: 'AviUtl Package Manager',
-        developer: 'Team apm',
-        nicommons: 'nc251912',
-      },
-      type: [] as never[],
-    },
-    ...(await asyncFilter(
-      packages,
-      async (value) =>
-        (await apmJson.has('packages.' + value.id)) && value.info.nicommons,
-    )),
-  ];
-
-  // show the package list
-  const columns = ['thumbnail', 'name', 'developer', 'type', 'nicommons'];
-  const makeLiFromArray = (columnList: string[]) => {
-    const li = document
-      .getElementById('nicommons-id-template')
-      .cloneNode(true) as HTMLLIElement;
-    li.removeAttribute('id');
-    const result: { li: HTMLLIElement; [key: string]: HTMLElement } = {
-      li: li,
-    };
-    columnList.forEach(
-      (tdName) =>
-        (result[tdName] = li.getElementsByClassName(tdName)[0] as HTMLElement),
-    );
-    return result;
-  };
-
-  const updateTextarea = () => {
-    const checkedId: string[] = [];
-    Array.from(
-      document.getElementsByName(
-        'nicommons-id',
-      ) as NodeListOf<HTMLInputElement>,
-    ).forEach((checkbox) => {
-      if (checkbox.checked) checkedId.push(checkbox.value);
-    });
-
-    const nicommonsIdTextarea = document.getElementById(
-      'nicommons-id-textarea',
-    ) as HTMLTextAreaElement;
-    nicommonsIdTextarea.value = checkedId.join(' ');
-  };
-
-  const nicommonsIdList = document.getElementById('nicommons-id-list');
-  nicommonsIdList.innerHTML = null;
-
-  for (const packageItem of packagesWithNicommonsId) {
-    const { li, thumbnail, name, developer, type, nicommons } = makeLiFromArray(
-      columns,
-    ) as {
-      li: HTMLLIElement;
-      thumbnail: HTMLDivElement;
-      name: HTMLHeadingElement;
-      developer: HTMLDivElement;
-      type: HTMLDivElement;
-      nicommons: HTMLDivElement;
-    };
-
-    const checkbox = li.getElementsByTagName('input')[0];
-    checkbox.value = packageItem.info.nicommons;
-    checkbox.checked = true;
-    checkbox.addEventListener('change', updateTextarea);
-
-    name.innerText = packageItem.info.name;
-    developer.innerText = packageItem.info.originalDeveloper
-      ? `${packageItem.info.developer}（オリジナル：${packageItem.info.originalDeveloper}）`
-      : packageItem.info.developer;
-    packageUtil.parsePackageType(packageItem.type).forEach((e) => {
-      const typeItem = document
-        .getElementById('tag-template')
-        .cloneNode(true) as HTMLSpanElement;
-      typeItem.removeAttribute('id');
-      typeItem.innerText = e;
-      type.appendChild(typeItem);
-    });
-    nicommons.innerText = packageItem.info.nicommons;
-
-    const nicommonsData = (await getNicommonsData(
-      packageItem.info.nicommons,
-    )) as { [key: string]: { [key: string]: string } };
-    if (nicommonsData && 'node' in nicommonsData) {
-      const img = document.createElement('img');
-      img.src = nicommonsData.node.thumbnailURL.replace('size=l', 'size=s');
-      img.classList.add('img-fluid');
-      thumbnail.appendChild(img);
-    }
-
-    nicommonsIdList.appendChild(li);
-  }
-
-  updateTextarea();
-}
-
-/**
- * Returns a nicommonsID list separated by space.
- * @param {string} instPath - An installation path.
- */
 async function sharePackages(instPath: string) {
   const btn = document.getElementById('share-packages') as HTMLButtonElement;
   const { enableButton } = btn
@@ -904,7 +767,6 @@ const packageMain = {
   installScript,
   setSelectedEntry,
   installPackageById,
-  displayNicommonsIdList,
   sharePackages,
 };
 export default packageMain;

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -34,7 +34,6 @@ contextBridge.exposeInMainWorld('coreBridge', {
     ) as HTMLInputElement | null;
     const instPath = input?.value ?? '';
     await packageMain.setPackagesList(instPath);
-    await packageMain.displayNicommonsIdList(instPath);
   },
 });
 

--- a/src/renderer/main/renderer.tsx
+++ b/src/renderer/main/renderer.tsx
@@ -7,6 +7,7 @@ import '../main.css';
 import './index.css';
 import ProgramRow from './aviutl/ProgramRow';
 import { MonacoEditorRenderer } from './monacoEditorRenderer';
+import NicommonsTab from './nicommons/NicommonsTab';
 import OthersTab from './others/OthersTab';
 import PackagesTab from './packages/PackagesTab';
 import DataUrlSettings from './settings/DataUrlSettings';
@@ -36,6 +37,11 @@ window.addEventListener('DOMContentLoaded', () => {
   createRoot(document.getElementById('others-root')).render(
     <TrpcProvider>
       <OthersTab />
+    </TrpcProvider>,
+  );
+  createRoot(document.getElementById('nicommons-id-list')).render(
+    <TrpcProvider>
+      <NicommonsTab />
     </TrpcProvider>,
   );
   createRoot(document.getElementById('packages-react-root')).render(


### PR DESCRIPTION
## 概要

**Nicommons タブを React コンポーネント化**します(タブ順: Settings✅ → Other✅ → AviUtl✅ → Plugins(一覧✅)→ Nicommons)。

- `nicommons/NicommonsTab.tsx` — 固定 2 件(AviUtl / apm)+ インストール済みでニコニ・コモンズ ID を持つパッケージの一覧。チェックボックスから `#nicommons-id-textarea` を更新(コピーは既存 ClipboardJS のまま)。サムネイルは nicommons API から取得
- tRPC `nicommons.getData`(既存 `services/nicommons.ts` の公開)+ `packages.getApmJsonInstalledIds`(apm.json のインストール済み判定。dot-prop のパス解釈に依存するため判定ごと main 側で実施)
- 再描画は `apm-packages-changed` イベント購読(一覧再取得時に全チェック済みへ戻る旧挙動も維持)
- レガシー削除: `displayNicommonsIdList`(package.ts)、旧 IPC 経路(`ipcWrapper.getNicommonsData` / `GET_NICOMMONS_DATA` ハンドラ・チャンネル)、`nicommons-id-template` / `tag-template`

## 挙動の差分(意図的な軽微なもの)

- サムネイル取得が逐次 await → 行ごとの並行クエリに(表示順は変わらず、初期表示が速くなる)

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(128 件)すべて緑
- `yarn package` + CDP スモーク: AviUtl 6 項目 + Plugins 8 項目 + **Nicommons 2 項目**(一覧描画 + textarea 連動、チェック解除で ID が外れる)ALL PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
