### PR TITLE
refactor(package): installPackage のアーカイブ解決を main プロセスへ移設

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -20,7 +20,7 @@ import {
   getPackagesExtra,
   getPackagesWithStatus,
   getScriptsList,
-  installPackageArchive,
+  installPackageFlow,
   installScriptArchive,
   uninstallPackageFiles,
 } from './services/packages';
@@ -94,22 +94,32 @@ const packageItemInput = (
   return { id, info: info as Record<string, unknown> };
 };
 
-const installArchiveInput = (
+const installPackageInput = (
   value: unknown,
 ): {
   instPath: string;
-  archivePath: string;
   packageItem: { id: string; info: Record<string, unknown> };
+  direct: boolean;
+  archivePath?: string;
 } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { instPath, archivePath, packageItem } = value as Record<
+  const { instPath, packageItem, direct, archivePath } = value as Record<
     string,
     unknown
   >;
-  if (typeof instPath !== 'string' || typeof archivePath !== 'string')
-    throw new TypeError('instPath and archivePath are expected to be strings.');
-  return { instPath, archivePath, packageItem: packageItemInput(packageItem) };
+  if (typeof instPath !== 'string')
+    throw new TypeError('instPath is expected to be a string.');
+  if (typeof direct !== 'boolean')
+    throw new TypeError('direct is expected to be a boolean.');
+  if (archivePath !== undefined && typeof archivePath !== 'string')
+    throw new TypeError('archivePath is expected to be a string.');
+  return {
+    instPath,
+    packageItem: packageItemInput(packageItem),
+    direct,
+    archivePath: archivePath as string | undefined,
+  };
 };
 
 const uninstallPackageInput = (
@@ -335,13 +345,17 @@ export const router = t.router({
           input.fixIntegrity,
         );
       }),
-    installPackageArchive: procedure
-      .input(installArchiveInput)
-      .mutation(async ({ input }) => {
-        return await installPackageArchive(
+    installPackage: procedure
+      .input(installPackageInput)
+      .mutation(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        return await installPackageFlow(
+          win,
+          getConfig(),
           input.instPath,
-          input.archivePath,
-          input.packageItem as Parameters<typeof installPackageArchive>[2],
+          input.packageItem as Parameters<typeof installPackageFlow>[3],
+          { direct: input.direct, archivePath: input.archivePath },
         );
       }),
     uninstallPackage: procedure

--- a/src/main/services/browser.ts
+++ b/src/main/services/browser.ts
@@ -1,0 +1,76 @@
+import { app, BrowserWindow } from 'electron';
+import path from 'node:path';
+
+const icon =
+  process.platform === 'linux'
+    ? path.join(__dirname, '../icon/apm1024.png')
+    : undefined;
+
+export type OpenBrowserResult = {
+  savePath: string;
+  history: string[];
+} | null;
+
+/**
+ * Opens a modal browser window and waits for the user to download a file.
+ * 旧 windows.ts の OPEN_BROWSER ハンドラと同一の挙動。ウィンドウが閉じられたら
+ * null(キャンセル)を返す。
+ * @param {BrowserWindow} parent - The parent (main) window.
+ * @param {string} url - The URL to open.
+ * @param {'core' | 'package'} type - The subdirectory in the data folder to save the file.
+ * @returns {Promise<OpenBrowserResult>} The download result, or null if canceled.
+ */
+export function openBrowser(
+  parent: BrowserWindow,
+  url: string,
+  type: 'core' | 'package',
+): Promise<OpenBrowserResult> {
+  const browserWindow = new BrowserWindow({
+    width: 800,
+    height: 600,
+    minWidth: 240,
+    minHeight: 320,
+    webPreferences: { sandbox: true },
+    parent,
+    modal: true,
+    icon: icon,
+  });
+
+  parent.once('closed', () => {
+    if (!browserWindow.isDestroyed()) {
+      browserWindow.destroy();
+    }
+  });
+
+  void browserWindow.loadURL(url);
+
+  return new Promise((resolve) => {
+    const history: string[] = [];
+
+    browserWindow.webContents.on('did-navigate', (e, url) => {
+      history.push(url);
+    });
+
+    browserWindow.webContents.session.once('will-download', (event, item) => {
+      if (!browserWindow.isDestroyed()) browserWindow.hide();
+
+      const ext = path.extname(item.getFilename());
+      const dir = path.join(app.getPath('userData'), 'Data');
+      if (['.zip', '.lzh', '.7z', '.rar'].includes(ext)) {
+        item.setSavePath(path.join(dir, type, 'archive/', item.getFilename()));
+      } else {
+        item.setSavePath(path.join(dir, type, item.getFilename()));
+      }
+
+      item.once('done', () => {
+        history.push(...item.getURLChain(), item.getFilename());
+        resolve({ savePath: item.getSavePath(), history: history });
+        if (!browserWindow.isDestroyed()) browserWindow.close();
+      });
+    });
+
+    browserWindow.once('closed', () => {
+      resolve(null);
+    });
+  });
+}

--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -18,7 +18,7 @@ import ApmJson from '../../lib/ApmJson';
 import type Config from '../../lib/Config';
 import { getHash } from '../../shared/getHash';
 import { install, verifyFilesByCount } from '../../shared/install';
-import { checkIntegrity } from '../../shared/integrity';
+import { checkIntegrity, verifyFile } from '../../shared/integrity';
 import {
   computePackagesStatus,
   detectPackageTypes,
@@ -30,6 +30,7 @@ import { safeRemove } from '../../shared/safeRemove';
 import unzip from '../../shared/unzip';
 import { ApmJsonObject } from '../../types/apmJson';
 import { PackageItem } from '../../types/packageItem';
+import { openBrowser } from './browser';
 import { downloadFile } from './download';
 import { getConvertDataUrl, getInfo, getScriptsDataUrl } from './modList';
 import { existsTempFile } from './tempFile';
@@ -469,6 +470,112 @@ export async function installPackageArchive(
   }
 
   return installResult;
+}
+
+export type InstallPackageResult =
+  | 'success'
+  | 'canceled'
+  | 'downloadFailed'
+  | 'corrupt'
+  | 'redownloadFailed'
+  | 'installFailed';
+
+/**
+ * Resolves the archive (local file / direct link / interactive browser) and
+ * installs the package.
+ * 旧 src/renderer/main/package.ts の installPackage のアーカイブ解決部分と
+ * 同一の挙動。UI(ボタン遷移・メッセージ表示)は renderer 側に残る。
+ * @param {BrowserWindow} win - A browser window used for downloads and dialogs.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @param {Pick<PackageItem, 'id' | 'info'>} packageItem - The package to install.
+ * @param {object} [options] - Options.
+ * @param {boolean} [options.direct] - Install from the direct link to the zip.
+ * @param {string} [options.archivePath] - Path to the already-downloaded archive.
+ * @returns {Promise<InstallPackageResult>} The result status.
+ */
+export async function installPackageFlow(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+  packageItem: Pick<PackageItem, 'id' | 'info'>,
+  { direct = false, archivePath }: { direct?: boolean; archivePath?: string },
+): Promise<InstallPackageResult> {
+  let resolvedArchivePath = '';
+  if (archivePath) {
+    resolvedArchivePath = archivePath;
+  } else if (direct) {
+    resolvedArchivePath = await downloadFile(win, packageItem.info.directURL, {
+      loadCache: true,
+      subDir: 'package',
+    });
+
+    if (!resolvedArchivePath) {
+      log.error('Failed downloading a file.');
+      return 'downloadFailed';
+    }
+
+    const integrityForArchive = packageItem.info.releases?.find(
+      (r) => r.version === packageItem.info.latestVersion,
+    )?.integrity?.archive;
+
+    if (integrityForArchive) {
+      // Verify file integrity
+      while (!(await verifyFile(resolvedArchivePath, integrityForArchive))) {
+        const dialogResult =
+          (
+            await dialog.showMessageBox(win, {
+              title: 'エラー',
+              message:
+                'ダウンロードされたファイルは破損しています。再ダウンロードしますか？',
+              type: 'warning',
+              buttons: ['はい', 'いいえ'],
+              cancelId: 1,
+            })
+          ).response === 0;
+
+        if (!dialogResult) {
+          log.error(
+            `The downloaded archive file is corrupt. URL:${packageItem.info.directURL}`,
+          );
+          return 'corrupt';
+        }
+
+        // 再ダウンロード先が subDir 'core' なのは旧実装のままの挙動
+        resolvedArchivePath = await downloadFile(
+          win,
+          packageItem.info.directURL,
+          { subDir: 'core' },
+        );
+        if (!resolvedArchivePath) {
+          log.error(
+            `Failed downloading the archive file. URL:${packageItem.info.directURL}`,
+          );
+          return 'redownloadFailed';
+        }
+      }
+    }
+  } else {
+    const downloadResult = await openBrowser(
+      win,
+      packageItem.info.downloadURLs[0],
+      'package',
+    );
+
+    if (!downloadResult) {
+      log.info('The installation was canceled.');
+      return 'canceled';
+    }
+
+    resolvedArchivePath = downloadResult.savePath;
+  }
+
+  const installResult = await installPackageArchive(
+    instPath,
+    resolvedArchivePath,
+    packageItem,
+  );
+  return installResult ? 'success' : 'installFailed';
 }
 
 export type UninstallPackageResult = 'success' | 'removeFailed' | 'filesRemain';

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -1,5 +1,4 @@
 import {
-  app,
   BrowserWindow,
   dialog,
   ipcMain,
@@ -16,6 +15,7 @@ import type Config from '../lib/Config';
 import { setAboutWindowOpener } from './aboutWindow';
 import { createContext, router } from './api';
 import { runAutoUpdate } from './services/appUpdate';
+import { openBrowser } from './services/browser';
 import { downloadFile } from './services/download';
 
 declare const SPLASH_WINDOW_WEBPACK_ENTRY: string;
@@ -174,56 +174,8 @@ export async function launch(config: Config) {
   });
 
   ipcMain.handle(IPC_CHANNELS.OPEN_BROWSER, async (event, url, type) => {
-    const browserWindow = new BrowserWindow({
-      width: 800,
-      height: 600,
-      minWidth: 240,
-      minHeight: 320,
-      webPreferences: { sandbox: true },
-      parent: mainWindow,
-      modal: true,
-      icon: icon,
-    });
-
-    mainWindow.once('closed', () => {
-      if (!browserWindow.isDestroyed()) {
-        browserWindow.destroy();
-      }
-    });
-
-    void browserWindow.loadURL(url);
-
-    return await new Promise((resolve) => {
-      const history: string[] = [];
-
-      browserWindow.webContents.on('did-navigate', (e, url) => {
-        history.push(url);
-      });
-
-      browserWindow.webContents.session.once('will-download', (event, item) => {
-        if (!browserWindow.isDestroyed()) browserWindow.hide();
-
-        const ext = path.extname(item.getFilename());
-        const dir = path.join(app.getPath('userData'), 'Data');
-        if (['.zip', '.lzh', '.7z', '.rar'].includes(ext)) {
-          item.setSavePath(
-            path.join(dir, type, 'archive/', item.getFilename()),
-          );
-        } else {
-          item.setSavePath(path.join(dir, type, item.getFilename()));
-        }
-
-        item.once('done', () => {
-          history.push(...item.getURLChain(), item.getFilename());
-          resolve({ savePath: item.getSavePath(), history: history });
-          if (!browserWindow.isDestroyed()) browserWindow.close();
-        });
-      });
-
-      browserWindow.once('closed', () => {
-        resolve(null);
-      });
-    });
+    // 実装は services/browser.ts へ抽出済み(main 内部からも呼べるようにするため)
+    return await openBrowser(mainWindow, url, type);
   });
 
   setTimeout(() => {

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -7,16 +7,13 @@ import { getConfig } from '../../lib/Config';
 import {
   app,
   clipboardWriteText,
-  download,
   openBrowser,
   openPath,
-  openYesNoDialog,
 } from '../../lib/ipcWrapper';
 import * as modList from '../../lib/modList';
 import * as parseJson from '../../lib/parseJson';
 import replaceText from '../../lib/replaceText';
 import { trpc } from '../../lib/trpcClient';
-import { verifyFile } from '../../shared/integrity';
 import { shareStringVersion } from '../../shared/shareString';
 import { PackageItem } from '../../types/packageItem';
 import { programs } from './common';
@@ -302,123 +299,81 @@ async function installPackage(
     installedPackage = { ...selectedEntry } as PackageItem;
   }
 
-  let archivePath = '';
-  if (role === roles.Internal_Local_File) {
-    archivePath = strArchivePath;
-  } else if (role === roles.Internal_Direct_Link) {
-    archivePath = await download(installedPackage.info.directURL, {
-      loadCache: true,
-      subDir: 'package',
-    });
-
-    if (!archivePath) {
-      log.error('Failed downloading a file.');
-      if (btn) {
-        buttonTransition.message(
-          btn,
-          'ダウンロード中にエラーが発生しました。',
-          'danger',
-        );
-        setTimeout(() => {
-          enableButton();
-        }, 3000);
-      }
-      return;
-    }
-
-    const integrityForArchive = installedPackage.info.releases?.find(
-      (r) => r.version === installedPackage.info.latestVersion,
-    )?.integrity?.archive;
-
-    if (integrityForArchive) {
-      // Verify file integrity
-      while (!(await verifyFile(archivePath, integrityForArchive))) {
-        const dialogResult = await openYesNoDialog(
-          'エラー',
-          'ダウンロードされたファイルは破損しています。再ダウンロードしますか？',
-        );
-
-        if (!dialogResult) {
-          log.error(
-            `The downloaded archive file is corrupt. URL:${installedPackage.info.directURL}`,
-          );
-          if (btn) {
-            buttonTransition.message(
-              btn,
-              'ダウンロードされたファイルは破損しています。',
-              'danger',
-            );
-            setTimeout(() => {
-              enableButton();
-            }, 3000);
-          }
-          // Direct installation can throw an error because it is called only from within the try catch block.
-          throw new Error('The downloaded archive file is corrupt.');
-        }
-
-        archivePath = await download(installedPackage.info.directURL, {
-          subDir: 'core',
-        });
-        if (!archivePath) {
-          log.error(
-            `Failed downloading the archive file. URL:${installedPackage.info.directURL}`,
-          );
-          if (btn) {
-            buttonTransition.message(
-              btn,
-              'ファイルのダウンロードに失敗しました。',
-              'danger',
-            );
-            setTimeout(() => {
-              enableButton();
-            }, 3000);
-          }
-          // Direct installation can throw an error because it is called only from within the try catch block.
-          throw new Error('Failed downloading the archive file.');
-        }
-      }
-    }
-  } else {
-    // if (role === roles.Internal_Browser || role === roles.Event_Handler)
-
-    const downloadResult = await openBrowser(
-      installedPackage.info.downloadURLs[0],
-      'package',
-    );
-
-    if (!downloadResult) {
-      log.info('The installation was canceled.');
-      if (btn) {
-        buttonTransition.message(
-          btn,
-          'インストールがキャンセルされました。',
-          'info',
-        );
-        setTimeout(() => {
-          enableButton();
-        }, 3000);
-      }
-      return;
-    }
-
-    archivePath = downloadResult.savePath;
-  }
-
-  // 展開 → 配置(またはインストーラ実行)→ 検証 → apm.json 記録は
-  // main プロセス側(services/packages.ts)へ移設済み
-  let installResult = false;
+  // アーカイブの解決(直リンク DL・整合性ダイアログ・ブラウザ DL)と
+  // 展開・配置・apm.json 記録は main プロセス側(services/packages.ts)へ移設済み
+  let result: Awaited<ReturnType<typeof trpc.packages.installPackage.mutate>>;
   try {
-    installResult = await trpc.packages.installPackageArchive.mutate({
+    result = await trpc.packages.installPackage.mutate({
       instPath,
-      archivePath,
       packageItem: { id: installedPackage.id, info: installedPackage.info },
+      direct: role === roles.Internal_Direct_Link,
+      archivePath:
+        role === roles.Internal_Local_File ? strArchivePath : undefined,
     });
   } catch (e) {
     log.error(e);
-    installResult = false;
+    result = 'installFailed';
   }
 
-  if (installResult) {
+  if (result === 'canceled') {
+    if (btn) {
+      buttonTransition.message(
+        btn,
+        'インストールがキャンセルされました。',
+        'info',
+      );
+      setTimeout(() => {
+        enableButton();
+      }, 3000);
+    }
+    return;
+  }
+
+  if (result === 'downloadFailed') {
+    if (btn) {
+      buttonTransition.message(
+        btn,
+        'ダウンロード中にエラーが発生しました。',
+        'danger',
+      );
+      setTimeout(() => {
+        enableButton();
+      }, 3000);
+    }
+    return;
+  }
+
+  if (result === 'corrupt') {
+    if (btn) {
+      buttonTransition.message(
+        btn,
+        'ダウンロードされたファイルは破損しています。',
+        'danger',
+      );
+      setTimeout(() => {
+        enableButton();
+      }, 3000);
+    }
+    // Direct installation can throw an error because it is called only from within the try catch block.
+    throw new Error('The downloaded archive file is corrupt.');
+  }
+
+  if (result === 'redownloadFailed') {
+    if (btn) {
+      buttonTransition.message(
+        btn,
+        'ファイルのダウンロードに失敗しました。',
+        'danger',
+      );
+      setTimeout(() => {
+        enableButton();
+      }, 3000);
+    }
+    // Direct installation can throw an error because it is called only from within the try catch block.
+    throw new Error('Failed downloading the archive file.');
+  }
+
+  if (result === 'success') {
     await setPackagesList(instPath);
 
     if (btn) buttonTransition.message(btn, 'インストール完了', 'success');


### PR DESCRIPTION
## 概要

Plugins タブに残るアクション系オーケストレーションの main 化(その 1)。

- `services/browser.ts` — OPEN_BROWSER ハンドラの実装を service 関数へ抽出(挙動不変。main 内部からも対話的ダウンロードを呼べるように)
- `services/packages.ts` に `installPackageFlow`: ローカルファイル / 直リンク(キャッシュ・整合性検証・再ダウンロード確認ダイアログ)/ ブラウザ経由のアーカイブ解決 → `installPackageArchive`。ステータス union(`success / canceled / downloadFailed / corrupt / redownloadFailed / installFailed`)を返す
- tRPC `packages.installPackage` mutation を公開。renderer の `installPackage` はロール判定・ガード・ボタン遷移・メッセージ変換のみに縮小(corrupt / redownloadFailed の throw は batchInstall の try/catch 前提の旧挙動を維持)
- renderer から使われなくなった `packages.installPackageArchive` ルートを削除(service 関数は flow が使用)
- 再ダウンロード先が subDir 'core' なのは旧実装のままの挙動(コメントで明示)

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(128 件)すべて緑
- `yarn package` + CDP スモーク: AviUtl 6 + Plugins 8 + Nicommons 2 の全 16 項目 ALL PASS
- インストール実走(ブラウザ DL → 配置)の検証は Windows 依存のため実機確認をお願いします

🤖 Generated with [Claude Code](https://claude.com/claude-code)