### PR TITLE
fix(settings): 拡大率の未設定時に select が 50% と表示される問題を修正

### DIFF
--- a/src/main/Config.test.ts
+++ b/src/main/Config.test.ts
@@ -55,7 +55,8 @@ describe('Config', () => {
       expect(config.getAutoUpdate()).toBe('notify');
 
       expect(config.hasZoomFactor()).toBe(false);
-      expect(config.getZoomFactor()).toBe('1');
+      // 拡大率は select の option 値(パーセント文字列)で保存される
+      expect(config.getZoomFactor()).toBe('100');
     });
   });
 
@@ -73,8 +74,8 @@ describe('Config', () => {
       config.setAutoUpdate('download');
       expect(config.getAutoUpdate()).toBe('download');
 
-      config.setZoomFactor('1.25');
-      expect(config.getZoomFactor()).toBe('1.25');
+      config.setZoomFactor('125');
+      expect(config.getZoomFactor()).toBe('125');
 
       config.dataURL.setMain('https://example.com/data/');
       config.dataURL.setExtra('https://example.com/extra/');

--- a/src/main/Config.ts
+++ b/src/main/Config.ts
@@ -119,7 +119,9 @@ export default class Config extends Store<StoreType> {
   }
 
   public getZoomFactor() {
-    return this.get('zoomFactor', '1');
+    // 保存値は設定タブの select の option 値(パーセント文字列)。既定値を '1' に
+    // すると未設定時にどの option とも一致せず先頭の 50% が表示されてしまう
+    return this.get('zoomFactor', '100');
   }
 
   public setZoomFactor(value: string) {


### PR DESCRIPTION
## 概要

設定が記録されていない状態で設定タブを開くと、拡大率の select が先頭の「50%」を表示していた(実際のズームは 100% のままなので表示だけが食い違う)。

## 原因

`Config.getZoomFactor()` の既定値が `'1'` で、select の option 値(`'50'`〜`'200'` のパーセント文字列)のどれとも一致しないため、controlled select が先頭 option を表示していた。旧実装(HTML 直書き時代)は store 未設定なら `<option value="100" selected>` が表示される仕様で、`'1'` は Config 化の際に混入した誤り。

## 変更

- `getZoomFactor()` の既定値を `'100'` に変更
- 特性化テストの期待値を更新(set/get の往復も実際に保存される形式 `'125'` に変更)

## 確認

- packaged ビルド + フレッシュな userData で、修正前に select が「50%」(selectedIndex 0)となることを CDP で実測済み
- `yarn lint` / `yarn lint:ts` / `yarn test` 緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)