### PR TITLE
fix(main): dev 起動時の electron-log preload 警告を解消

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,7 +9,12 @@ import { ensureAutoUpdateDefault } from './services/appUpdate';
 import * as shortcut from './shortcut';
 import { launch } from './windows';
 
-log.initialize();
+// preload: true(既定)のセッション preload 注入は使わない。注入パスの解決が
+// forge の asset relocator に書き換えられ、dev ビルドでは相対パスに壊れて
+// Electron 39 の registerPreloadScript が絶対パス検証の警告を出すため。
+// 代わりに electron-log 公式のバンドラ向けパターンで、各 preload バンドルが
+// 'electron-log/preload' を import して __electronLog を生やす
+log.initialize({ preload: false });
 
 log.errorHandler.startCatching({
   showDialog: false,

--- a/src/renderer/about/preload.ts
+++ b/src/renderer/about/preload.ts
@@ -1,4 +1,7 @@
 import { contextBridge } from 'electron';
+// __electronLog を両ワールドに生やす(electron-log/renderer の ipc transport が
+// 依存)。main 側のセッション preload 注入は dev でパス解決が壊れるため使わない
+import 'electron-log/preload';
 import log from 'electron-log/renderer';
 import { exposeElectronTRPC } from 'electron-trpc/main';
 import 'source-map-support/register';

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -1,5 +1,8 @@
 import ClipboardJS from 'clipboard/src/clipboard';
 import { contextBridge } from 'electron';
+// __electronLog を両ワールドに生やす(electron-log/renderer の ipc transport が
+// 依存)。main 側のセッション preload 注入は dev でパス解決が壊れるため使わない
+import 'electron-log/preload';
 import log from 'electron-log/renderer';
 import { exposeElectronTRPC } from 'electron-trpc/main';
 import 'source-map-support/register';


### PR DESCRIPTION
## 概要

Windows の `yarn start` で main プロセスに出ていた警告の修正です:

```
[warn]  Error: Preload script must have absolute path: undefinedelectron-log-preload.js
```

## 原因

- electron-log v5 の `log.initialize()` は既定で、メインワールドに `__electronLog` を生やすためのセッション preload(`electron-log-preload.js`)を注入する
- その内部のパス解決(`path.resolve(__dirname, ...)`)は forge の asset relocator によって `__webpack_require__.ab + "electron-log-preload.js"` に書き換えられており、**dev ビルドでは `.ab` が未定義**のため `'undefinedelectron-log-preload.js'` という相対パスになる
- Electron 34 までの `setPreloads()` はこれを黙って受理していた(= 以前から壊れていたが無症状)。**Electron 35 で入った `registerPreloadScript()` は絶対パスを検証する**ため、Electron 39 更新(#2291)以降の dev 起動で警告として顕在化した
- パッケージ版は relocator が `native_modules/electron-log-preload.js` を同梱し `.ab` も定義されるため影響なし(v3.11.0 のリリース版は正常)

electron-log 5.4.4(最新)でも未修正で、`initialize({preload: '<path>'})` と明示しても内部の `path.resolve` に上書きされるため回避できません。

## 修正

electron-log 公式のバンドラ向けパターンに切り替え:

- main: `log.initialize({ preload: false })` でセッション preload 注入を無効化
- preload 2 つ(main 窓 / About 窓): `import 'electron-log/preload'` を追加し、preload バンドル自身が `__electronLog` を両ワールドに生やす

> [!NOTE]
> `preload: false` 単独では不十分です。electron-log/renderer の ipc transport は `window.__electronLog` 必須(ipcRenderer 直送ではない)で、renderer → main のエラー転送が黙って壊れます(CDP 実測で確認済み)。import の追加とセットです。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(142 件)緑
- `yarn package` + CDP 検証(macOS):
  - `__electronLog` が隔離ワールド・メインワールド両方に存在
  - 隔離ワールドから `__electronLog.info('marker')` → main.log に到達(転送実走)
  - 隔離ワールドで未処理 rejection → main のエラーハンドラ(ダイアログ + 終了)まで到達
  - 既存スモーク(パッケージ一覧 11 項目 + About 窓 2 項目)ALL PASS、新規 error/warn ゼロ
- Windows `yarn start` で警告が消えることの確認はお願いします

🤖 Generated with [Claude Code](https://claude.com/claude-code)
