### PR TITLE
refactor(package): installScript と uninstall の後処理を main プロセスへ移設

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -21,7 +21,7 @@ import {
   getPackagesWithStatus,
   getScriptsList,
   installPackageFlow,
-  installScriptArchive,
+  installScriptFlow,
   uninstallPackageFiles,
 } from './services/packages';
 import { ensureExtraDataUrl, setDataUrls } from './services/settings';
@@ -136,58 +136,15 @@ const uninstallPackageInput = (
   return { instPath, packageItem: packageItemInput(packageItem) };
 };
 
-const installScriptInput = (
+const installScriptFlowInput = (
   value: unknown,
-): {
-  instPath: string;
-  archivePath: string;
-  url: string;
-  matchInfo: { folder: string; developer?: string; dependencies?: string[] };
-} => {
+): { instPath: string; url: string } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { instPath, archivePath, url, matchInfo } = value as Record<
-    string,
-    unknown
-  >;
-  if (
-    typeof instPath !== 'string' ||
-    typeof archivePath !== 'string' ||
-    typeof url !== 'string'
-  )
-    throw new TypeError(
-      'instPath, archivePath, and url are expected to be strings.',
-    );
-  if (typeof matchInfo !== 'object' || matchInfo === null)
-    throw new TypeError('matchInfo is expected to be an object.');
-  const { folder, developer, dependencies } = matchInfo as Record<
-    string,
-    unknown
-  >;
-  if (typeof folder !== 'string')
-    throw new TypeError('matchInfo.folder is expected to be a string.');
-  if (developer !== undefined && typeof developer !== 'string')
-    throw new TypeError('matchInfo.developer is expected to be a string.');
-  if (
-    dependencies !== undefined &&
-    !(
-      Array.isArray(dependencies) &&
-      dependencies.every((d) => typeof d === 'string')
-    )
-  )
-    throw new TypeError(
-      'matchInfo.dependencies is expected to be an array of strings.',
-    );
-  return {
-    instPath,
-    archivePath,
-    url,
-    matchInfo: {
-      folder,
-      developer: developer as string | undefined,
-      dependencies: dependencies as string[] | undefined,
-    },
-  };
+  const { instPath, url } = value as Record<string, unknown>;
+  if (typeof instPath !== 'string' || typeof url !== 'string')
+    throw new TypeError('instPath and url are expected to be strings.');
+  return { instPath, url };
 };
 
 const installedIdsInput = (
@@ -360,24 +317,26 @@ export const router = t.router({
       }),
     uninstallPackage: procedure
       .input(uninstallPackageInput)
-      .mutation(async ({ input }) => {
-        return await uninstallPackageFiles(
-          input.instPath,
-          input.packageItem as Parameters<typeof uninstallPackageFiles>[1],
-        );
-      }),
-    installScriptArchive: procedure
-      .input(installScriptInput)
       .mutation(async ({ input, ctx }) => {
         const win = BrowserWindow.fromWebContents(ctx.event.sender);
         if (!win) throw new Error('The calling window was not found.');
-        return await installScriptArchive(
+        return await uninstallPackageFiles(
           win,
           getConfig(),
           input.instPath,
-          input.archivePath,
+          input.packageItem as Parameters<typeof uninstallPackageFiles>[3],
+        );
+      }),
+    installScript: procedure
+      .input(installScriptFlowInput)
+      .mutation(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        return await installScriptFlow(
+          win,
+          getConfig(),
+          input.instPath,
           input.url,
-          input.matchInfo,
         );
       }),
   }),

--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -581,14 +581,19 @@ export async function installPackageFlow(
 export type UninstallPackageResult = 'success' | 'removeFailed' | 'filesRemain';
 
 /**
- * Removes the files of the package and removes it from apm.json.
+ * Removes the files of the package, removes it from apm.json, and (for
+ * script-derived packages) removes it from the local packages.json.
  * 旧 src/renderer/main/package.ts の uninstallPackage の計算部分と同一の挙動
- * (削除失敗時のメッセージ表示・スクリプト用の後処理は renderer 側の責務)。
+ * (削除失敗時のメッセージ表示は renderer 側の責務)。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
  * @param {string} instPath - An installation path.
  * @param {object} packageItem - A package to uninstall.
  * @returns {Promise<UninstallPackageResult>} The result of the uninstallation.
  */
 export async function uninstallPackageFiles(
+  win: BrowserWindow,
+  config: Config,
   instPath: string,
   packageItem: Pick<PackageItem, 'id' | 'info'>,
 ): Promise<UninstallPackageResult> {
@@ -620,7 +625,53 @@ export async function uninstallPackageFiles(
 
   const apmJson = await ApmJson.load(instPath);
   await apmJson.removePackage(packageItem.id);
-  return filesCount === notExistCount ? 'success' : 'filesRemain';
+
+  const result: UninstallPackageResult =
+    filesCount === notExistCount ? 'success' : 'filesRemain';
+  // スクリプト由来のパッケージはローカル packages.json からも削除する
+  // (旧 renderer 側 parseJson.removePackage の呼び出しと同一の挙動)
+  if (result === 'success' && packageItem.id.startsWith('script_')) {
+    await removeScriptPackage(win, config, instPath, packageItem.id);
+  }
+  return result;
+}
+
+/**
+ * Removes the package entry from the local packages.json.
+ * 旧 src/lib/parseJson.ts の removePackage と同一の挙動(データ v1 互換の
+ * ID 変換込み。残りが無くなったらファイルごと削除)。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @param {string} packageId - The id of the package to remove.
+ */
+async function removeScriptPackage(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+  packageId: string,
+) {
+  const localPackagesPath = path.join(instPath, 'packages.json');
+  if (!existsSync(localPackagesPath))
+    throw new Error('The version file does not exist.');
+  const localPackages = ((await readJson(localPackagesPath)) as Packages)
+    .packages;
+  const convDict = await getIdDict(win, config);
+  for (const localPackage of localPackages) {
+    // For compatibility with data v1
+    if (Object.prototype.hasOwnProperty.call(convDict, localPackage.id)) {
+      localPackage.id = convDict[localPackage.id];
+    }
+  }
+  const newLocalPackages = localPackages.filter((p) => p.id !== packageId);
+  if (newLocalPackages.length > 0) {
+    await writeJson(localPackagesPath, {
+      version: 3,
+      packages: newLocalPackages,
+    });
+  } else {
+    await rm(localPackagesPath);
+  }
 }
 
 // To avoid a bug in the library
@@ -827,4 +878,87 @@ export async function installScriptArchive(
     log.error(e);
     return 'installFailed';
   }
+}
+
+export type InstallScriptFlowResult =
+  | { route: 'flow'; status: 'canceled' | 'notSupported' | 'redirectNotFound' }
+  | { route: 'script'; status: InstallScriptResult }
+  | { route: 'redirect'; status: InstallPackageResult };
+
+/**
+ * Opens the script distribution site in the browser, resolves the matched
+ * script (or its redirect package) from the download history, and installs it.
+ * 旧 src/renderer/main/package.ts の installScript 前半(ブラウザ DL →
+ * matchInfo 解決 → redirect 分岐)と同一の挙動。UI は renderer 側に残る。
+ * @param {BrowserWindow} win - A browser window used for downloads and dialogs.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @param {string} url - The URL of the script distribution site.
+ * @returns {Promise<InstallScriptFlowResult>} The result status with its route.
+ */
+export async function installScriptFlow(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+  url: string,
+): Promise<InstallScriptFlowResult> {
+  const downloadResult = await openBrowser(win, url, 'package');
+  if (!downloadResult) {
+    log.info('The installation was canceled.');
+    return { route: 'flow', status: 'canceled' };
+  }
+
+  const archivePath = downloadResult.savePath;
+  const history = downloadResult.history;
+  const matchInfo = [...(await getScriptsList(win, config, false)).scripts]
+    .reverse()
+    .find((item) => isMatch(history, item.match));
+
+  if (!matchInfo) {
+    log.error('The script is not supported.');
+    return { route: 'flow', status: 'notSupported' };
+  }
+
+  if ('redirect' in matchInfo) {
+    // Determine which of the redirections can be installed and install them.
+    const packages = (await getPackagesWithStatus(win, config, instPath, false))
+      .packages;
+    const packageId = matchInfo.redirect
+      .split('|')
+      .find((candidate: string) =>
+        packages.find((p) => p.id === candidate && p.doNotInstall !== true),
+      );
+    if (!packageId) {
+      return { route: 'flow', status: 'redirectNotFound' };
+    }
+    const packageToInstall = packages.find((p) => p.id === packageId);
+    return {
+      route: 'redirect',
+      status: await installPackageFlow(
+        win,
+        config,
+        instPath,
+        packageToInstall,
+        {
+          archivePath,
+        },
+      ),
+    };
+  }
+
+  return {
+    route: 'script',
+    status: await installScriptArchive(
+      win,
+      config,
+      instPath,
+      archivePath,
+      url,
+      {
+        folder: matchInfo.folder,
+        developer: matchInfo.developer,
+        dependencies: matchInfo.dependencies,
+      },
+    ),
+  };
 }

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -1,32 +1,19 @@
 import { Scripts } from 'apm-schema';
 import log from 'electron-log/renderer';
-import * as matcher from 'matcher';
 import ApmJson from '../../lib/ApmJson';
 import * as buttonTransition from '../../lib/buttonTransition';
 import { getConfig } from '../../lib/Config';
-import {
-  app,
-  clipboardWriteText,
-  openBrowser,
-  openPath,
-} from '../../lib/ipcWrapper';
+import { app, clipboardWriteText, openPath } from '../../lib/ipcWrapper';
 import * as modList from '../../lib/modList';
-import * as parseJson from '../../lib/parseJson';
 import replaceText from '../../lib/replaceText';
 import { trpc } from '../../lib/trpcClient';
+import type { InstallScriptFlowResult } from '../../main/services/packages';
 import { shareStringVersion } from '../../shared/shareString';
 import { PackageItem } from '../../types/packageItem';
 import { programs } from './common';
 import packageUtil from './packageUtil';
 
 const config = getConfig();
-
-// To avoid a bug in the library
-// https://github.com/sindresorhus/matcher/issues/32
-const isMatch = (
-  input: string | readonly string[],
-  pattern: readonly string[],
-) => pattern.some((p) => matcher.isMatch(input, p));
 
 let selectedEntry: PackageItem | Scripts['webpage'][number];
 let selectedEntryType: string;
@@ -459,13 +446,11 @@ async function uninstallPackage(instPath: string) {
   }
 
   if (result === 'success') {
+    // スクリプト由来のパッケージのローカル packages.json からの削除は
+    // main プロセス側(services/packages.ts)へ移設済み
     if (!uninstalledPackage.id.startsWith('script_')) {
       await setPackagesList(instPath);
     } else {
-      await parseJson.removePackage(
-        modList.getLocalPackagesDataUrl(instPath),
-        uninstalledPackage,
-      );
       await checkPackagesList(instPath);
     }
 
@@ -559,51 +544,28 @@ async function installScript(instPath: string) {
     return;
   }
 
-  const downloadResult = await openBrowser(url, 'package');
-  if (!downloadResult) {
-    log.info('The installation was canceled.');
-    buttonTransition.message(
-      btn,
-      'インストールがキャンセルされました。',
-      'info',
-    );
-    setTimeout(() => {
-      enableButton();
-    }, 3000);
-    return;
+  // ブラウザ DL → matchInfo 解決 → redirect 分岐 → 展開・配置・保存は
+  // main プロセス側(services/packages.ts の installScriptFlow)へ移設済み
+  let result: InstallScriptFlowResult;
+  try {
+    result = (await trpc.packages.installScript.mutate({
+      instPath,
+      url,
+    })) as InstallScriptFlowResult;
+  } catch (e) {
+    log.error(e);
+    result = { route: 'script', status: 'installFailed' };
   }
 
-  const archivePath = downloadResult.savePath;
-  const history = downloadResult.history;
-  const matchInfo = [...(await getScriptsList()).scripts]
-    .reverse()
-    .find((item) => isMatch(history, item.match));
-
-  if (!matchInfo) {
-    log.error('The script is not supported.');
-    buttonTransition.message(btn, '未対応のスクリプトです。', 'danger');
-    setTimeout(() => {
-      enableButton();
-    }, 3000);
-    return;
-  }
-
-  if ('redirect' in matchInfo) {
-    // Determine which of the redirections can be installed and install them.
-    const packages = (await packageUtil.getPackagesWithStatus(instPath))
-      .packages;
-    const packageId = matchInfo.redirect
-      .split('|')
-      .find((candidate: string) =>
-        packages.find((p) => p.id === candidate && p.doNotInstall !== true),
+  if (result.route === 'flow') {
+    if (result.status === 'canceled') {
+      buttonTransition.message(
+        btn,
+        'インストールがキャンセルされました。',
+        'info',
       );
-    if (packageId) {
-      await installPackage(
-        instPath,
-        packages.find((p) => p.id === packageId),
-        undefined,
-        archivePath,
-      );
+    } else if (result.status === 'notSupported') {
+      buttonTransition.message(btn, '未対応のスクリプトです。', 'danger');
     } else {
       buttonTransition.message(
         btn,
@@ -611,42 +573,22 @@ async function installScript(instPath: string) {
         'danger',
       );
     }
-    setTimeout(() => {
-      enableButton();
-    }, 3000);
-    return;
-  }
-
-  // 展開 → スクリプト検証 → 配置 → パッケージ情報の生成と保存は
-  // main プロセス側(services/packages.ts)へ移設済み
-  let result: Awaited<
-    ReturnType<typeof trpc.packages.installScriptArchive.mutate>
-  >;
-  try {
-    result = await trpc.packages.installScriptArchive.mutate({
-      instPath,
-      archivePath,
-      url,
-      matchInfo: {
-        folder: matchInfo.folder,
-        developer: matchInfo.developer,
-        dependencies: matchInfo.dependencies,
-      },
-    });
-  } catch (e) {
-    log.error(e);
-    result = 'installFailed';
-  }
-
-  if (result === 'noScript') {
+  } else if (result.route === 'redirect') {
+    if (result.status === 'success') {
+      await setPackagesList(instPath);
+      buttonTransition.message(btn, 'インストール完了', 'success');
+    } else {
+      buttonTransition.message(btn, 'エラーが発生しました。', 'danger');
+    }
+  } else if (result.status === 'noScript') {
     buttonTransition.message(btn, 'スクリプトが含まれていません。', 'danger');
-  } else if (result === 'containsPlugin') {
+  } else if (result.status === 'containsPlugin') {
     buttonTransition.message(
       btn,
       'プラグインが含まれているためインストールできません。',
       'danger',
     );
-  } else if (result === 'success') {
+  } else if (result.status === 'success') {
     await checkPackagesList(instPath);
     buttonTransition.message(btn, 'インストール完了', 'success');
   } else {


### PR DESCRIPTION
## 概要

Plugins タブのアクション系 main 化(その 2、#2327 スタック)。

- `installScriptFlow`: ブラウザ DL → matchInfo 解決(matcher)→ redirect 分岐 → `installPackageFlow` / `installScriptArchive` を main 側に集約し、tRPC `packages.installScript` mutation として公開。戻り値は `{route: 'flow' | 'script' | 'redirect', status}` で renderer がメッセージ変換
- `uninstallPackageFiles` にスクリプト由来パッケージのローカル packages.json からの削除(旧 `parseJson.removePackage` 相当、データ v1 互換の ID 変換込み・残り 0 件でファイル削除)を統合
- renderer の `installScript` / `uninstallPackage` はガード・ボタン遷移・メッセージ変換のみに縮小。renderer の matcher / parseJson / openBrowser 依存を削除
- renderer から使われなくなった `packages.installScriptArchive` ルートを削除(service 関数は flow が使用)

これで Plugins タブの renderer 残留は UI(ボタン遷移・メッセージ)と sharePackages / checkPackagesList のオーケストレーションのみになります。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(128 件)すべて緑
- `yarn package` + CDP スモーク 16 項目 ALL PASS
- スクリプトインストール実走は Windows 依存のため実機確認をお願いします

## 注意

base が #2327 のため、#2327 マージ後に rebase + force push で CI を発火させます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)