### PR TITLE
refactor(renderer): contextBridge 露出を縮小する(coreBridge 削除 + About の tRPC 化)

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -280,6 +280,13 @@ export const router = t.router({
   getAppVersion: procedure.query(async () => {
     return app.getVersion();
   }),
+  // About 窓の表示用。renderer の process.versions と同じ値が main でも取れる
+  // ため、contextBridge での露出(旧 window.process)は使わない
+  getProcessVersions: procedure.query(() => ({
+    node: process.versions.node,
+    chrome: process.versions.chrome,
+    electron: process.versions.electron,
+  })),
   isExeVersion: procedure.query(() => isExeVersion()),
   getAppName: procedure.query(() => app.getName()),
   quitApp: procedure.mutation(() => {

--- a/src/renderer/about/About.tsx
+++ b/src/renderer/about/About.tsx
@@ -9,6 +9,7 @@ import { TRPCReact } from '../trpc';
  */
 function About() {
   const { data: appVersion } = TRPCReact.getAppVersion.useQuery();
+  const { data: versions } = TRPCReact.getProcessVersions.useQuery();
 
   return (
     <Container fluid className="d-flex flex-column py-2 bg-dark text-white">
@@ -30,9 +31,9 @@ function About() {
           <h2>Versions</h2>
           <ul className="list-unstyled">
             <li>apm: {appVersion}</li>
-            <li>Node.js: {window.process.versions.node}</li>
-            <li>Chromium: {window.process.versions.chrome}</li>
-            <li>Electron: {window.process.versions.electron}</li>
+            <li>Node.js: {versions?.node}</li>
+            <li>Chromium: {versions?.chrome}</li>
+            <li>Electron: {versions?.electron}</li>
           </ul>
 
           <h2>Copyright</h2>

--- a/src/renderer/about/preload.ts
+++ b/src/renderer/about/preload.ts
@@ -1,4 +1,3 @@
-import { contextBridge } from 'electron';
 // __electronLog を両ワールドに生やす(electron-log/renderer の ipc transport が
 // 依存)。main 側のセッション preload 注入は dev でパス解決が壊れるため使わない
 import 'electron-log/preload';
@@ -18,8 +17,4 @@ window.addEventListener('click', () => {
 
 process.once('loaded', async () => {
   exposeElectronTRPC();
-});
-
-contextBridge.exposeInMainWorld('process', {
-  versions: process.versions,
 });

--- a/src/renderer/main/aviutl/BatchInstallButton.tsx
+++ b/src/renderer/main/aviutl/BatchInstallButton.tsx
@@ -4,6 +4,7 @@ import { states } from '../../../shared/packageDisplay';
 import { programs } from '../../../shared/programs';
 import type { PackageItem } from '../../../types/packageItem';
 import { TRPCReact } from '../../trpc';
+import { getInstallationPath } from '../instPath';
 
 type ButtonPhase =
   | { kind: 'idle' }
@@ -38,7 +39,7 @@ function BatchInstallButton(): JSX.Element {
     if (phase.kind === 'loading') return;
     setPhase({ kind: 'loading' });
 
-    const instPath = window.coreBridge?.getInstallationPath() ?? '';
+    const instPath = getInstallationPath();
     if (!instPath) {
       finish('インストール先フォルダを指定してください。', 'danger');
       return;

--- a/src/renderer/main/aviutl/BatchInstallList.tsx
+++ b/src/renderer/main/aviutl/BatchInstallList.tsx
@@ -2,6 +2,7 @@ import React, { type JSX, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 import type { PackageItem } from '../../../types/packageItem';
 import { TRPCReact } from '../../trpc';
+import { getInstallationPath } from '../instPath';
 
 /**
  * The list of the recommended plugins (directURL packages) shown in the
@@ -13,9 +14,7 @@ import { TRPCReact } from '../../trpc';
  * @returns {JSX.Element} The rendered component.
  */
 function BatchInstallList(): JSX.Element {
-  const [instPath, setInstPath] = useState(
-    () => window.coreBridge?.getInstallationPath() ?? '',
-  );
+  const [instPath, setInstPath] = useState(() => getInstallationPath());
 
   const utils = TRPCReact.useContext();
   const packagesQuery = TRPCReact.packages.getPackagesWithStatus.useQuery(
@@ -26,7 +25,7 @@ function BatchInstallList(): JSX.Element {
   // レガシー側(preload の package.ts)からの再描画通知を受けて最新化する
   useEffect(() => {
     const listener = () => {
-      setInstPath(window.coreBridge?.getInstallationPath() ?? '');
+      setInstPath(getInstallationPath());
       void utils.packages.getPackagesWithStatus.invalidate();
     };
     window.addEventListener('apm-packages-changed', listener);

--- a/src/renderer/main/aviutl/ProgramRow.tsx
+++ b/src/renderer/main/aviutl/ProgramRow.tsx
@@ -2,6 +2,7 @@ import type { Core } from 'apm-schema';
 import React, { type JSX, useEffect, useState } from 'react';
 import { releaseLabel } from '../../../shared/coreVersionText';
 import { TRPCReact } from '../../trpc';
+import { getInstallationPath } from '../instPath';
 
 type ButtonPhase = 'idle' | 'loading' | 'success' | 'danger';
 
@@ -27,9 +28,7 @@ function ProgramRow({
   iconClass,
   buttonRoundedClass,
 }: ProgramRowProps) {
-  const [instPath, setInstPath] = useState(
-    () => window.coreBridge?.getInstallationPath() ?? '',
-  );
+  const [instPath, setInstPath] = useState(() => getInstallationPath());
   const [phase, setPhase] = useState<ButtonPhase>('idle');
   const [buttonMessage, setButtonMessage] = useState('');
 
@@ -42,7 +41,7 @@ function ProgramRow({
   // レガシー側(preload の core.ts)からの再描画通知を受けて最新化する
   useEffect(() => {
     const listener = () => {
-      setInstPath(window.coreBridge?.getInstallationPath() ?? '');
+      setInstPath(getInstallationPath());
       void utils.core.getCoreInfo.invalidate();
       void utils.core.getInstalledVersionTexts.invalidate();
     };

--- a/src/renderer/main/aviutl/SelectInstallationPathButton.tsx
+++ b/src/renderer/main/aviutl/SelectInstallationPathButton.tsx
@@ -7,7 +7,7 @@ import { TRPCReact } from '../../trpc';
  * 相当する。判定・更新は main プロセス側(services/core.ts)が行い、ここは
  * ダイアログの表示と再描画通知のみを行う。
  * インストール先の値はレガシー DOM の #installation-path(readonly input)が
- * 保持し、各コンポーネントは coreBridge.getInstallationPath() で読む。
+ * 保持し、各コンポーネントは instPath.ts の getInstallationPath() で読む。
  * @returns {JSX.Element} The rendered component.
  */
 function SelectInstallationPathButton(): JSX.Element {

--- a/src/renderer/main/instPath.ts
+++ b/src/renderer/main/instPath.ts
@@ -1,0 +1,13 @@
+/**
+ * Reads the current installation path from the DOM input.
+ * @returns {string} The installation path (empty string if not set).
+ */
+export function getInstallationPath(): string {
+  // DOM は隔離ワールドとメインワールドで共有されるため、contextBridge
+  // (旧 coreBridge)を介さずメインワールドから直接読める。値の書き込みは
+  // 引き続き preload の初期化フローと SelectInstallationPathButton が行う
+  const input = document.getElementById(
+    'installation-path',
+  ) as HTMLInputElement | null;
+  return input?.value ?? '';
+}

--- a/src/renderer/main/nicommons/NicommonsTab.tsx
+++ b/src/renderer/main/nicommons/NicommonsTab.tsx
@@ -2,6 +2,7 @@ import React, { type JSX, useEffect, useMemo, useState } from 'react';
 import { parsePackageType } from '../../../shared/packageDisplay';
 import type { PackageItem } from '../../../types/packageItem';
 import { TRPCReact } from '../../trpc';
+import { getInstallationPath } from '../instPath';
 
 type NicommonsItem = {
   name: string;
@@ -95,9 +96,7 @@ function NicommonsRow({
  * @returns {JSX.Element} The rendered component.
  */
 function NicommonsTab(): JSX.Element {
-  const [instPath, setInstPath] = useState(
-    () => window.coreBridge?.getInstallationPath() ?? '',
-  );
+  const [instPath, setInstPath] = useState(() => getInstallationPath());
   // 除外したもの(チェックを外したもの)だけを持つ。一覧の再取得時に全部
   // チェック済みへ戻る旧挙動と同じにするため、checked の集合は持たない
   const [uncheckedIds, setUncheckedIds] = useState<ReadonlySet<string>>(
@@ -124,7 +123,7 @@ function NicommonsTab(): JSX.Element {
 
   useEffect(() => {
     const onCoreChanged = () => {
-      setInstPath(window.coreBridge?.getInstallationPath() ?? '');
+      setInstPath(getInstallationPath());
     };
     const onPackagesChanged = () => {
       void utils.packages.getPackages.invalidate();

--- a/src/renderer/main/packages/PackagesTab.tsx
+++ b/src/renderer/main/packages/PackagesTab.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../shared/shareString';
 import type { PackageItem } from '../../../types/packageItem';
 import { TRPCReact } from '../../trpc';
+import { getInstallationPath } from '../instPath';
 import PackageActions, { type SelectedEntry } from './PackageActions';
 
 // list.js(fuzzySearch)に合わせた検索オプション。
@@ -140,9 +141,7 @@ const naturalCompare = (a: string, b: string) => {
  * @returns {JSX.Element} The rendered component.
  */
 function PackagesTab(): JSX.Element {
-  const [instPath, setInstPath] = useState(
-    () => window.coreBridge?.getInstallationPath() ?? '',
-  );
+  const [instPath, setInstPath] = useState(() => getInstallationPath());
   const [searchString, setSearchString] = useState('');
   const [alertDismissed, setAlertDismissed] = useState(false);
   const [sort, setSort] = useState<SortState>({
@@ -169,7 +168,7 @@ function PackagesTab(): JSX.Element {
   // レガシー側からの通知: インストール先変更と一覧の再取得要求
   useEffect(() => {
     const onCoreChanged = () => {
-      setInstPath(window.coreBridge?.getInstallationPath() ?? '');
+      setInstPath(getInstallationPath());
     };
     const onPackagesChanged = () => {
       void utils.packages.getPackagesWithStatus.invalidate();

--- a/src/renderer/main/preload.ts
+++ b/src/renderer/main/preload.ts
@@ -1,5 +1,4 @@
 import ClipboardJS from 'clipboard/src/clipboard';
-import { contextBridge } from 'electron';
 // __electronLog を両ワールドに生やす(electron-log/renderer の ipc transport が
 // 依存)。main 側のセッション preload 注入は dev でパス解決が壊れるため使わない
 import 'electron-log/preload';
@@ -16,16 +15,6 @@ log.errorHandler.startCatching({
   },
 });
 const editorContextBridge = new EditorContextBridge();
-
-// メインワールドの React(AviUtl タブ ProgramRow ほか)とレガシーの橋渡し
-contextBridge.exposeInMainWorld('coreBridge', {
-  getInstallationPath: () => {
-    const input = document.getElementById(
-      'installation-path',
-    ) as HTMLInputElement | null;
-    return input?.value ?? '';
-  },
-});
 
 // メインワールドの React(Settings ほか)から tRPC を使うための bridge
 process.once('loaded', () => {

--- a/src/renderer/main/settings/ManualUpdateTable.tsx
+++ b/src/renderer/main/settings/ManualUpdateTable.tsx
@@ -1,6 +1,7 @@
 import React, { type JSX, useEffect, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 import { TRPCReact } from '../../trpc';
+import { getInstallationPath } from '../instPath';
 import {
   getPhase,
   runPackagesListCheck,
@@ -90,7 +91,7 @@ function ManualUpdateTable(): JSX.Element {
 
   const checkPackagesList = async () => {
     // 旧実装どおり呼び出し時点の入力値を使う
-    const instPath = window.coreBridge?.getInstallationPath() ?? '';
+    const instPath = getInstallationPath();
     await runPackagesListCheck(() => refreshListMutation.mutateAsync(instPath));
   };
 

--- a/src/types/mainRenderer.d.ts
+++ b/src/types/mainRenderer.d.ts
@@ -8,8 +8,5 @@ declare global {
       ) => void;
       save: (packages: Packages['packages']) => Promise<void>;
     };
-    coreBridge: {
-      getInstallationPath: () => string;
-    };
   }
 }


### PR DESCRIPTION
## 概要

Phase 4 の contextBridge 最小化スライス 1 です。main 窓と About 窓の contextBridge 露出を 3 → 1 に減らします。

| 露出 | 対応 |
| --- | --- |
| `coreBridge.getInstallationPath`(main 窓) | **削除**。DOM は両ワールド共有なので、メインワールドの `instPath.ts` が `#installation-path` を直接読む |
| `process`(About 窓、versions 表示用) | **削除**。tRPC `getProcessVersions` query に置き換え(main プロセスの `process.versions` は同じ値) |
| `editor`(データエディタの save / onload) | 次のスライスで DOM イベント化を検討(本 PR では変更なし) |

`exposeElectronTRPC`(tRPC の前提)と electron-log の `__electronLog` は残ります。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(142 件)緑
- `yarn package` + CDP スモーク(macOS、sandbox: true):
  - main 窓 18 項目 ALL PASS(一覧・選択・検索・手動更新テーブル実走・インストール先選択ボタン描画 + 初期化フロー)
  - About 窓: バージョン一覧が tRPC 経由で全項目表示(apm 3.12.0 / Node.js / Chromium / Electron)
  - 新規 error/warn ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)
