### PR TITLE
test: resolvePath テストの base を Windows でも絶対パスにする

### DIFF
--- a/src/shared/resolvePath.test.ts
+++ b/src/shared/resolvePath.test.ts
@@ -26,7 +26,8 @@ describe('resolvePath', () => {
   });
 
   describe('with a local base', () => {
-    const base = path.join('/data', 'apm');
+    // path.join だと Windows でドライブレターが付かず、実装側の path.resolve の結果と一致しない
+    const base = path.resolve('/data', 'apm');
 
     it('resolves a relative path inside the base directory', () => {
       expect(resolvePath(base, path.join('packages', 'list.json'))).toBe(


### PR DESCRIPTION
## Description

`resolvePath` のローカル base テストで、base の生成を `path.join('/data', 'apm')` から `path.resolve('/data', 'apm')` に変更しました。実装コード([src/shared/resolvePath.ts](https://github.com/team-apm/apm/blob/main/src/shared/resolvePath.ts))に変更はありません。

## Related Issue

なし(小規模なテスト修正)

## Motivation and Context

Windows では `path.join('/data', 'apm')` がドライブレター無しの `\data\apm` になる一方、実装側の `path.resolve` はカレントドライブ(`C:` 等)を付与するため、「base ディレクトリ内の相対パスを解決する」テストの期待値がドライブレター分だけ食い違って落ちていました。`path.resolve` で base を作ることで両 OS とも完全な絶対パスになり、環境非依存になります。

CI のテストジョブ(nodejs.yml)が ubuntu-latest のみのため CI では顕在化せず、ローカル Windows でのみ再現する状態でした。Windows メインのプロジェクトなので、テスト matrix への windows-latest 追加は別途検討の余地があります(本 PR のスコープ外)。

## How Has This Been Tested?

Windows 11 + Node 22 で以下を確認:

- `yarn vitest run src/shared/resolvePath.test.ts` — 7 件すべて緑(修正前は 1 件失敗)
- `yarn lint` / `yarn lint:ts` / `yarn test` — すべて緑

## Screenshots (if appropriate):

なし

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)