### PR TITLE
refactor(package): おすすめプラグイン一覧を React 化

### DIFF
--- a/src/renderer/main/aviutl/BatchInstallList.tsx
+++ b/src/renderer/main/aviutl/BatchInstallList.tsx
@@ -1,0 +1,64 @@
+import React, { type JSX, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { PackageItem } from '../../../types/packageItem';
+import { TRPCReact } from '../../trpc';
+
+/**
+ * The list of the recommended plugins (directURL packages) shown in the
+ * batch-install section of the AviUtl tab.
+ * 旧 package.ts の updateBatchInstallList と同一の表示。
+ * クエリは PackagesTab と同じキー(fixIntegrity: true)でキャッシュを共有する
+ * (apm.json の整合性補正は冪等のため表示結果は旧実装と変わらない)。
+ * レガシー側からの再描画通知(apm-packages-changed イベント)で自動更新する。
+ * @returns {JSX.Element} The rendered component.
+ */
+function BatchInstallList(): JSX.Element {
+  const [instPath, setInstPath] = useState(
+    () => window.coreBridge?.getInstallationPath() ?? '',
+  );
+
+  const utils = TRPCReact.useContext();
+  const packagesQuery = TRPCReact.packages.getPackagesWithStatus.useQuery(
+    { instPath, fixIntegrity: true },
+    { refetchOnWindowFocus: false },
+  );
+
+  // レガシー側(preload の package.ts)からの再描画通知を受けて最新化する
+  useEffect(() => {
+    const listener = () => {
+      setInstPath(window.coreBridge?.getInstallationPath() ?? '');
+      void utils.packages.getPackagesWithStatus.invalidate();
+    };
+    window.addEventListener('apm-packages-changed', listener);
+    return () => window.removeEventListener('apm-packages-changed', listener);
+  }, [utils]);
+
+  // tRPC の Serialize 型はプロパティを optional 化するため元の型に戻す
+  const packages = (packagesQuery.data?.packages ?? []) as PackageItem[];
+  const batchInstallPackages = packages.filter((p) => p.info.directURL);
+
+  const listElement = document.getElementById('batch-install-packages');
+  if (!listElement) return <></>;
+
+  return createPortal(
+    <>
+      {batchInstallPackages.map((p) => (
+        <li
+          key={p.id}
+          className="list-group-item py-0 d-flex py-2 batch-install-package"
+        >
+          <div className="d-flex align-items-center flex-grow-1">
+            <i className="bi bi-box-seam me-3"></i>
+            <div className="name">{p.info.name}</div>
+          </div>
+          <div>
+            <span className="installed-version">{p.installationStatus}</span>
+          </div>
+        </li>
+      ))}
+    </>,
+    listElement,
+  );
+}
+
+export default BatchInstallList;

--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -115,7 +115,7 @@ async function changeInstallationPath(instPath: string) {
 
   // redraw
   await displayInstalledVersion();
-  await packageMain.setPackagesList(instPath);
+  await packageMain.setPackagesList();
 }
 
 /**
@@ -199,7 +199,7 @@ async function installProgram(
   try {
     if (result === 'success') {
       await displayInstalledVersion();
-      await packageMain.setPackagesList(instPath);
+      await packageMain.setPackagesList();
 
       if (btn) buttonTransition.message(btn, 'インストール完了', 'success');
     } else {

--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -151,7 +151,7 @@
 								</button>
 							</div>
 							<ul class="list-group mb-3" id="batch-install-packages">
-								<!-- 中身は React(ProgramRow)が描画する -->
+								<!-- 中身は React(ProgramRow / BatchInstallList)が描画する -->
 								<li
 									class="list-group-item py-0 pe-0 d-flex"
 									id="aviutl-program-root"
@@ -161,20 +161,7 @@
 									id="exedit-program-root"
 								></li>
 							</ul>
-							<div class="d-none">
-								<li
-									id="batch-install-package-template"
-									class="list-group-item py-0 d-flex py-2 batch-install-package"
-								>
-									<div class="d-flex align-items-center flex-grow-1">
-										<i class="bi bi-box-seam me-3"></i>
-										<div class="name"></div>
-									</div>
-									<div>
-										<span class="installed-version"></span>
-									</div>
-								</li>
-							</div>
+							<div class="d-none" id="batch-install-react-root"></div>
 							<div class="d-flex justify-content-end">
 								<button
 									type="button"

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -24,45 +24,16 @@ async function getPackages(instPath: string) {
 }
 
 /**
- * Requests the React list (PackagesTab) to refresh, and updates the legacy
- * parts that are not migrated yet (batch-install text and mod dates).
- * 一覧の描画・ソート・検索・フィルタは React 側(packages/PackagesTab.tsx)へ
- * 移設済み。
- * @param {string} instPath - An installation path.
+ * Requests the React lists (PackagesTab / BatchInstallList) to refresh, and
+ * updates the legacy parts that are not migrated yet (mod dates).
+ * 一覧の描画・ソート・検索・フィルタは React 側(packages/PackagesTab.tsx)、
+ * おすすめプラグイン一覧は React 側(aviutl/BatchInstallList.tsx)へ移設済み。
  */
-async function setPackagesList(instPath: string) {
+async function setPackagesList() {
   // 隔離ワールドの DOM イベントはメインワールドに届くため、これで React 側が
   // tRPC クエリを再取得する
   window.dispatchEvent(new Event('apm-packages-changed'));
-  await updateBatchInstallList(instPath);
   await updateModDates();
-}
-
-/**
- * Updates the batch installation text in the AviUtl tab.
- * @param {string} instPath - An installation path.
- */
-async function updateBatchInstallList(instPath: string) {
-  const packages = (await packageUtil.getPackagesWithStatus(instPath)).packages;
-  const batchInstallElm = document.getElementById('batch-install-packages');
-  [...batchInstallElm.getElementsByClassName('batch-install-package')].map(
-    (e) => e.remove(),
-  );
-  packages
-    .filter((p) => p.info.directURL)
-    .map((p) => {
-      const liTag = document
-        .getElementById('batch-install-package-template')
-        .cloneNode(true) as HTMLSpanElement;
-      liTag.removeAttribute('id');
-      (liTag.getElementsByClassName('name')[0] as HTMLElement).innerText =
-        p.info.name;
-      (
-        liTag.getElementsByClassName('installed-version')[0] as HTMLElement
-      ).innerText = p.installationStatus;
-      return liTag;
-    })
-    .forEach((e) => batchInstallElm.appendChild(e));
 }
 
 /**
@@ -149,7 +120,7 @@ async function checkPackagesList(instPath: string) {
     // 再取得と日付の記録は main プロセス側(services/packages.ts の
     // refreshPackagesList)へ移設済み
     await trpc.packages.refreshList.mutate(instPath);
-    await setPackagesList(instPath);
+    await setPackagesList();
 
     if (btn) buttonTransition.message(btn, '更新完了', 'success');
   } catch (e) {
@@ -353,7 +324,7 @@ async function installPackage(
   }
 
   if (result === 'success') {
-    await setPackagesList(instPath);
+    await setPackagesList();
 
     if (btn) buttonTransition.message(btn, 'インストール完了', 'success');
   } else {
@@ -441,7 +412,7 @@ async function uninstallPackage(instPath: string) {
     // スクリプト由来のパッケージのローカル packages.json からの削除は
     // main プロセス側(services/packages.ts)へ移設済み
     if (!uninstalledPackage.id.startsWith('script_')) {
-      await setPackagesList(instPath);
+      await setPackagesList();
     } else {
       await checkPackagesList(instPath);
     }
@@ -567,7 +538,7 @@ async function installScript(instPath: string) {
     }
   } else if (result.route === 'redirect') {
     if (result.status === 'success') {
-      await setPackagesList(instPath);
+      await setPackagesList();
       buttonTransition.message(btn, 'インストール完了', 'success');
     } else {
       buttonTransition.message(btn, 'エラーが発生しました。', 'danger');

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -26,11 +26,7 @@ contextBridge.exposeInMainWorld('coreBridge', {
     return input?.value ?? '';
   },
   onProgramInstalled: async () => {
-    const input = document.getElementById(
-      'installation-path',
-    ) as HTMLInputElement | null;
-    const instPath = input?.value ?? '';
-    await packageMain.setPackagesList(instPath);
+    await packageMain.setPackagesList();
   },
 });
 

--- a/src/renderer/main/renderer.tsx
+++ b/src/renderer/main/renderer.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client';
 import '../../../node_modules/bootstrap-icons/font/bootstrap-icons.css';
 import '../main.css';
 import './index.css';
+import BatchInstallList from './aviutl/BatchInstallList';
 import ProgramRow from './aviutl/ProgramRow';
 import { MonacoEditorRenderer } from './monacoEditorRenderer';
 import NicommonsTab from './nicommons/NicommonsTab';
@@ -67,6 +68,12 @@ window.addEventListener('DOMContentLoaded', () => {
         iconClass="bi-calendar3-range"
         buttonRoundedClass="rounded-0"
       />
+    </TrpcProvider>,
+  );
+  // おすすめプラグイン一覧は portal で #batch-install-packages(ul)へ描画する
+  createRoot(document.getElementById('batch-install-react-root')).render(
+    <TrpcProvider>
+      <BatchInstallList />
     </TrpcProvider>,
   );
 });


### PR DESCRIPTION
## 概要

AviUtl タブの残レガシー回収です。おすすめプラグイン一覧(batch-install セクションの directURL パッケージ表示)を React 化しました。

## 変更内容

- **`src/renderer/main/aviutl/BatchInstallList.tsx`**(新規): 旧 `updateBatchInstallList` と同一の表示を portal で `#batch-install-packages`(ul)へ描画。ProgramRow の 2 行(静的 li)の後ろに追加される位置関係も旧実装(末尾 append)と同じ
- クエリは PackagesTab と同じキー(`getPackagesWithStatus {instPath, fixIntegrity: true}`)にして react-query のキャッシュを共有(旧実装は `fixIntegrity: false` でしたが、同一起動内で PackagesTab が先に補正を済ませるため表示結果は同一。二重取得も回避)
- **`src/renderer/main/package.ts`**: `updateBatchInstallList` を削除。`setPackagesList` はイベント通知 + 日付表示のみになったため instPath 引数を削除(呼び出し元 6 箇所も更新)
- **`src/renderer/main/index.html`**: `batch-install-package-template` を削除し React root を追加

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(138 件)すべて緑
- `yarn package` + CDP スモーク 11 項目 ALL PASS・未処理例外ゼロ
- BatchInstallList の DOM 検証(CDP): `.batch-install-package` の li が ul 直下に 2 件(L-SMASH Works・かんたんMP4出力)、name / installed-version とも旧実装と同一構造で描画されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
