### PR TITLE
fix(main): 初回起動時にパッケージ一覧が表示されない問題を修正

### DIFF
--- a/src/main/services/download.ts
+++ b/src/main/services/download.ts
@@ -6,6 +6,12 @@ import path from 'node:path';
 import { isParent } from '../../shared/apmPath';
 import { getHash } from '../../shared/getHash';
 
+// electron-dl の download() は session 共有の will-download リスナーを呼び出しの
+// たびに登録し、リスナーは自分宛てでない DownloadItem にも savePath を設定する。
+// そのため並行実行すると保存先の取り違えや同一ファイルへの同時書き込み
+// (Windows ではロック違反で interrupted)が起きる。呼び出しを直列化して回避する
+let downloadChain: Promise<void> = Promise.resolve();
+
 /**
  * Downloads a file (or copies a local file) into the data folder.
  * @param {BrowserWindow} win - The window that receives the download progress.
@@ -47,7 +53,12 @@ export async function downloadFile(
 
   try {
     if (url.startsWith('http')) {
-      await download(win, url, opt);
+      const run = downloadChain.then(() => download(win, url, opt));
+      downloadChain = run.then(
+        (): void => undefined,
+        (): void => undefined,
+      );
+      await run;
     } else {
       await mkdir(path.dirname(retFilePath), { recursive: true });
       fs.copyFileSync(url, retFilePath);

--- a/src/main/services/modList.ts
+++ b/src/main/services/modList.ts
@@ -15,6 +15,13 @@ import { existsTempFile } from './tempFile';
  * @param {Config} config - The config instance.
  */
 export async function updateInfo(win: BrowserWindow, config: Config) {
+  // 初回起動では dataURL.main の設定(initSettings)より先に renderer の
+  // クエリがここへ到達しうる。空のまま進めると 'list.json' がローカルパス
+  // 扱いになり紛らわしい ENOENT で落ちるため、明示的に失敗させて
+  // 呼び出し側(react-query)のリトライに任せる
+  if (config.dataURL.getMain() === '') {
+    throw new Error('The main data URL is not set yet.');
+  }
   await downloadFile(win, joinUrlOrPath(config.dataURL.getMain(), 'list.json'));
 
   const modFile = existsTempFile('list.json');


### PR DESCRIPTION
## 概要

初回起動(設定未記録)のとき、パッケージ一覧が空のまま表示されないことがある問題の修正。2回目以降の起動では自然に直る=キャッシュの有無で並行度が変わるレース条件が原因だった。

## 原因(2つ)

1. **dataURL 未設定のまま list.json 取得が走る**
   renderer の React クエリ(`getScriptsList` / `getCoreInfo` など)は preload の初期化フロー(initSettings → changeInstallationPath)と並行に走る。初回起動では `dataURL.main` が空のため `joinUrlOrPath('', 'list.json')` が `'list.json'` になり、`downloadFile` がローカルパス扱いで `copyFileSync` を試みて紛らわしい ENOENT で失敗していた(フレッシュな userData + packaged ビルドの実測ログで確認)。

2. **electron-dl の並行ダウンロード競合**
   electron-dl の `download()` は session 共有の `will-download` リスナーを呼び出しごとに登録し、各リスナーは自分宛てでない DownloadItem にも自分の savePath を設定する。初回起動はキャッシュが無く preload 初期化と React クエリのリトライが同時にダウンロードを行うため、保存先の取り違えや同一ファイルへの同時書き込みが発生する。Windows ではロック違反でダウンロードが `interrupted` になり、`changeInstallationPath` 内の一覧データ取得が失敗してパッケージ一覧が空のままになる(`downloadRepository` に同趣旨の既知の注意コメントあり)。

## 変更

- `updateInfo`: `dataURL.main` 未設定なら明示的に throw し、react-query のリトライと初期化完了後の invalidate に回復を任せる
- `downloadFile`: http ダウンロードを直列化して同時実行を 1 件に保つ(旧実装ではダウンロードは実質逐次だった)。electron-dl 自体の置き換え(net.fetch 化)は別途検討

## 確認

- `yarn lint` / `yarn lint:ts` / `yarn test` 緑
- packaged ビルド + フレッシュな userData の初回起動で、修正前に上記 1 の ENOENT が main プロセスログに出ることを実測済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)