### PR TITLE
refactor(core): changeInstallationPath の後続更新を main プロセスへ集約

### DIFF
--- a/src/main/services/core.ts
+++ b/src/main/services/core.ts
@@ -13,7 +13,11 @@ import { addAviUtlShortcut, removeAviUtlShortcut } from '../shortcut';
 import { downloadFile } from './download';
 import { migrationByFolder } from './migration';
 import { getCoreDataUrl, getInfo, updateInfo } from './modList';
-import { convertPackageIds } from './packages';
+import {
+  convertPackageIds,
+  getScriptsList,
+  refreshPackagesList,
+} from './packages';
 import { existsTempFile } from './tempFile';
 
 /**
@@ -232,27 +236,21 @@ export function hasExeditInPluginsFolder(instPath: string): boolean {
   return existsSync(path.join(instPath, 'plugins/exedit.auf'));
 }
 
-export type ChangeInstallationPathResult = {
-  needScriptsUpdate: boolean;
-  needCoreUpdate: boolean;
-  needPackagesUpdate: boolean;
-};
-
 /**
  * Applies an installation path change: updates the mod info, runs the folder
- * migration and the id conversion, and reports which data needs re-fetching.
- * 旧 src/renderer/main/core.ts の changeInstallationPath の判定・更新部分と
- * 同一の挙動。UI の再取得・再描画は renderer 側が戻り値を見て行う。
+ * migration and the id conversion, and re-fetches the outdated data.
+ * 旧 src/renderer/main/core.ts の changeInstallationPath と同一の挙動
+ * (判定に加えて scripts・core・packages の再取得まで行う)。
+ * UI の再描画は renderer 側の責務。
  * @param {BrowserWindow} win - The main window.
  * @param {Config} config - The config instance.
  * @param {string} instPath - An installation path.
- * @returns {Promise<ChangeInstallationPathResult>} Which data needs re-fetching.
  */
 export async function changeInstallationPath(
   win: BrowserWindow,
   config: Config,
   instPath: string,
-): Promise<ChangeInstallationPathResult> {
+): Promise<void> {
   config.setInstallationPath(instPath);
 
   // update 1
@@ -280,20 +278,32 @@ export async function changeInstallationPath(
   const oldCoreMod = new Date(config.modDate.getCore());
   const oldPackagesMod = new Date(config.modDate.getPackages());
 
-  return {
-    needScriptsUpdate:
-      oldScriptsMod.getTime() <
-      Math.max(
-        ...currentMod.scripts.map((p) => new Date(p.modified).getTime()),
-      ),
-    needCoreUpdate:
-      oldCoreMod.getTime() < new Date(currentMod.core.modified).getTime(),
-    needPackagesUpdate:
-      oldPackagesMod.getTime() <
-      Math.max(
-        ...currentMod.packages.map((p) => new Date(p.modified).getTime()),
-      ),
-  };
+  if (
+    oldScriptsMod.getTime() <
+    Math.max(...currentMod.scripts.map((p) => new Date(p.modified).getTime()))
+  ) {
+    await getScriptsList(win, config, true);
+  }
+  if (oldCoreMod.getTime() < new Date(currentMod.core.modified).getTime()) {
+    // 旧 renderer の checkLatestVersion は失敗をボタン表示に丸めて
+    // 後続処理を続けていたため、ここでも throw せずログのみ残す
+    try {
+      await checkCoreLatestVersion(win, config);
+    } catch (e) {
+      log.error(e);
+    }
+  }
+  if (
+    oldPackagesMod.getTime() <
+    Math.max(...currentMod.packages.map((p) => new Date(p.modified).getTime()))
+  ) {
+    // 旧 renderer の checkPackagesList も同様に失敗を throw しない
+    try {
+      await refreshPackagesList(win, config, instPath);
+    } catch (e) {
+      log.error(e);
+    }
+  }
 }
 
 /**

--- a/src/renderer/main/core.ts
+++ b/src/renderer/main/core.ts
@@ -85,20 +85,10 @@ async function selectInstallationPath(input: HTMLInputElement) {
  * @param {string} instPath - An installation path.
  */
 async function changeInstallationPath(instPath: string) {
-  // mod 情報の更新・migration・変換辞書の適用と再取得要否の判定は
+  // mod 情報の更新・migration・変換辞書の適用と、必要なデータの再取得は
   // main プロセス側(services/core.ts の changeInstallationPath)へ移設済み。
-  // renderer は戻り値に従って再取得・再描画のみ行う
-  const need = await trpc.core.changeInstallationPath.mutate(instPath);
-
-  if (need.needScriptsUpdate) {
-    await packageMain.getScriptsList(true);
-  }
-  if (need.needCoreUpdate) {
-    await checkLatestVersion();
-  }
-  if (need.needPackagesUpdate) {
-    await packageMain.checkPackagesList(instPath);
-  }
+  // renderer は再描画のみ行う
+  await trpc.core.changeInstallationPath.mutate(instPath);
 
   // redraw
   await displayInstalledVersion();

--- a/src/renderer/main/package.ts
+++ b/src/renderer/main/package.ts
@@ -1,4 +1,3 @@
-import { Scripts } from 'apm-schema';
 import log from 'electron-log/renderer';
 import * as buttonTransition from '../../lib/buttonTransition';
 import replaceText from '../../lib/replaceText';
@@ -81,22 +80,8 @@ async function checkPackagesList(instPath: string) {
   }
 }
 
-/**
- * Checks the scripts list.
- * 取得・キャッシュ・更新日時の記録は main プロセス側(services/packages.ts)へ移設済み。
- * @param {boolean} update - Download the json file.
- * @returns {Promise<Scripts>} - An object parsed from scripts.json.
- */
-async function getScriptsList(update = false) {
-  return (await trpc.packages.getScriptsList.query({ update })) as {
-    webpage: Scripts['webpage'];
-    scripts: Scripts['scripts'];
-  };
-}
-
 const packageMain = {
   setPackagesList,
   checkPackagesList,
-  getScriptsList,
 };
 export default packageMain;


### PR DESCRIPTION
## 概要

これまで main の `changeInstallationPath` は「何を更新すべきか」の判定結果(needScriptsUpdate / needCoreUpdate / needPackagesUpdate)を renderer に返し、renderer が tRPC で main の更新処理を呼び戻すブーメラン構造でした。renderer を経由する理由は設定タブの更新ボタン演出のみで、パス変更時はそのタブ自体が見えていないため、更新の実行も main 側で完結させます。

## 変更内容

- **`src/main/services/core.ts`**: `changeInstallationPath` が判定に加えて scripts / core / packages の再取得(`getScriptsList(update)` / `checkCoreLatestVersion` / `refreshPackagesList`)まで実行して完結。旧 renderer の `checkLatestVersion` / `checkPackagesList` は失敗をボタン表示に丸めて後続処理を続けていたため、main 側でも core / packages の再取得失敗は throw せずログのみ残します(scripts は旧実装どおり throw で中断)
- **`src/renderer/main/core.ts`**: `changeInstallationPath` は mutate + 再描画通知のみに縮小
- **`src/renderer/main/package.ts`**: 唯一の利用者(旧 changeInstallationPath)を失った `getScriptsList` を削除

## 挙動の差分(意図的)

パス変更に伴うデータ再取得中、設定タブの更新ボタン(check-core-version / check-packages-list)とプラグインタブのオーバーレイのローディング演出が出なくなります。パス変更の操作中はどちらのタブも表示されていないため、実用上の見え方は変わりません。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(138 件)すべて緑
- `yarn package` + CDP スモーク 11 項目 ALL PASS(起動フロー = ensureInstallationPath → changeInstallationPath の実走を含む)・未処理例外ゼロ
- 更新ボタン(refreshList 経由の再取得)スモーク PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
