### PR TITLE
fix: dataURL への path.join をやめ起動時の list.json 取得の失敗を修正

### DIFF
--- a/src/main/services/migration.ts
+++ b/src/main/services/migration.ts
@@ -4,6 +4,7 @@ import prompt from 'electron-prompt';
 import fs, { readdir, rename, unlink, writeJson } from 'fs-extra';
 import path from 'node:path';
 import { convertPackagesV2toV3 } from '../../shared/convertPackagesV2toV3';
+import { joinUrlOrPath } from '../../shared/joinUrlOrPath';
 import { parsePackagesXml } from '../../shared/parsePackagesXml';
 import ApmJson from '../ApmJson';
 import type Config from '../Config';
@@ -96,7 +97,7 @@ async function migration1to2Global(
         const urls = config.dataURL
           .getPackages()
           .filter((url) => !url.includes(oldDataURL));
-        urls.push(path.join(newDataURL, 'packages.xml'));
+        urls.push(joinUrlOrPath(newDataURL, 'packages.xml'));
         config.dataURL.setMain(newDataURL);
         config.dataURL.setPackages(urls);
         config.set('migration1to2', {
@@ -211,8 +212,8 @@ async function migration1to2ByFolder(
     if (config.has('migration1to2')) {
       const dataURLs = config.get('migration1to2');
       text = text.replaceAll(
-        path.join(dataURLs.oldDataURL, 'packages_list.xml'),
-        path.join(dataURLs.newDataURL, 'packages.xml'),
+        joinUrlOrPath(dataURLs.oldDataURL, 'packages_list.xml'),
+        joinUrlOrPath(dataURLs.newDataURL, 'packages.xml'),
       );
     }
     packages[id].repository = text;

--- a/src/main/services/modList.ts
+++ b/src/main/services/modList.ts
@@ -2,7 +2,7 @@ import type { List } from 'apm-schema';
 import type { BrowserWindow } from 'electron';
 import { readJson } from 'fs-extra';
 import * as os from 'node:os';
-import path from 'node:path';
+import { joinUrlOrPath } from '../../shared/joinUrlOrPath';
 import { resolvePath } from '../../shared/resolvePath';
 import type Config from '../Config';
 import { downloadFile } from './download';
@@ -15,7 +15,7 @@ import { existsTempFile } from './tempFile';
  * @param {Config} config - The config instance.
  */
 export async function updateInfo(win: BrowserWindow, config: Config) {
-  await downloadFile(win, path.join(config.dataURL.getMain(), 'list.json'));
+  await downloadFile(win, joinUrlOrPath(config.dataURL.getMain(), 'list.json'));
 
   const modFile = existsTempFile('list.json');
   const info = (await readJson(modFile.path)) as List;

--- a/src/shared/joinUrlOrPath.test.ts
+++ b/src/shared/joinUrlOrPath.test.ts
@@ -1,0 +1,37 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { joinUrlOrPath } from './joinUrlOrPath';
+
+describe('joinUrlOrPath', () => {
+  describe('http(s) の base', () => {
+    it('末尾スラッシュありの base に連結できる', () => {
+      expect(
+        joinUrlOrPath(
+          'https://cdn.jsdelivr.net/gh/team-apm/apm-data@main/v3/',
+          'list.json',
+        ),
+      ).toBe('https://cdn.jsdelivr.net/gh/team-apm/apm-data@main/v3/list.json');
+    });
+
+    it('末尾スラッシュなしの base に連結できる', () => {
+      expect(joinUrlOrPath('https://example.com/data', 'list.json')).toBe(
+        'https://example.com/data/list.json',
+      );
+    });
+
+    it('URL をローカルパス形式に変換しない(Node 22 の path.join 対策)', () => {
+      const joined = joinUrlOrPath('https://example.com/data/', 'list.json');
+      expect(joined.startsWith('http')).toBe(true);
+      expect(joined).not.toContain('\\');
+    });
+  });
+
+  describe('ローカルパスの base', () => {
+    it('path.join と同じ結果になる', () => {
+      const base = path.resolve('/data', 'apm');
+      expect(joinUrlOrPath(base, 'list.json')).toBe(
+        path.join(base, 'list.json'),
+      );
+    });
+  });
+});

--- a/src/shared/joinUrlOrPath.ts
+++ b/src/shared/joinUrlOrPath.ts
@@ -1,0 +1,18 @@
+import path from 'node:path';
+
+/**
+ * Joins a base URL or a local base path with a relative segment.
+ * http(s) の base に path.join を使わないための関数。Electron 39(Node 22)の
+ * Windows 版 path.join は URL を `.\https:\...` 形式に正規化してしまい、
+ * downloadFile 等の `startsWith('http')` 判定がローカルパス扱いに化ける
+ * (Electron 34 = Node 20 までは偶然動いていた)。
+ * @param {string} base - The base URL or local path.
+ * @param {string} segment - The relative segment to append.
+ * @returns {string} The joined URL or path.
+ */
+export function joinUrlOrPath(base: string, segment: string) {
+  if (base.startsWith('http')) {
+    return base.replace(/\/+$/, '') + '/' + segment;
+  }
+  return path.join(base, segment);
+}


### PR DESCRIPTION
## Description

URL とローカルパスの両方を扱える `joinUrlOrPath` を `src/shared/` に追加し、dataURL にファイル名を連結していた `path.join` を置き換えました。

- `src/main/services/modList.ts` — `updateInfo` の `list.json` ダウンロード(**起動時に必ず通る、今回のクラッシュの直接原因**)
- `src/main/services/migration.ts` — v1→v2 移行時の `packages.xml` URL の生成・置換(壊れた値が config に永続化されるのを防止)

## Related Issue

なし(v3.11.0 リリース前の手動テストで発見)

## Motivation and Context

Electron 39(内蔵 Node 22)の Windows 版 `path.join` は URL を `.\https:\cdn.jsdelivr.net\...` というローカルパス形式に正規化します。このため `downloadFile` の `startsWith('http')` 判定が false になってローカルコピー分岐に落ち、起動直後の `list.json` 取得が ENOENT で失敗、パッケージ一覧が一切取得できない状態でした。

v3.10.0(Electron 34 = 内蔵 Node 20)では同じコードが `https:\cdn...`(`.\` プレフィックス無し)を返し、http 判定を通過して Chromium 側がバックスラッシュを許容するため**偶然動いていた**ものです。Electron 39 への更新でリグレッションとして顕在化しました。修正しないままリリースすると、Windows の全ユーザーが起動時にこの問題を踏みます。

再現ログ(パッケージ版):

```
Error: ENOENT: no such file or directory, copyfile
'...\out\AviUtl Package Manager-win32-x64\https:\cdn.jsdelivr.net\gh\team-apm\apm-data@main\v3\list.json'
-> 'C:\Users\...\AppData\Roaming\AviUtl Package Manager\Data\list.json'
```

## How Has This Been Tested?

Windows 11 + Node 22 で確認:

- `joinUrlOrPath` のユニットテストを追加(末尾スラッシュあり/なしの URL、ローカルパス、`.\` 化しないことの回帰テスト)
- `yarn test` 全 142 件緑 / `yarn lint:ts` 緑 / 変更ファイルの eslint 緑
- `yarn package` で再ビルドした実行ファイルで起動確認(手動テスト実施中)

## Screenshots (if appropriate):

なし

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)