### PR TITLE
E2E の userData を分離し実ネットワーク非依存にする

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ AviUtl Package Manager (apm) — AviUtl のプラグイン・スクリプトを�
 yarn lint       # prettier + eslint
 yarn lint:ts    # tsc --noEmit
 yarn test       # vitest run (src/**/*.test.ts)
-yarn test:e2e   # Playwright E2E (e2e/)。パッケージ版を起動するため先に yarn package が必要
+yarn test:e2e   # Playwright E2E (e2e/)。パッケージ版を起動するため先に yarn package が必要。--user-data-dir で一時 userData を渡して起動するため実プロファイルは汚さない
 yarn start      # 開発起動 (Node 22 推奨)
 ```
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,4 +1,10 @@
-import type { ElectronApplication, Page } from '@playwright/test';
+import {
+  _electron,
+  type ElectronApplication,
+  type Page,
+} from '@playwright/test';
+import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 /**
@@ -22,6 +28,40 @@ export function packagedExecutablePath(): string {
     );
   if (process.platform === 'win32') return path.join(outDir, 'apm.exe');
   return path.join(outDir, 'apm');
+}
+
+/**
+ * Launches the packaged app with an isolated (temporary) userData directory
+ * so that tests never touch the real profile.
+ * @param {object} [options] - Launch options.
+ * @param {Record<string, unknown>} [options.config] - Initial contents of
+ * config.json (electron-store). Omit to start from a clean profile.
+ * @returns {Promise<{app: ElectronApplication, userDataDir: string}>} The
+ * launched app and the userData directory (remove it after closing the app).
+ */
+export async function launchIsolated(options?: {
+  config?: Record<string, unknown>;
+}): Promise<{ app: ElectronApplication; userDataDir: string }> {
+  const executablePath = packagedExecutablePath();
+  if (!existsSync(executablePath)) {
+    throw new Error(
+      `パッケージ版が見つからない(先に yarn package を実行する): ${executablePath}`,
+    );
+  }
+  const userDataDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-userdata-'));
+  if (options?.config) {
+    // electron-store の実体は userData/config.json の素の JSON なので、
+    // 起動前に書いておくだけで設定済み状態を再現できる
+    writeFileSync(
+      path.join(userDataDir, 'config.json'),
+      JSON.stringify(options.config),
+    );
+  }
+  const app = await _electron.launch({
+    executablePath,
+    args: [`--user-data-dir=${userDataDir}`],
+  });
+  return { app, userDataDir };
 }
 
 /**

--- a/e2e/install.spec.ts
+++ b/e2e/install.spec.ts
@@ -1,5 +1,5 @@
 import { path7za } from '7zip-bin';
-import { _electron, expect, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 import { execFileSync } from 'node:child_process';
 import {
   existsSync,
@@ -13,13 +13,47 @@ import { createServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { getMainWindow, packagedExecutablePath } from './helpers';
+import { getMainWindow, launchIsolated } from './helpers';
 
 const MODIFIED = '2026-01-01T00:00:00+09:00';
 
 /**
- * Writes the apm data files (list/core/convert/packages) and a dummy plugin
- * archive into the fixtures directory.
+ * Writes the apm data files (list/core/convert/packages) into the given
+ * directory.
+ * @param {string} dir - The destination directory.
+ * @param {object[]} packages - The contents of packages.json's packages field.
+ */
+function writeDataFiles(dir: string, packages: object[]) {
+  mkdirSync(dir, { recursive: true });
+  const write = (name: string, data: unknown) =>
+    writeFileSync(path.join(dir, name), JSON.stringify(data));
+  write('list.json', {
+    core: { path: 'core.json', modified: MODIFIED },
+    convert: { path: 'convert.json', modified: MODIFIED },
+    packages: [{ path: 'packages.json', modified: MODIFIED }],
+    scripts: [],
+  });
+  write('core.json', {
+    version: 3,
+    aviutl: {
+      latestVersion: '1.10',
+      files: [{ filename: 'aviutl.exe' }],
+      releases: [],
+    },
+    exedit: {
+      latestVersion: '0.92',
+      files: [{ filename: 'exedit.auf' }],
+      releases: [],
+    },
+  });
+  write('convert.json', {});
+  write('packages.json', { version: 3, packages });
+}
+
+/**
+ * Writes the fixtures: the initial data set (without the dummy plugin) under
+ * /initial, and the main data set (with the dummy plugin) + its archive at
+ * the root.
  * @param {string} fixturesDir - The directory served over HTTP.
  * @param {string} workDir - A working directory for intermediate files.
  * @param {string} baseUrl - The base URL of the fixtures server.
@@ -41,57 +75,31 @@ function writeFixtures(fixturesDir: string, workDir: string, baseUrl: string) {
     path.join(pluginDir, '*'),
   ]);
 
-  const write = (name: string, data: unknown) =>
-    writeFileSync(path.join(fixturesDir, name), JSON.stringify(data));
-  write('list.json', {
-    core: { path: 'core.json', modified: MODIFIED },
-    convert: { path: 'convert.json', modified: MODIFIED },
-    packages: [{ path: 'packages.json', modified: MODIFIED }],
-    scripts: [],
-  });
-  write('core.json', {
-    version: 3,
-    aviutl: {
-      latestVersion: '1.10',
-      files: [{ filename: 'aviutl.exe' }],
-      releases: [],
+  // 差し替え前のデータ取得先(ダミープラグインを含まない)
+  writeDataFiles(path.join(fixturesDir, 'initial'), []);
+  // 差し替え後のデータ取得先(ダミープラグインを含む)
+  writeDataFiles(fixturesDir, [
+    {
+      id: 'e2e/dummyPlugin',
+      name: 'E2E ダミープラグイン',
+      overview: 'E2E テスト用のダミープラグイン',
+      description: 'Playwright のインストールフロー検証用。',
+      developer: 'apm-e2e',
+      pageURL: `${baseUrl}/`,
+      downloadURLs: [`${baseUrl}/files/dummy.zip`],
+      latestVersion: '1.0.0',
+      files: [{ filename: 'dummy.auf' }],
     },
-    exedit: {
-      latestVersion: '0.92',
-      files: [{ filename: 'exedit.auf' }],
-      releases: [],
-    },
-  });
-  write('convert.json', {});
-  write('packages.json', {
-    version: 3,
-    packages: [
-      {
-        id: 'e2e/dummyPlugin',
-        name: 'E2E ダミープラグイン',
-        overview: 'E2E テスト用のダミープラグイン',
-        description: 'Playwright のインストールフロー検証用。',
-        developer: 'apm-e2e',
-        pageURL: `${baseUrl}/`,
-        downloadURLs: [`${baseUrl}/files/dummy.zip`],
-        latestVersion: '1.0.0',
-        files: [{ filename: 'dummy.auf' }],
-      },
-    ],
-  });
+  ]);
 }
 
 test('dataURL の差し替えとパッケージのインストールができる', async () => {
-  const executablePath = packagedExecutablePath();
-  expect(
-    existsSync(executablePath),
-    `パッケージ版が見つからない(先に yarn package を実行する): ${executablePath}`,
-  ).toBe(true);
-
   // --- フィクスチャと配信サーバ ---
   const workDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-'));
   const fixturesDir = path.join(workDir, 'fixtures');
+  const initialInstPath = path.join(workDir, 'aviutl-initial');
   const instPath = path.join(workDir, 'aviutl');
+  mkdirSync(initialInstPath, { recursive: true });
   mkdirSync(instPath, { recursive: true });
 
   const server = createServer((req, res) => {
@@ -117,21 +125,23 @@ test('dataURL の差し替えとパッケージのインストールができる
   const baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
   writeFixtures(fixturesDir, workDir, baseUrl);
 
-  const app = await _electron.launch({ executablePath });
+  // 設定済みプロファイルを事前シードして起動する。dataVersion が無いと
+  // migration がダイアログを出すため必ず '3' を入れる。初期のデータ取得先も
+  // フィクスチャに向け、テスト全体を実ネットワーク非依存にする
+  const { app, userDataDir } = await launchIsolated({
+    config: {
+      dataVersion: '3',
+      installationPath: initialInstPath,
+      dataURL: { main: `${baseUrl}/initial/`, extra: '' },
+    },
+  });
   try {
     const window = await getMainWindow(app);
-    // preload の初期化フロー完了を待つ(完了するとインストール先の既定値が
-    // 入る。クリーン環境の初回起動はダウンロードを含むため長めに待つ)
-    await expect(window.locator('#installation-path')).not.toHaveValue('', {
-      timeout: 120_000,
-    });
-
-    // ローカル実行では実プロファイルを使うため、元の設定を控えて最後に戻す
-    const originalInstPath = await window
-      .locator('#installation-path')
-      .inputValue();
-    await window.getByRole('tab', { name: '設定' }).click();
-    const originalDataUrl = await window.locator('#data-url').inputValue();
+    // preload の初期化フロー完了を待つ(完了するとインストール先が入る)
+    await expect(window.locator('#installation-path')).toHaveValue(
+      initialInstPath,
+      { timeout: 120_000 },
+    );
 
     // フォルダ選択のネイティブダイアログはモックして固定のパスを返す
     const mockOpenDialog = (dir: string) =>
@@ -140,69 +150,51 @@ test('dataURL の差し替えとパッケージのインストールができる
           Promise.resolve({ canceled: false, filePaths: [filePath] });
       }, dir);
 
-    try {
-      // インストール先をテスト用フォルダへ変更
-      await mockOpenDialog(instPath);
-      await window.getByRole('tab', { name: 'AviUtl' }).click();
-      await window
-        .getByRole('button', { name: 'AviUtlインストールフォルダを選択' })
-        .click();
-      // インストール先変更に伴う再取得(初回はダウンロード込み)を待つ
-      await expect(window.locator('#installation-path')).toHaveValue(instPath, {
-        timeout: 120_000,
-      });
+    // インストール先をテスト用フォルダへ変更
+    await mockOpenDialog(instPath);
+    await window
+      .getByRole('button', { name: 'AviUtlインストールフォルダを選択' })
+      .click();
+    await expect(window.locator('#installation-path')).toHaveValue(instPath, {
+      timeout: 120_000,
+    });
 
-      // データ取得先をフィクスチャサーバへ変更
-      await window.getByRole('tab', { name: '設定' }).click();
-      await window.locator('#data-url').fill(baseUrl);
-      await window.locator('#set-data-url').click();
-      await expect(window.locator('#set-data-url')).toHaveText('設定完了', {
-        timeout: 60_000,
-      });
+    // 差し替え前のデータにはダミープラグインが存在しない
+    await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
+    const row = window.locator('#packages-list li', {
+      hasText: 'E2E ダミープラグイン',
+    });
+    await expect(row).toHaveCount(0);
 
-      // パッケージ一覧を再取得するとダミープラグインが現れる
-      await window.locator('#check-packages-list').click();
-      await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
-      const row = window.locator('#packages-list li', {
-        hasText: 'E2E ダミープラグイン',
-      });
-      await expect(row).toBeVisible({ timeout: 120_000 });
+    // データ取得先をダミープラグイン入りのデータへ変更
+    await window.getByRole('tab', { name: '設定' }).click();
+    await window.locator('#data-url').fill(baseUrl);
+    await window.locator('#set-data-url').click();
+    await expect(window.locator('#set-data-url')).toHaveText('設定完了', {
+      timeout: 60_000,
+    });
 
-      // インストール(ダウンロード用ブラウザ窓が zip 直リンクを開き、
-      // ユーザー操作なしでダウンロードが完了する)
-      await row.click();
-      await window.locator('#install-package').click();
-      await expect(window.locator('#install-package')).toHaveText(
-        'インストール完了',
-        { timeout: 120_000 },
-      );
+    // パッケージ一覧を再取得するとダミープラグインが現れる
+    await window.locator('#check-packages-list').click();
+    await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
+    await expect(row).toBeVisible({ timeout: 120_000 });
 
-      // 実ファイルが置かれ、一覧の表示もインストール済みになる
-      expect(existsSync(path.join(instPath, 'dummy.auf'))).toBe(true);
-      await expect(row).toContainText('インストール済み');
-    } finally {
-      // 実プロファイルの設定をベストエフォートで元に戻す
-      await window.getByRole('tab', { name: '設定' }).click();
-      await window.locator('#data-url').fill(originalDataUrl);
-      await window.locator('#set-data-url').click();
-      await expect(window.locator('#set-data-url')).toHaveText('設定完了', {
-        timeout: 60_000,
-      });
-      if (originalInstPath) {
-        await mockOpenDialog(originalInstPath);
-        await window.getByRole('tab', { name: 'AviUtl' }).click();
-        await window
-          .getByRole('button', { name: 'AviUtlインストールフォルダを選択' })
-          .click();
-        await expect(window.locator('#installation-path')).toHaveValue(
-          originalInstPath,
-          { timeout: 120_000 },
-        );
-      }
-    }
+    // インストール(ダウンロード用ブラウザ窓が zip 直リンクを開き、
+    // ユーザー操作なしでダウンロードが完了する)
+    await row.click();
+    await window.locator('#install-package').click();
+    await expect(window.locator('#install-package')).toHaveText(
+      'インストール完了',
+      { timeout: 120_000 },
+    );
+
+    // 実ファイルが置かれ、一覧の表示もインストール済みになる
+    expect(existsSync(path.join(instPath, 'dummy.auf'))).toBe(true);
+    await expect(row).toContainText('インストール済み');
   } finally {
     await app.close();
     server.close();
+    rmSync(userDataDir, { recursive: true, force: true });
     rmSync(workDir, { recursive: true, force: true });
   }
 });

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -1,15 +1,10 @@
-import { _electron, expect, test } from '@playwright/test';
-import { existsSync } from 'node:fs';
-import { getMainWindow, packagedExecutablePath } from './helpers';
+import { expect, test } from '@playwright/test';
+import { rmSync } from 'node:fs';
+import { getMainWindow, launchIsolated } from './helpers';
 
 test('起動して main 窓が開き、パッケージ一覧が描画される', async () => {
-  const executablePath = packagedExecutablePath();
-  expect(
-    existsSync(executablePath),
-    `パッケージ版が見つからない(先に yarn package を実行する): ${executablePath}`,
-  ).toBe(true);
-
-  const app = await _electron.launch({ executablePath });
+  // クリーンな userData で起動し、実データでの初回起動フローを検証する
+  const { app, userDataDir } = await launchIsolated();
   try {
     const window = await getMainWindow(app);
 
@@ -34,5 +29,6 @@ test('起動して main 窓が開き、パッケージ一覧が描画される',
     ).toEqual([]);
   } finally {
     await app.close();
+    rmSync(userDataDir, { recursive: true, force: true });
   }
 });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow, dialog, MessageBoxSyncOptions } from 'electron';
 import debug from 'electron-debug';
 import log from 'electron-log/main';
 import Store from 'electron-store';
+import path from 'node:path';
 import 'source-map-support/register';
 import { getConfig } from './Config';
 import { registerIpcHandlers } from './ipcHandlers';
@@ -41,7 +42,14 @@ if (require('electron-squirrel-startup')) app.quit();
 log.debug(process.versions);
 
 const isDevEnv = process.env.NODE_ENV === 'development';
-if (isDevEnv) app.setPath('userData', app.getPath('userData') + '_Dev');
+// Chromium は --user-data-dir を userData に反映しないため自前で解釈する
+// (VS Code 等と同じ方式)。E2E が実プロファイルから隔離して起動するために使う
+const userDataDir = app.commandLine.getSwitchValue('user-data-dir');
+if (userDataDir) {
+  app.setPath('userData', path.resolve(userDataDir));
+} else if (isDevEnv) {
+  app.setPath('userData', app.getPath('userData') + '_Dev');
+}
 debug({ showDevTools: false }); // Press F12 to open DevTools
 
 Store.initRenderer();


### PR DESCRIPTION
## 概要

Phase 5 スライス 3: E2E の userData 分離です。E2E が実プロファイルを読み書きしていた問題を解消し、インストールフロー E2E を実ネットワーク完全非依存にします。

- **main**: `--user-data-dir` スイッチ対応を追加。Chromium はこのスイッチを `app.getPath('userData')` に反映しないため、main プロセスで自前解釈して `setPath` します(VS Code 等と同じ方式)。未指定時の挙動(dev の `_Dev` サフィックス含む)は従来どおりです
- **E2E**: `helpers.launchIsolated()` を追加。mkdtemp した一時 userData で起動し、electron-store の実体(`userData/config.json`)を起動前に書いて設定済みプロファイルを再現できます(`dataVersion: '3'` を入れて migration ダイアログを回避)
- **install E2E の強化**:
  - 初期 dataURL もフィクスチャ(`/initial` = ダミープラグイン無しのデータ)に向け、初回起動のダウンロード込みで**実ネットワークに一切出ない**構成に。CI の初回起動 120 秒待ちも実質不要になり、ローカル 2 本 5 秒で安定
  - UI でデータ取得先を差し替えた**後に**ダミープラグインが一覧に現れることを検証(差し替え前は 0 件を確認)。設定変更の効果を実データで区別できるようになりました
  - 実プロファイルの保存・復元ハック(テスト末尾で dataURL / インストール先を戻す処理)を削除

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(142 件)緑
- macOS ローカルで `yarn package` → `yarn test:e2e` 緑(launch + install の 2 本、計 5.3 秒)
- install E2E が事前シードした値を `#installation-path` で検証して通るため、`--user-data-dir` の分離が効いていることもテスト自身が保証します

🤖 Generated with [Claude Code](https://claude.com/claude-code)
