### PR TITLE
test(e2e): インストールフローの E2E を追加し 7za の実行権限バグを修正する

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,39 @@
+import type { ElectronApplication, Page } from '@playwright/test';
+import path from 'node:path';
+
+/**
+ * Returns the path of the packaged executable for the current platform.
+ * @returns {string} Path of the executable
+ */
+export function packagedExecutablePath(): string {
+  const outDir = path.join(
+    __dirname,
+    '..',
+    'out',
+    `AviUtl Package Manager-${process.platform}-${process.arch}`,
+  );
+  if (process.platform === 'darwin')
+    return path.join(
+      outDir,
+      'AviUtl Package Manager.app',
+      'Contents',
+      'MacOS',
+      'apm',
+    );
+  if (process.platform === 'win32') return path.join(outDir, 'apm.exe');
+  return path.join(outDir, 'apm');
+}
+
+/**
+ * Returns the main window, waiting for it if it has not opened yet.
+ * splash 窓が先に開くため、URL で main 窓を特定する。
+ * @param {ElectronApplication} app - The launched Electron application.
+ * @returns {Promise<Page>} The main window.
+ */
+export async function getMainWindow(app: ElectronApplication): Promise<Page> {
+  const isMainWindow = (page: Page) => page.url().includes('main_window');
+  return (
+    app.windows().find(isMainWindow) ??
+    (await app.waitForEvent('window', { predicate: isMainWindow }))
+  );
+}

--- a/e2e/install.spec.ts
+++ b/e2e/install.spec.ts
@@ -120,7 +120,11 @@ test('dataURL の差し替えとパッケージのインストールができる
   const app = await _electron.launch({ executablePath });
   try {
     const window = await getMainWindow(app);
-    await expect(window.locator('#installation-path')).toBeVisible();
+    // preload の初期化フロー完了を待つ(完了するとインストール先の既定値が
+    // 入る。クリーン環境の初回起動はダウンロードを含むため長めに待つ)
+    await expect(window.locator('#installation-path')).not.toHaveValue('', {
+      timeout: 120_000,
+    });
 
     // ローカル実行では実プロファイルを使うため、元の設定を控えて最後に戻す
     const originalInstPath = await window
@@ -143,13 +147,18 @@ test('dataURL の差し替えとパッケージのインストールができる
       await window
         .getByRole('button', { name: 'AviUtlインストールフォルダを選択' })
         .click();
-      await expect(window.locator('#installation-path')).toHaveValue(instPath);
+      // インストール先変更に伴う再取得(初回はダウンロード込み)を待つ
+      await expect(window.locator('#installation-path')).toHaveValue(instPath, {
+        timeout: 120_000,
+      });
 
       // データ取得先をフィクスチャサーバへ変更
       await window.getByRole('tab', { name: '設定' }).click();
       await window.locator('#data-url').fill(baseUrl);
       await window.locator('#set-data-url').click();
-      await expect(window.locator('#set-data-url')).toHaveText('設定完了');
+      await expect(window.locator('#set-data-url')).toHaveText('設定完了', {
+        timeout: 60_000,
+      });
 
       // パッケージ一覧を再取得するとダミープラグインが現れる
       await window.locator('#check-packages-list').click();
@@ -176,7 +185,9 @@ test('dataURL の差し替えとパッケージのインストールができる
       await window.getByRole('tab', { name: '設定' }).click();
       await window.locator('#data-url').fill(originalDataUrl);
       await window.locator('#set-data-url').click();
-      await expect(window.locator('#set-data-url')).toHaveText('設定完了');
+      await expect(window.locator('#set-data-url')).toHaveText('設定完了', {
+        timeout: 60_000,
+      });
       if (originalInstPath) {
         await mockOpenDialog(originalInstPath);
         await window.getByRole('tab', { name: 'AviUtl' }).click();
@@ -185,6 +196,7 @@ test('dataURL の差し替えとパッケージのインストールができる
           .click();
         await expect(window.locator('#installation-path')).toHaveValue(
           originalInstPath,
+          { timeout: 120_000 },
         );
       }
     }

--- a/e2e/install.spec.ts
+++ b/e2e/install.spec.ts
@@ -1,0 +1,196 @@
+import { path7za } from '7zip-bin';
+import { _electron, expect, test } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { getMainWindow, packagedExecutablePath } from './helpers';
+
+const MODIFIED = '2026-01-01T00:00:00+09:00';
+
+/**
+ * Writes the apm data files (list/core/convert/packages) and a dummy plugin
+ * archive into the fixtures directory.
+ * @param {string} fixturesDir - The directory served over HTTP.
+ * @param {string} workDir - A working directory for intermediate files.
+ * @param {string} baseUrl - The base URL of the fixtures server.
+ */
+function writeFixtures(fixturesDir: string, workDir: string, baseUrl: string) {
+  const filesDir = path.join(fixturesDir, 'files');
+  mkdirSync(filesDir, { recursive: true });
+
+  // ダミープラグインの zip(アプリ側の展開が 7z なので生成にも同梱の 7za を使う)
+  const pluginDir = path.join(workDir, 'plugin');
+  mkdirSync(pluginDir, { recursive: true });
+  writeFileSync(
+    path.join(pluginDir, 'dummy.auf'),
+    'dummy aviutl plugin for e2e',
+  );
+  execFileSync(path7za, [
+    'a',
+    path.join(filesDir, 'dummy.zip'),
+    path.join(pluginDir, '*'),
+  ]);
+
+  const write = (name: string, data: unknown) =>
+    writeFileSync(path.join(fixturesDir, name), JSON.stringify(data));
+  write('list.json', {
+    core: { path: 'core.json', modified: MODIFIED },
+    convert: { path: 'convert.json', modified: MODIFIED },
+    packages: [{ path: 'packages.json', modified: MODIFIED }],
+    scripts: [],
+  });
+  write('core.json', {
+    version: 3,
+    aviutl: {
+      latestVersion: '1.10',
+      files: [{ filename: 'aviutl.exe' }],
+      releases: [],
+    },
+    exedit: {
+      latestVersion: '0.92',
+      files: [{ filename: 'exedit.auf' }],
+      releases: [],
+    },
+  });
+  write('convert.json', {});
+  write('packages.json', {
+    version: 3,
+    packages: [
+      {
+        id: 'e2e/dummyPlugin',
+        name: 'E2E ダミープラグイン',
+        overview: 'E2E テスト用のダミープラグイン',
+        description: 'Playwright のインストールフロー検証用。',
+        developer: 'apm-e2e',
+        pageURL: `${baseUrl}/`,
+        downloadURLs: [`${baseUrl}/files/dummy.zip`],
+        latestVersion: '1.0.0',
+        files: [{ filename: 'dummy.auf' }],
+      },
+    ],
+  });
+}
+
+test('dataURL の差し替えとパッケージのインストールができる', async () => {
+  const executablePath = packagedExecutablePath();
+  expect(
+    existsSync(executablePath),
+    `パッケージ版が見つからない(先に yarn package を実行する): ${executablePath}`,
+  ).toBe(true);
+
+  // --- フィクスチャと配信サーバ ---
+  const workDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-'));
+  const fixturesDir = path.join(workDir, 'fixtures');
+  const instPath = path.join(workDir, 'aviutl');
+  mkdirSync(instPath, { recursive: true });
+
+  const server = createServer((req, res) => {
+    const filePath = path.join(
+      fixturesDir,
+      (req.url ?? '/').replace(/^\//, ''),
+    );
+    if (!filePath.startsWith(fixturesDir) || !existsSync(filePath)) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    res.writeHead(200, {
+      'content-type': filePath.endsWith('.zip')
+        ? 'application/zip'
+        : 'application/json',
+    });
+    res.end(readFileSync(filePath));
+  });
+  await new Promise<void>((resolve) =>
+    server.listen(0, '127.0.0.1', () => resolve()),
+  );
+  const baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  writeFixtures(fixturesDir, workDir, baseUrl);
+
+  const app = await _electron.launch({ executablePath });
+  try {
+    const window = await getMainWindow(app);
+    await expect(window.locator('#installation-path')).toBeVisible();
+
+    // ローカル実行では実プロファイルを使うため、元の設定を控えて最後に戻す
+    const originalInstPath = await window
+      .locator('#installation-path')
+      .inputValue();
+    await window.getByRole('tab', { name: '設定' }).click();
+    const originalDataUrl = await window.locator('#data-url').inputValue();
+
+    // フォルダ選択のネイティブダイアログはモックして固定のパスを返す
+    const mockOpenDialog = (dir: string) =>
+      app.evaluate(({ dialog }, filePath) => {
+        dialog.showOpenDialog = () =>
+          Promise.resolve({ canceled: false, filePaths: [filePath] });
+      }, dir);
+
+    try {
+      // インストール先をテスト用フォルダへ変更
+      await mockOpenDialog(instPath);
+      await window.getByRole('tab', { name: 'AviUtl' }).click();
+      await window
+        .getByRole('button', { name: 'AviUtlインストールフォルダを選択' })
+        .click();
+      await expect(window.locator('#installation-path')).toHaveValue(instPath);
+
+      // データ取得先をフィクスチャサーバへ変更
+      await window.getByRole('tab', { name: '設定' }).click();
+      await window.locator('#data-url').fill(baseUrl);
+      await window.locator('#set-data-url').click();
+      await expect(window.locator('#set-data-url')).toHaveText('設定完了');
+
+      // パッケージ一覧を再取得するとダミープラグインが現れる
+      await window.locator('#check-packages-list').click();
+      await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
+      const row = window.locator('#packages-list li', {
+        hasText: 'E2E ダミープラグイン',
+      });
+      await expect(row).toBeVisible({ timeout: 120_000 });
+
+      // インストール(ダウンロード用ブラウザ窓が zip 直リンクを開き、
+      // ユーザー操作なしでダウンロードが完了する)
+      await row.click();
+      await window.locator('#install-package').click();
+      await expect(window.locator('#install-package')).toHaveText(
+        'インストール完了',
+        { timeout: 120_000 },
+      );
+
+      // 実ファイルが置かれ、一覧の表示もインストール済みになる
+      expect(existsSync(path.join(instPath, 'dummy.auf'))).toBe(true);
+      await expect(row).toContainText('インストール済み');
+    } finally {
+      // 実プロファイルの設定をベストエフォートで元に戻す
+      await window.getByRole('tab', { name: '設定' }).click();
+      await window.locator('#data-url').fill(originalDataUrl);
+      await window.locator('#set-data-url').click();
+      await expect(window.locator('#set-data-url')).toHaveText('設定完了');
+      if (originalInstPath) {
+        await mockOpenDialog(originalInstPath);
+        await window.getByRole('tab', { name: 'AviUtl' }).click();
+        await window
+          .getByRole('button', { name: 'AviUtlインストールフォルダを選択' })
+          .click();
+        await expect(window.locator('#installation-path')).toHaveValue(
+          originalInstPath,
+        );
+      }
+    }
+  } finally {
+    await app.close();
+    server.close();
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -1,29 +1,6 @@
-import { _electron, expect, type Page, test } from '@playwright/test';
+import { _electron, expect, test } from '@playwright/test';
 import { existsSync } from 'node:fs';
-import path from 'node:path';
-
-/**
- * Returns the path of the packaged executable for the current platform.
- * @returns {string} Path of the executable
- */
-function packagedExecutablePath(): string {
-  const outDir = path.join(
-    __dirname,
-    '..',
-    'out',
-    `AviUtl Package Manager-${process.platform}-${process.arch}`,
-  );
-  if (process.platform === 'darwin')
-    return path.join(
-      outDir,
-      'AviUtl Package Manager.app',
-      'Contents',
-      'MacOS',
-      'apm',
-    );
-  if (process.platform === 'win32') return path.join(outDir, 'apm.exe');
-  return path.join(outDir, 'apm');
-}
+import { getMainWindow, packagedExecutablePath } from './helpers';
 
 test('起動して main 窓が開き、パッケージ一覧が描画される', async () => {
   const executablePath = packagedExecutablePath();
@@ -34,11 +11,7 @@ test('起動して main 窓が開き、パッケージ一覧が描画される',
 
   const app = await _electron.launch({ executablePath });
   try {
-    // splash 窓が先に開くため、URL で main 窓を特定して待つ
-    const isMainWindow = (page: Page) => page.url().includes('main_window');
-    const window =
-      app.windows().find(isMainWindow) ??
-      (await app.waitForEvent('window', { predicate: isMainWindow }));
+    const window = await getMainWindow(app);
 
     const pageErrors: Error[] = [];
     window.on('pageerror', (error) => pageErrors.push(error));

--- a/src/shared/unzip.ts
+++ b/src/shared/unzip.ts
@@ -1,5 +1,6 @@
 import { path7za } from '7zip-bin';
 import { extractFull } from 'node-7z';
+import { chmodSync } from 'node:fs';
 import path from 'node:path';
 import win7zip from 'win-7zip';
 
@@ -10,6 +11,17 @@ let pathTo7zip = process.platform === 'win32' ? win7zip['7z'] : path7za;
 // https://github.com/puppeteer/puppeteer/issues/2134#issuecomment-408221446
 if (!isDevEnv) {
   pathTo7zip = pathTo7zip.replace('app.asar', 'app.asar.unpacked');
+}
+
+// パッケージ版では asset relocator が native_modules へコピーした 7za の
+// 実行ビットが落ちていて spawn が EACCES になる(macOS / Linux のみ。
+// dev の node_modules 直下は実行可能なので無症状)。spawn 前に付与する
+if (process.platform !== 'win32') {
+  try {
+    chmodSync(pathTo7zip, 0o755);
+  } catch {
+    // 失敗しても spawn 時に EACCES / ENOENT として顕在化するため何もしない
+  }
 }
 
 /**


### PR DESCRIPTION
## 概要

Phase 5 スライス 2: インストールフローの E2E です。ネットワークをローカルフィクスチャに差し替えて、主要フロー(データ取得先の変更 → 一覧更新 → パッケージのインストール)を決定的に固定します。

- ローカル HTTP サーバ(空きポート)で apm-schema 準拠のフィクスチャを配信: `list.json` / `core.json` / `convert.json` / `packages.json` + ダミープラグイン zip(生成もアプリの展開と同じ同梱 7za を使用)
- UI 操作のみでフローを踏む:
  - インストール先の変更: フォルダ選択のネイティブダイアログを `electronApp.evaluate` で `dialog.showOpenDialog` をモックして一時フォルダへ
  - データ取得先: 設定タブの入力欄 + 設定ボタン(実 UI)
  - インストール: 通常経路(`openBrowser`)のまま。フィクスチャの `downloadURLs` が zip 直リンクなので、ブラウザ窓が開いた直後に `will-download` が発火してユーザー操作なしで完走する
- 検証: 「インストール完了」表示、`instPath` への実ファイル配置、一覧の「インストール済み」表記
- ローカル実行が実プロファイルを汚さないよう、データ取得先・インストール先はテスト末尾で元に戻す(CI はクリーン環境なので無関係)
- `packagedExecutablePath` / main 窓取得を `e2e/helpers.ts` に抽出

## 🐛 E2E が実バグを発見(fix を同梱)

初回実行で macOS のインストールが常に「エラーが発生しました。」になり、main.log に

```
Failed to unzip …: spawn …/app.asar.unpacked/.webpack/main/native_modules/mac/arm64/7za EACCES
```

が出ていました。**asset relocator が `native_modules` へコピーした 7za は実行ビットが落ちており、macOS / Linux のパッケージ版では zip 展開が必ず失敗します**(dev の node_modules 直下は実行可能なため無症状、Windows の .exe も無影響 — 現行リリースの mac / Linux 版にも存在するバグのはずです)。[unzip.ts](src/shared/unzip.ts) で spawn 前に chmod する修正を入れました。修正後、E2E は macOS で緑です。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(142 件)緑
- macOS ローカルで `yarn package` → `yarn test:e2e` 緑(launch + install の 2 本、計 5 秒)
- windows-latest の CI(e2e.yml)でも同じ 2 本が走ります

🤖 Generated with [Claude Code](https://claude.com/claude-code)
