### PR TITLE
refactor(package): checkPackagesList の再取得処理を main プロセスへ移設

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -19,7 +19,6 @@ import { getNicommonsData } from './services/nicommons';
 import {
   buildShareString,
   convertPackageIds,
-  downloadRepository,
   getApmJsonInstalledIds,
   getPackages,
   getPackagesExtra,
@@ -27,6 +26,7 @@ import {
   getScriptsList,
   installPackageFlow,
   installScriptFlow,
+  refreshPackagesList,
   uninstallPackageFiles,
 } from './services/packages';
 import { ensureExtraDataUrl, setDataUrls } from './services/settings';
@@ -281,12 +281,12 @@ export const router = t.router({
       if (!win) throw new Error('The calling window was not found.');
       return await getPackages(win, getConfig(), input);
     }),
-    downloadRepository: procedure
+    refreshList: procedure
       .input(stringInput)
       .mutation(async ({ input, ctx }) => {
         const win = BrowserWindow.fromWebContents(ctx.event.sender);
         if (!win) throw new Error('The calling window was not found.');
-        await downloadRepository(win, getConfig(), input);
+        await refreshPackagesList(win, getConfig(), input);
       }),
     getPackagesExtra: procedure
       .input(stringInput)

--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -34,7 +34,12 @@ import { ApmJsonObject } from '../../types/apmJson';
 import { PackageItem } from '../../types/packageItem';
 import { openBrowser } from './browser';
 import { downloadFile } from './download';
-import { getConvertDataUrl, getInfo, getScriptsDataUrl } from './modList';
+import {
+  getConvertDataUrl,
+  getInfo,
+  getScriptsDataUrl,
+  updateInfo,
+} from './modList';
 import { existsTempFile } from './tempFile';
 
 /**
@@ -1057,4 +1062,27 @@ export async function installScriptFlow(
       },
     ),
   };
+}
+
+/**
+ * Refreshes the packages data: re-downloads list.json and the package
+ * repositories, and records the check/mod dates.
+ * 旧 src/renderer/main/package.ts の checkPackagesList のデータ取得部分と
+ * 同一の挙動。ボタン・オーバーレイなどの UI は renderer 側に残る。
+ * @param {BrowserWindow} win - The main window.
+ * @param {Config} config - The config instance.
+ * @param {string} instPath - An installation path.
+ */
+export async function refreshPackagesList(
+  win: BrowserWindow,
+  config: Config,
+  instPath: string,
+) {
+  await updateInfo(win, config);
+  await downloadRepository(win, config, instPath);
+  config.checkDate.setPackages(Date.now());
+  const modInfo = await getInfo(win, config);
+  config.modDate.setPackages(
+    Math.max(...modInfo.packages.map((p) => new Date(p.modified).getTime())),
+  );
 }

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -3,7 +3,6 @@ import log from 'electron-log/renderer';
 import * as buttonTransition from '../../lib/buttonTransition';
 import { getConfig } from '../../lib/Config';
 import { clipboardWriteText, openPath } from '../../lib/ipcWrapper';
-import * as modList from '../../lib/modList';
 import replaceText from '../../lib/replaceText';
 import { trpc } from '../../lib/trpcClient';
 import type { InstallScriptFlowResult } from '../../main/services/packages';
@@ -147,13 +146,9 @@ async function checkPackagesList(instPath: string) {
   }
 
   try {
-    await modList.updateInfo();
-    await packageUtil.downloadRepository(instPath);
-    config.checkDate.setPackages(Date.now());
-    const modInfo = await modList.getInfo();
-    config.modDate.setPackages(
-      Math.max(...modInfo.packages.map((p) => new Date(p.modified).getTime())),
-    );
+    // 再取得と日付の記録は main プロセス側(services/packages.ts の
+    // refreshPackagesList)へ移設済み
+    await trpc.packages.refreshList.mutate(instPath);
     await setPackagesList(instPath);
 
     if (btn) buttonTransition.message(btn, '更新完了', 'success');

--- a/src/renderer/main/packageUtil.ts
+++ b/src/renderer/main/packageUtil.ts
@@ -18,15 +18,6 @@ async function getPackages(instPath: string) {
 }
 
 /**
- * Downloads the package data files.
- * 実装は main プロセス側(src/main/services/packages.ts)へ移設済み。
- * @param {string} instPath - An installation path
- */
-async function downloadRepository(instPath: string) {
-  await trpc.packages.downloadRepository.mutate(instPath);
-}
-
-/**
  * Updates the installedVersion of the packages and returns a list of
  * manually installed files.
  * 実装は main プロセス側(src/main/services/packages.ts)へ移設済み。
@@ -64,7 +55,6 @@ const packageUtil = {
   states,
   parsePackageType,
   getPackages,
-  downloadRepository,
   getPackagesExtra,
   getPackagesWithStatus,
 };

--- a/src/renderer/main/setting.ts
+++ b/src/renderer/main/setting.ts
@@ -1,6 +1,5 @@
 import log from 'electron-log/renderer';
 import { openDialog } from '../../lib/ipcWrapper';
-import * as modList from '../../lib/modList';
 import { trpc } from '../../lib/trpcClient';
 
 /**
@@ -18,7 +17,7 @@ async function initSettings() {
       await openDialog('エラー', message, 'error');
     }
     if (errors.length === 0) {
-      await modList.updateInfo();
+      await trpc.modList.updateInfo.mutate();
     } else {
       log.error('An error has occurred while setting data URL.');
     }


### PR DESCRIPTION
## 概要

preload 初期化フロー縮小の弧の続きです。`checkPackagesList`(Plugins タブの「更新」ボタン)のデータ取得部分を main プロセスへ移設し、renderer の modList 依存をデータエディタ系(monacoEditorPreload → parseJson/convertId 連鎖)だけに縮小しました。

## 変更内容

- **`src/main/services/packages.ts`**: `refreshPackagesList(win, config, instPath)` を追加。旧 renderer 実装の忠実な移植(updateInfo → downloadRepository → checkDate 記録 → getInfo → modDate 記録)
- **`src/main/api.ts`**: `packages.refreshList` mutation を追加。renderer から利用者のいなくなった `packages.downloadRepository` ルートを削除(main 内部関数としては refreshPackagesList が利用)
- **`src/renderer/main/package.ts`**: checkPackagesList はボタン・オーバーレイ UI と `setPackagesList` の再描画のみに。modList import を除去
- **`src/renderer/main/setting.ts`**: `modList.updateInfo()` → `trpc.modList.updateInfo.mutate()` 直呼びに変更し modList import を除去
- **`src/renderer/main/packageUtil.ts`**: 未使用になった downloadRepository wrapper を削除

renderer で lib/modList を使うのはデータエディタ系(`monacoEditorPreload.ts` の getEditorPackagesDataUrl / convertId 経由の getConvertDataUrl)のみになりました。この連鎖はデータエディタの弧で回収します。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(138 件)すべて緑
- `yarn package` + CDP スモーク 11 項目 ALL PASS・未処理例外ゼロ
- 「更新」ボタンの実走確認(CDP でクリック → main 側 refreshList 実行 → 「更新完了」表示)PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
