### PR TITLE
refactor(package): 共有文字列の生成を main プロセスへ移設

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -14,6 +14,7 @@ import {
 import { updateInfo } from './services/modList';
 import { getNicommonsData } from './services/nicommons';
 import {
+  buildShareString,
   downloadRepository,
   getApmJsonInstalledIds,
   getPackages,
@@ -283,6 +284,13 @@ export const router = t.router({
         async ({ input }) =>
           await getApmJsonInstalledIds(input.instPath, input.ids),
       ),
+    getShareString: procedure
+      .input(stringInput)
+      .query(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        return await buildShareString(win, getConfig(), input);
+      }),
     getScriptsList: procedure
       .input(scriptsListInput)
       .query(async ({ input, ctx }) => {

--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -1,5 +1,5 @@
 import type { Packages, Scripts } from 'apm-schema';
-import { type BrowserWindow, dialog } from 'electron';
+import { app, type BrowserWindow, dialog } from 'electron';
 import log from 'electron-log/main';
 import {
   copy,
@@ -26,7 +26,9 @@ import {
   getManuallyInstalledFiles,
   states,
 } from '../../shared/packageUtil';
+import { programs } from '../../shared/programs';
 import { safeRemove } from '../../shared/safeRemove';
+import { shareStringVersion } from '../../shared/shareString';
 import unzip from '../../shared/unzip';
 import { ApmJsonObject } from '../../types/apmJson';
 import { PackageItem } from '../../types/packageItem';
@@ -878,6 +880,55 @@ export async function installScriptArchive(
     log.error(e);
     return 'installFailed';
   }
+}
+
+/**
+ * Builds the share string of the installed packages for the clipboard.
+ * 旧 src/renderer/main/package.ts の sharePackages の文字列生成部分と同一の
+ * 挙動(クリップボードへの書き込みとボタン表示は renderer 側の責務)。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @returns {Promise<string>} The share string.
+ */
+export async function buildShareString(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+) {
+  const ver = {
+    share: shareStringVersion, // version of this data
+    apm: app.getVersion(),
+    aviutl: '',
+    exedit: '',
+    packages: [''],
+  };
+
+  const apmJson = await ApmJson.load(instPath);
+
+  for (const program of programs) {
+    const currentVersion = (await apmJson.get('core.' + program)) as string;
+    ver[program] = currentVersion;
+  }
+  ver.packages = (await getPackagesExtra(win, config, instPath)).packages
+    .filter(
+      (p) =>
+        p.installationStatus === states.installed ||
+        p.installationStatus === states.manuallyInstalled,
+    )
+    .map((p) => p.id)
+    .filter((id) => id.includes('/'))
+    .sort((a, b) => {
+      const compare = (a: string, b: string) => (a > b ? 1 : a < b ? -1 : 0);
+      const a2 = a.split('/');
+      const b2 = b.split('/');
+      return a2[0] === b2[0] ? compare(a2[1], b2[1]) : compare(a2[0], b2[0]);
+    });
+
+  //  Variation Selectors: 🍎️(color), 🎞︎(text), 🎬︎(text)
+  return `ここにタイトルを入力🍎️${ver.share}:${ver.apm},🎞︎${ver.aviutl},🎬︎${
+    ver.exedit
+  },${ver.packages.join(',')}`;
 }
 
 export type InstallScriptFlowResult =

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -1,16 +1,13 @@
 import { Scripts } from 'apm-schema';
 import log from 'electron-log/renderer';
-import ApmJson from '../../lib/ApmJson';
 import * as buttonTransition from '../../lib/buttonTransition';
 import { getConfig } from '../../lib/Config';
-import { app, clipboardWriteText, openPath } from '../../lib/ipcWrapper';
+import { clipboardWriteText, openPath } from '../../lib/ipcWrapper';
 import * as modList from '../../lib/modList';
 import replaceText from '../../lib/replaceText';
 import { trpc } from '../../lib/trpcClient';
 import type { InstallScriptFlowResult } from '../../main/services/packages';
-import { shareStringVersion } from '../../shared/shareString';
 import { PackageItem } from '../../types/packageItem';
-import { programs } from './common';
 import packageUtil from './packageUtil';
 
 const config = getConfig();
@@ -610,40 +607,9 @@ async function sharePackages(instPath: string) {
     ? buttonTransition.loading(btn, '共有')
     : { enableButton: null };
 
-  const ver = {
-    share: shareStringVersion, // version of this data
-    apm: await app.getVersion(),
-    aviutl: '',
-    exedit: '',
-    packages: [''],
-  };
-
-  const apmJson = await ApmJson.load(instPath);
-
-  for (const program of programs) {
-    const currentVersion = (await apmJson.get('core.' + program)) as string;
-    ver[program] = currentVersion;
-  }
-  ver.packages = (await packageUtil.getPackagesExtra(instPath)).packages
-    .filter(
-      (p) =>
-        p.installationStatus === packageUtil.states.installed ||
-        p.installationStatus === packageUtil.states.manuallyInstalled,
-    )
-    .map((p) => p.id)
-    .filter((id) => id.includes('/'))
-    .sort((a, b) => {
-      const compare = (a: string, b: string) => (a > b ? 1 : a < b ? -1 : 0);
-      const a2 = a.split('/');
-      const b2 = b.split('/');
-      return a2[0] === b2[0] ? compare(a2[1], b2[1]) : compare(a2[0], b2[0]);
-    });
-  await clipboardWriteText(
-    //  Variation Selectors: 🍎️(color), 🎞︎(text), 🎬︎(text)
-    `ここにタイトルを入力🍎️${ver.share}:${ver.apm},🎞︎${ver.aviutl},🎬︎${
-      ver.exedit
-    },${ver.packages.join(',')}`,
-  );
+  // 共有文字列の生成(apm.json のコアバージョン + インストール済み
+  // パッケージ一覧の整形)は main プロセス側(services/packages.ts)へ移設済み
+  await clipboardWriteText(await trpc.packages.getShareString.query(instPath));
 
   buttonTransition.message(btn, 'コピーしました', 'info');
   if (btn) {


### PR DESCRIPTION
## 概要

Plugins タブのアクション系 main 化(その 3・最終)。

- `services/packages.ts` に `buildShareString`: apm.json のコアバージョン + インストール済み(手動含む)パッケージ ID の整形を main 側に集約し、tRPC `packages.getShareString` query として公開
- renderer の `sharePackages` はクリップボード書き込みとボタン遷移のみに縮小。package.ts から ApmJson / programs / shareStringVersion への依存が消滅

これで package.ts の renderer 残留は UI オーケストレーション(ボタン遷移・メッセージ変換・checkPackagesList の進行表示)と React への橋渡しのみになりました。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(128 件)すべて緑
- `yarn package` + CDP スモーク **17 項目** ALL PASS(新規: 共有ボタンクリック → 「コピーしました」表示 = getShareString 経路の実走)

🤖 Generated with [Claude Code](https://claude.com/claude-code)