### PR TITLE
fix(shared): verifyFile の遅延ストリームエラーによる CI flake を修正

### DIFF
--- a/src/shared/integrity.ts
+++ b/src/shared/integrity.ts
@@ -36,6 +36,11 @@ export async function verifyFile(filePath: string, integrity: string) {
   let readStream;
   try {
     readStream = fs.createReadStream(filePath);
+    // checkStream(内部は pipe)は source の error イベントを引き取らない。
+    // 早期 reject 後に遅れて届く open/read エラー(競合で消えた一時ファイル等)が
+    // リスナー無しの error イベント = プロセスの uncaught exception になるため、
+    // 先に握りつぶすリスナーを付けておく。失敗は戻り値 false で表現される
+    readStream.on('error', () => {});
     await checkStream(readStream, integrity);
   } catch {
     return false;


### PR DESCRIPTION
## 概要

CI の Lint ジョブが `integrity.test.ts` 由来の Unhandled Error で不定期に落ちる flake の修正です([#2332 の初回 CI](https://github.com/team-apm/apm/actions/runs/32095896035/job/95587063890) で発生。テスト自体は 138 件全部緑なのに Vitest が uncaught exception を検出して exit 1)。

## 原因

`verifyFile` は `fs.createReadStream` → `ssri.checkStream`(内部は pipe)という構成ですが、**pipe は source ストリームの error イベントを引き取りません**。checkStream が早期 reject するケース(不正な integrity 文字列等)では source に error リスナーが一度も付かないまま処理が終わり、その後に遅れて届く open エラー(CI ではテストの afterEach が一時ファイルを削除した後に open が実行され ENOENT)がリスナー無しの error イベント = プロセスの uncaught exception になっていました。

テストだけでなく本番でも、レース等でファイルが消えた場合に main プロセスを落とし得る経路です。

## 修正

ストリーム生成直後に握りつぶす error リスナーを付けます。失敗は従来どおり戻り値 `false` で表現されるため、挙動の変化はありません。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test` すべて緑
- 競合の決定的な再現はスレッドプールの実行順序に依存するためできませんが(ローカルの単一スレッド実験では open が unlink より先に FIFO 実行される)、リスナーの有無でクラッシュ経路が閉じることは構造上明確です

🤖 Generated with [Claude Code](https://claude.com/claude-code)
