### PR TITLE
refactor(package): convertId を main プロセスへ移設

### DIFF
--- a/src/lib/convertId.ts
+++ b/src/lib/convertId.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs-extra';
 import path from 'node:path';
-import ApmJson from './ApmJson';
 import { download, existsTempFile } from './ipcWrapper';
 import * as modList from './modList';
 
@@ -32,29 +31,5 @@ export async function getIdDict(
   }
 }
 
-/**
- * Converts id.
- * @param {string} instPath - An installation path
- * @param {number} modTime - A mod time.
- */
-export async function convertId(instPath: string, modTime: number) {
-  const apmJson = await ApmJson.load(instPath);
-  apmJson.begin();
-  const packages = (await apmJson.get('packages')) as {
-    [key: string]: { id: string };
-  };
-
-  const convDict = await getIdDict(true);
-  for (const [oldId, packageItem] of Object.entries(packages)) {
-    if (Object.prototype.hasOwnProperty.call(convDict, oldId)) {
-      const newId = convDict[packageItem.id];
-      packages[newId] = packages[oldId];
-      delete packages[oldId];
-      packages[newId].id = newId;
-    }
-  }
-
-  await apmJson.set('packages', packages);
-  await apmJson.set('convertMod', modTime);
-  await apmJson.commit();
-}
+// convertId は main プロセス側(src/main/services/packages.ts の
+// convertPackageIds)へ移設済み。getIdDict は parseJson(データエディタ)が使用中

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -15,6 +15,7 @@ import { updateInfo } from './services/modList';
 import { getNicommonsData } from './services/nicommons';
 import {
   buildShareString,
+  convertPackageIds,
   downloadRepository,
   getApmJsonInstalledIds,
   getPackages,
@@ -146,6 +147,19 @@ const installScriptFlowInput = (
   if (typeof instPath !== 'string' || typeof url !== 'string')
     throw new TypeError('instPath and url are expected to be strings.');
   return { instPath, url };
+};
+
+const convertIdsInput = (
+  value: unknown,
+): { instPath: string; modTime: number } => {
+  if (typeof value !== 'object' || value === null)
+    throw new TypeError('An object is expected.');
+  const { instPath, modTime } = value as Record<string, unknown>;
+  if (typeof instPath !== 'string' || typeof modTime !== 'number')
+    throw new TypeError(
+      'instPath is expected to be a string and modTime a number.',
+    );
+  return { instPath, modTime };
 };
 
 const installedIdsInput = (
@@ -284,6 +298,18 @@ export const router = t.router({
         async ({ input }) =>
           await getApmJsonInstalledIds(input.instPath, input.ids),
       ),
+    convertIds: procedure
+      .input(convertIdsInput)
+      .mutation(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        await convertPackageIds(
+          win,
+          getConfig(),
+          input.instPath,
+          input.modTime,
+        );
+      }),
     getShareString: procedure
       .input(stringInput)
       .query(async ({ input, ctx }) => {

--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -60,16 +60,25 @@ export function getPackagesDataUrl(config: Config, instPath: string) {
 
 /**
  * Returns the id conversion dictionary.
- * 旧 src/lib/convertId.ts の getIdDict(update = false)と同一の挙動。
+ * 旧 src/lib/convertId.ts の getIdDict と同一の挙動。
  * @param {BrowserWindow} win - A browser window used for the download session.
  * @param {Config} config - The config instance.
+ * @param {boolean} [update] - Download the json file.
  * @returns {Promise<{ [key: string]: string }>} Dictionary of id relationships.
  */
 async function getIdDict(
   win: BrowserWindow,
   config: Config,
+  update = false,
 ): Promise<{ [key: string]: string }> {
   const dictUrl = await getConvertDataUrl(win, config);
+  if (update) {
+    const convertJson = await downloadFile(win, dictUrl, {
+      subDir: 'package',
+      keyText: dictUrl,
+    });
+    return convertJson ? await readJson(convertJson) : {};
+  }
   const convertJson = existsTempFile(
     path.join('package', path.basename(dictUrl)),
     dictUrl,
@@ -79,6 +88,42 @@ async function getIdDict(
   } else {
     return {};
   }
+}
+
+/**
+ * Converts the package ids in apm.json using the conversion dictionary.
+ * 旧 src/lib/convertId.ts の convertId と同一の挙動(新 ID の解決に
+ * packageItem.id を引く点も含めて維持)。
+ * @param {BrowserWindow} win - A browser window used for the download session.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @param {number} modTime - A mod time.
+ */
+export async function convertPackageIds(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+  modTime: number,
+) {
+  const apmJson = await ApmJson.load(instPath);
+  apmJson.begin();
+  const packages = (await apmJson.get('packages')) as {
+    [key: string]: { id: string };
+  };
+
+  const convDict = await getIdDict(win, config, true);
+  for (const [oldId, packageItem] of Object.entries(packages)) {
+    if (Object.prototype.hasOwnProperty.call(convDict, oldId)) {
+      const newId = convDict[packageItem.id];
+      packages[newId] = packages[oldId];
+      delete packages[oldId];
+      packages[newId].id = newId;
+    }
+  }
+
+  await apmJson.set('packages', packages);
+  await apmJson.set('convertMod', modTime);
+  await apmJson.commit();
 }
 
 /**

--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -5,7 +5,6 @@ import path from 'node:path';
 import ApmJson from '../../lib/ApmJson';
 import * as buttonTransition from '../../lib/buttonTransition';
 import { getConfig } from '../../lib/Config';
-import { convertId } from '../../lib/convertId';
 import { app, openDialog, openDirDialog } from '../../lib/ipcWrapper';
 import * as modList from '../../lib/modList';
 import replaceText from '../../lib/replaceText';
@@ -136,7 +135,12 @@ async function changeInstallationPath(instPath: string) {
       const currentConvertMod = new Date(currentMod.convert.modified).getTime();
 
       if (oldConvertMod.getTime() < currentConvertMod)
-        await convertId(instPath, currentConvertMod);
+        // 変換辞書の取得と apm.json の書き換えは main プロセス側
+        // (services/packages.ts の convertPackageIds)へ移設済み
+        await trpc.packages.convertIds.mutate({
+          instPath,
+          modTime: currentConvertMod,
+        });
     }
   }
 


### PR DESCRIPTION
## 概要

changeInstallationPath 連鎖の main 化に向けた小スライス。

- `services/packages.ts` の `getIdDict` に `update = true`(辞書ダウンロード)対応を追加し、`convertPackageIds`(apm.json の ID 書き換えトランザクション)を移設。tRPC `packages.convertIds` mutation として公開
- 旧実装の「新 ID の解決に `packageItem.id` を引く」挙動もそのまま維持(現行コードが仕様書)
- `lib/convertId.ts` には parseJson(データエディタ)が使う `getIdDict` のみ残置

次の弧は migration 連鎖(migration1to2 / 2to3 + parseXML)の main 化で、その後 preload の初期化フロー縮小 → Phase 3 の旧コード削除に進みます。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(128 件)すべて緑
- `yarn package` + CDP スモーク 17 項目 ALL PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)