### PR TITLE
feat(security): メイン窓と About 窓の sandbox を有効化

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -69,7 +69,7 @@ export async function launch(config: Config) {
     titleBarOverlay: getTitleBarColor(),
     webPreferences: {
       preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
-      sandbox: false,
+      sandbox: true,
     },
   });
 
@@ -116,7 +116,7 @@ export async function launch(config: Config) {
       icon: icon,
       webPreferences: {
         preload: ABOUT_WINDOW_PRELOAD_WEBPACK_ENTRY,
-        sandbox: false,
+        sandbox: true,
       },
     });
     ipcHandler.attachWindow(aboutWindow);

--- a/src/renderer/about/preload.ts
+++ b/src/renderer/about/preload.ts
@@ -1,7 +1,6 @@
 import { contextBridge } from 'electron';
 import log from 'electron-log/renderer';
 import { exposeElectronTRPC } from 'electron-trpc/main';
-import 'source-map-support/register';
 import { openDialog } from '../../lib/ipcWrapper';
 
 log.errorHandler.startCatching({

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -2,7 +2,6 @@ import ClipboardJS from 'clipboard/src/clipboard';
 import { contextBridge } from 'electron';
 import log from 'electron-log/renderer';
 import { exposeElectronTRPC } from 'electron-trpc/main';
-import 'source-map-support/register';
 import { app, openDialog } from '../../lib/ipcWrapper';
 import { trpc } from '../../lib/trpcClient';
 import { EditorContextBridge } from './monacoEditorPreload';

--- a/webpack.renderer.config.ts
+++ b/webpack.renderer.config.ts
@@ -1,5 +1,5 @@
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
-import type { Configuration } from 'webpack';
+import { BannerPlugin, type Configuration } from 'webpack';
 import { plugins } from './webpack.plugins';
 import { rules } from './webpack.rules';
 
@@ -19,6 +19,17 @@ rules.push({
 });
 
 plugins.push(new MiniCssExtractPlugin());
+
+// sandbox: true の preload には __dirname が無く、forge の webpack plugin が
+// 全バンドル先頭に注入する asset relocator patch(`__dirname + "/native_modules/"`)
+// が ReferenceError で preload 全体を殺すため、空文字のシムを先頭に足す
+plugins.push(
+  new BannerPlugin({
+    banner: 'var __dirname = "";',
+    raw: true,
+    entryOnly: false,
+  }),
+);
 
 export const rendererConfig: Configuration = {
   // 本番ビルドに inline source map を含めない(バンドル肥大 + ソース露出防止)。


### PR DESCRIPTION
## 概要

**Phase 4 の最初のスライス: メイン窓と About 窓の `sandbox: true` 化**です。Phase 3 で preload から Node API 依存のロジックが消えた(残りは tRPC クライアント・contextBridge・DOM 操作のみ)ため、Chromium サンドボックスを有効にできます。renderer が侵害されても Node API へ直接到達できなくなります。

> [!NOTE]
> ROADMAP の順序(v3.11.0 リリース → Phase 4)に従い、**draft で提出します。v3.11.0 リリース後に ready 化・マージしてください。**

## 変更内容と判明した障害(2 件、両方解決済み)

1. **forge の webpack plugin が注入する asset relocator patch が `__dirname` を参照**: sandbox 化した preload には `__dirname` が存在せず、ReferenceError で preload 全体が死ぬ(UI が完全に空になる)。`BannerPlugin` で空文字の `var __dirname` シムをバンドル先頭に追加して回避
2. **`source-map-support/register` が fs 依存**: sandbox 化した preload ではロード時に落ちるため、preload 2 つから除去。preload のエラートレースはミニファイ位置になるが、main プロセス側の解決は引き続き有効

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(138 件)すべて緑
- `yarn package`(sandbox: true)+ CDP スモーク 19 項目 ALL PASS・未処理例外ゼロ:
  - メイン窓 11 項目(一覧・選択・検索・ニコニ・コモンズ・共有コピー)
  - 手動更新テーブル 4 項目(core / packages 更新ボタン実走・オーバーレイ連動・エディタ保存経路イベント)
  - データエディタ save → 読み戻し往復 2 項目(一時 instPath)
  - About 窓 2 項目(その他タブから開く / tRPC getAppVersion のバージョン表示)— sandbox 化した About preload の動作確認
- Windows 実機での起動スモークは未実施です(このリポジトリの通例どおりお願いします)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
