### PR TITLE
test(e2e): 起動スモークの Playwright E2E を導入する

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,24 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    name: E2E (Playwright)
+    # メインターゲットの Windows で、出荷形態に近いパッケージ版を起動して検証する
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          # build.yml / release.yml と同じ Node 22 に固定
+          # (Node 24 では electron-forge 6.4.1 の make/publish が無言で失敗する)
+          node-version: '22'
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn package
+      - run: yarn test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,7 @@ out/
 .vscode/
 .czrc
 ThirdPartyNotices.txt
+
+# Playwright
+test-results/
+playwright-report/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ AviUtl Package Manager (apm) — AviUtl のプラグイン・スクリプトを�
 yarn lint       # prettier + eslint
 yarn lint:ts    # tsc --noEmit
 yarn test       # vitest run (src/**/*.test.ts)
+yarn test:e2e   # Playwright E2E (e2e/)。パッケージ版を起動するため先に yarn package が必要
 yarn start      # 開発起動 (Node 22 推奨)
 ```
 

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -1,0 +1,65 @@
+import { _electron, expect, type Page, test } from '@playwright/test';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Returns the path of the packaged executable for the current platform.
+ * @returns {string} Path of the executable
+ */
+function packagedExecutablePath(): string {
+  const outDir = path.join(
+    __dirname,
+    '..',
+    'out',
+    `AviUtl Package Manager-${process.platform}-${process.arch}`,
+  );
+  if (process.platform === 'darwin')
+    return path.join(
+      outDir,
+      'AviUtl Package Manager.app',
+      'Contents',
+      'MacOS',
+      'apm',
+    );
+  if (process.platform === 'win32') return path.join(outDir, 'apm.exe');
+  return path.join(outDir, 'apm');
+}
+
+test('起動して main 窓が開き、パッケージ一覧が描画される', async () => {
+  const executablePath = packagedExecutablePath();
+  expect(
+    existsSync(executablePath),
+    `パッケージ版が見つからない(先に yarn package を実行する): ${executablePath}`,
+  ).toBe(true);
+
+  const app = await _electron.launch({ executablePath });
+  try {
+    // splash 窓が先に開くため、URL で main 窓を特定して待つ
+    const isMainWindow = (page: Page) => page.url().includes('main_window');
+    const window =
+      app.windows().find(isMainWindow) ??
+      (await app.waitForEvent('window', { predicate: isMainWindow }));
+
+    const pageErrors: Error[] = [];
+    window.on('pageerror', (error) => pageErrors.push(error));
+
+    await expect(window).toHaveTitle('AviUtl Package Manager');
+
+    // 初期表示は AviUtl タブ(インストール先が表示される)
+    await expect(window.locator('#installation-path')).toBeVisible();
+
+    // プラグイン&スクリプトタブへ切り替えると一覧が描画される
+    // (初回はパッケージ一覧のダウンロードを含むため長めに待つ)
+    await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
+    await expect(window.locator('#packages-list li').first()).toBeVisible({
+      timeout: 240_000,
+    });
+
+    expect(
+      pageErrors.map((e) => e.message),
+      'renderer で uncaught exception が発生していない',
+    ).toEqual([]);
+  } finally {
+    await app.close();
+  }
+});

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "release:patch": "release-it patch",
     "start": "cross-env NODE_ENV=development electron-forge start",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "test:watch": "vitest"
   },
   "lint-staged": {
@@ -83,6 +84,7 @@
     "@electron-forge/plugin-auto-unpack-natives": "6.4.1",
     "@electron-forge/plugin-webpack": "6.4.1",
     "@electron-forge/publisher-github": "6.4.1",
+    "@playwright/test": "^1.62.1",
     "@release-it/conventional-changelog": "^11.0.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/bootstrap": "^5.2.11",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+
+// E2E はパッケージ版バイナリ(yarn package の成果物)を起動する。
+// 先に yarn package を実行しておくこと
+export default defineConfig({
+  testDir: './e2e',
+  // 初回起動はパッケージ一覧のダウンロードを含むため長めに取る
+  timeout: 300_000,
+  // Electron アプリを同時に複数起動しない
+  workers: 1,
+  fullyParallel: false,
+  reporter: 'list',
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     },
     "jsx": "react-jsx"
   },
-  "include": ["src/**/*", "webpack.*.ts", "*.config.ts"]
+  "include": ["src/**/*", "e2e/**/*", "webpack.*.ts", "*.config.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,6 +1415,13 @@
   resolved "https://registry.yarnpkg.com/@phun-ky/typeof/-/typeof-2.0.3.tgz#581f617862e6fd9245e992440e46a88dbc228005"
   integrity sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==
 
+"@playwright/test@^1.62.1":
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.62.1.tgz#68e1aaf6e480e1923936dee6c66fae1921d3a65a"
+  integrity sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==
+  dependencies:
+    playwright "1.62.1"
+
 "@popperjs/core@^2.11.8", "@popperjs/core@^2.9.2":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
@@ -5506,6 +5513,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -8277,6 +8289,20 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+playwright-core@1.62.1:
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.62.1.tgz#120f67a19181bfd183c60fa903c0d99330b56785"
+  integrity sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==
+
+playwright@1.62.1:
+  version "1.62.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.62.1.tgz#8447b6755e8aec85a3cb7207c823e3ed2fc66700"
+  integrity sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==
+  dependencies:
+    playwright-core "1.62.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 plist@^3.0.0, plist@^3.0.4, plist@^3.0.5:
   version "3.1.0"


### PR DESCRIPTION
## 概要

Phase 5(品質・E2E)の最初のスライスです。Playwright を導入し、起動スモーク E2E を CI に組み込みます。

- `@playwright/test` の `_electron.launch` で **`yarn package` の成果物(パッケージ版バイナリ)** を起動する
  - dev ビルドではなくパッケージ版を対象にするのは、sandbox / asar / asset relocator を含む出荷形態で検証するため(ブラウザバイナリのダウンロードも不要)
- テスト内容([launch.spec.ts](e2e/launch.spec.ts)): 起動 → splash に続いて main 窓が開く(URL で特定)→ タイトル → AviUtl タブにインストール先が表示 → 「プラグイン&スクリプト」タブへ切り替えて一覧が描画される。あわせて renderer の uncaught exception ゼロを確認
- CI は新規 [e2e.yml](.github/workflows/e2e.yml)(windows-latest、Node 22 固定): `yarn package` → `yarn test:e2e`
- `yarn test:e2e` スクリプト追加、tsconfig include に `e2e/`、.gitignore に Playwright 生成物、AGENTS.md のコマンド表を更新

次スライス以降で主要フロー(インストール等)の E2E を足していきます(ネットワークのフィクスチャ化を検討)。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(142 件)緑
- macOS ローカルで `yarn package` → `yarn test:e2e` 緑(1 passed)
- CI 初回はクリーン環境の初回起動(パッケージ一覧のダウンロード込み)になるため、一覧描画の待ちは 240 秒に設定。windows-latest での実走はこの PR の CI が初回です

🤖 Generated with [Claude Code](https://claude.com/claude-code)
