### PR TITLE
アンインストールフローの E2E を追加する

### DIFF
--- a/e2e/install.spec.ts
+++ b/e2e/install.spec.ts
@@ -93,7 +93,7 @@ function writeFixtures(fixturesDir: string, workDir: string, baseUrl: string) {
   ]);
 }
 
-test('dataURL の差し替えとパッケージのインストールができる', async () => {
+test('dataURL の差し替えとパッケージのインストール・アンインストールができる', async () => {
   // --- フィクスチャと配信サーバ ---
   const workDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-'));
   const fixturesDir = path.join(workDir, 'fixtures');
@@ -191,6 +191,17 @@ test('dataURL の差し替えとパッケージのインストールができる
     // 実ファイルが置かれ、一覧の表示もインストール済みになる
     expect(existsSync(path.join(instPath, 'dummy.auf'))).toBe(true);
     await expect(row).toContainText('インストール済み');
+
+    // アンインストールすると実ファイルが消え、一覧の表示も戻る
+    // (インストール後の一覧再取得で選択が外れている場合に備えて再選択する)
+    await row.click();
+    await window.locator('#uninstall-package').click();
+    await expect(window.locator('#uninstall-package')).toHaveText(
+      'アンインストール完了',
+      { timeout: 120_000 },
+    );
+    expect(existsSync(path.join(instPath, 'dummy.auf'))).toBe(false);
+    await expect(row).not.toContainText('インストール済み');
   } finally {
     await app.close();
     server.close();


### PR DESCRIPTION
## 概要

Phase 5 スライス 4: アンインストールフローの E2E です。#2359 のインストール E2E の直後に、同じダミープラグインをアンインストールする手順を足して主要フローの残りを固定します。

- インストール検証の直後に行を再選択(一覧再取得で選択が外れる場合に備える)→ `#uninstall-package` → 「アンインストール完了」
- 実ファイル(`dummy.auf`)がインストール先から消えること、一覧の「インストール済み」表記が戻ることを検証
- main 側 `uninstallPackageFiles` は確認ダイアログを出さないため、ダイアログのモックは不要でした

## テスト

- `yarn lint:ts` 緑
- macOS ローカルで `yarn test:e2e` 緑(2 本、計 4.4 秒。install スペックはアンインストール込みで 3.0 秒)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
