### PR TITLE
refactor(core): changeInstallationPath の判定・更新を main プロセスへ移設

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -5,10 +5,12 @@ import { getConfig } from '../lib/Config';
 import { openAboutWindow } from './aboutWindow';
 import { isExeVersion } from './services/appUpdate';
 import {
+  changeInstallationPath,
   checkCoreLatestVersion,
   getApmJsonCoreVersions,
   getCoreInfo,
   getInstalledVersionTexts,
+  hasExeditInPluginsFolder,
   installCoreProgram,
 } from './services/core';
 import { migrationByFolder, migrationGlobal } from './services/migration';
@@ -400,6 +402,16 @@ export const router = t.router({
       if (!win) throw new Error('The calling window was not found.');
       return await getCoreInfo(win, getConfig());
     }),
+    hasExeditInPluginsFolder: procedure
+      .input(stringInput)
+      .query(({ input }) => hasExeditInPluginsFolder(input)),
+    changeInstallationPath: procedure
+      .input(stringInput)
+      .mutation(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        return await changeInstallationPath(win, getConfig(), input);
+      }),
     getApmJsonCoreVersions: procedure
       .input(stringInput)
       .query(async ({ input }) => await getApmJsonCoreVersions(input)),

--- a/src/main/services/core.ts
+++ b/src/main/services/core.ts
@@ -11,7 +11,9 @@ import { install, verifyFilesByCount } from '../../shared/install';
 import { checkIntegrity, verifyFile } from '../../shared/integrity';
 import unzip from '../../shared/unzip';
 import { downloadFile } from './download';
+import { migrationByFolder } from './migration';
 import { getCoreDataUrl, getInfo, updateInfo } from './modList';
+import { convertPackageIds } from './packages';
 import { existsTempFile } from './tempFile';
 
 /**
@@ -219,4 +221,77 @@ export async function installCoreProgram(
     log.error(e);
     return 'installFailed';
   }
+}
+
+/**
+ * Returns whether ExEdit is misplaced in the `plugins` folder.
+ * @param {string} instPath - An installation path.
+ * @returns {boolean} True if `plugins/exedit.auf` exists.
+ */
+export function hasExeditInPluginsFolder(instPath: string): boolean {
+  return existsSync(path.join(instPath, 'plugins/exedit.auf'));
+}
+
+export type ChangeInstallationPathResult = {
+  needScriptsUpdate: boolean;
+  needCoreUpdate: boolean;
+  needPackagesUpdate: boolean;
+};
+
+/**
+ * Applies an installation path change: updates the mod info, runs the folder
+ * migration and the id conversion, and reports which data needs re-fetching.
+ * 旧 src/renderer/main/core.ts の changeInstallationPath の判定・更新部分と
+ * 同一の挙動。UI の再取得・再描画は renderer 側が戻り値を見て行う。
+ * @param {BrowserWindow} win - The main window.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ * @returns {Promise<ChangeInstallationPathResult>} Which data needs re-fetching.
+ */
+export async function changeInstallationPath(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+): Promise<ChangeInstallationPathResult> {
+  config.setInstallationPath(instPath);
+
+  // update 1
+  await updateInfo(win, config);
+  const currentMod = await getInfo(win, config);
+
+  if (existsSync(instPath)) {
+    // migration
+    await migrationByFolder(win, config, instPath);
+
+    if (existsSync(ApmJson.getPath(instPath)) && currentMod.convert) {
+      const apmJson = await ApmJson.load(instPath);
+      const oldConvertMod = new Date(
+        (await apmJson.get('convertMod', 0)) as number,
+      );
+      const currentConvertMod = new Date(currentMod.convert.modified).getTime();
+
+      if (oldConvertMod.getTime() < currentConvertMod)
+        await convertPackageIds(win, config, instPath, currentConvertMod);
+    }
+  }
+
+  // update 2
+  const oldScriptsMod = new Date(config.modDate.getScripts());
+  const oldCoreMod = new Date(config.modDate.getCore());
+  const oldPackagesMod = new Date(config.modDate.getPackages());
+
+  return {
+    needScriptsUpdate:
+      oldScriptsMod.getTime() <
+      Math.max(
+        ...currentMod.scripts.map((p) => new Date(p.modified).getTime()),
+      ),
+    needCoreUpdate:
+      oldCoreMod.getTime() < new Date(currentMod.core.modified).getTime(),
+    needPackagesUpdate:
+      oldPackagesMod.getTime() <
+      Math.max(
+        ...currentMod.packages.map((p) => new Date(p.modified).getTime()),
+      ),
+  };
 }

--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -1,12 +1,9 @@
 import { Core } from 'apm-schema';
 import log from 'electron-log/renderer';
-import fs from 'fs-extra';
 import path from 'node:path';
-import ApmJson from '../../lib/ApmJson';
 import * as buttonTransition from '../../lib/buttonTransition';
 import { getConfig } from '../../lib/Config';
 import { app, openDialog, openDirDialog } from '../../lib/ipcWrapper';
-import * as modList from '../../lib/modList';
 import replaceText from '../../lib/replaceText';
 import { trpc } from '../../lib/trpcClient';
 import { programs } from './common';
@@ -94,7 +91,7 @@ async function selectInstallationPath(input: HTMLInputElement) {
     originalPath,
   );
   if (selectedPath.length !== 0 && selectedPath[0] !== originalPath) {
-    if (fs.existsSync(path.join(selectedPath[0], 'plugins/exedit.auf'))) {
+    if (await trpc.core.hasExeditInPluginsFolder.query(selectedPath[0])) {
       await openDialog(
         'エラー',
         '拡張編集が「plugins」フォルダに配置されています。apmは拡張編集を「aviutl.exe」と同じフォルダに配置する場合のみに対応しています。',
@@ -116,51 +113,18 @@ async function selectInstallationPath(input: HTMLInputElement) {
  * @param {string} instPath - An installation path.
  */
 async function changeInstallationPath(instPath: string) {
-  config.setInstallationPath(instPath);
+  // mod 情報の更新・migration・変換辞書の適用と再取得要否の判定は
+  // main プロセス側(services/core.ts の changeInstallationPath)へ移設済み。
+  // renderer は戻り値に従って再取得・再描画のみ行う
+  const need = await trpc.core.changeInstallationPath.mutate(instPath);
 
-  // update 1
-  await modList.updateInfo();
-  const currentMod = await modList.getInfo();
-
-  if (fs.existsSync(instPath)) {
-    // migration(実装は main プロセス側 services/migration.ts へ移設済み)
-    await trpc.migration.byFolder.mutate(instPath);
-
-    if (fs.existsSync(ApmJson.getPath(instPath)) && currentMod.convert) {
-      const apmJson = await ApmJson.load(instPath);
-      const oldConvertMod = new Date(
-        (await apmJson.get('convertMod', 0)) as number,
-      );
-      const currentConvertMod = new Date(currentMod.convert.modified).getTime();
-
-      if (oldConvertMod.getTime() < currentConvertMod)
-        // 変換辞書の取得と apm.json の書き換えは main プロセス側
-        // (services/packages.ts の convertPackageIds)へ移設済み
-        await trpc.packages.convertIds.mutate({
-          instPath,
-          modTime: currentConvertMod,
-        });
-    }
-  }
-
-  // update 2
-  const oldScriptsMod = new Date(config.modDate.getScripts());
-  const oldCoreMod = new Date(config.modDate.getCore());
-  const oldPackagesMod = new Date(config.modDate.getPackages());
-
-  if (
-    oldScriptsMod.getTime() <
-    Math.max(...currentMod.scripts.map((p) => new Date(p.modified).getTime()))
-  ) {
+  if (need.needScriptsUpdate) {
     await packageMain.getScriptsList(true);
   }
-  if (oldCoreMod.getTime() < new Date(currentMod.core.modified).getTime()) {
+  if (need.needCoreUpdate) {
     await checkLatestVersion();
   }
-  if (
-    oldPackagesMod.getTime() <
-    Math.max(...currentMod.packages.map((p) => new Date(p.modified).getTime()))
-  ) {
+  if (need.needPackagesUpdate) {
     await packageMain.checkPackagesList(instPath);
   }
 


### PR DESCRIPTION
## 概要

preload 初期化フロー縮小の弧の第 1 スライスです(fix PR の上に積んだスタック PR)。`changeInstallationPath` の判定・更新ロジックを main プロセスへ移設し、renderer の `core.ts` から fs / ApmJson / modList 依存を除去しました。

## 変更内容

- **`src/main/services/core.ts`**: `changeInstallationPath(win, config, instPath)` を追加。旧 renderer 実装の忠実な移植で、mod 情報の更新(updateInfo / getInfo)→ migration byFolder → 変換辞書の適用判定(convertMod 比較 + convertPackageIds)→ 再取得要否の判定(modDate 比較)までを main 側で行い、`{needScriptsUpdate, needCoreUpdate, needPackagesUpdate}` を返す。`hasExeditInPluginsFolder(instPath)` も追加
- **`src/main/api.ts`**: `core.changeInstallationPath` mutation / `core.hasExeditInPluginsFolder` query を追加
- **`src/renderer/main/core.ts`**: `changeInstallationPath` は戻り値に従って再取得(getScriptsList / checkLatestVersion / checkPackagesList)と再描画のみ行う委譲に。`selectInstallationPath` の exedit.auf 配置チェックも query 委譲。fs / ApmJson / modList の import を除去(残 import は UI 系 + path のみ)

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(138 件)すべて緑
- `yarn package` + CDP スモーク 11 項目 ALL PASS・未処理例外ゼロ(起動時に main 側 changeInstallationPath が通ることを含む)

## 依存

ベース: fix(trpc) PR(ID 衝突修正)。この修正なしでは本スライスは起動時 TypeError を踏みます(衝突が顕在化するタイミングになるため)。ベースのマージ後に main へ rebase します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
