### PR TITLE
コア(AviUtl 本体)インストールの E2E を追加する

### DIFF
--- a/e2e/core.spec.ts
+++ b/e2e/core.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from '@playwright/test';
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createZip, serveFixtures, ssriOf, writeDataSet } from './fixtures';
+import { getMainWindow, launchIsolated } from './helpers';
+
+test('AviUtl 本体のインストールができる', async () => {
+  // --- フィクスチャと配信サーバ ---
+  const workDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-core-'));
+  const fixturesDir = path.join(workDir, 'fixtures');
+  const instPath = path.join(workDir, 'aviutl');
+  mkdirSync(instPath, { recursive: true });
+
+  const { baseUrl, close } = await serveFixtures(fixturesDir);
+  const zipPath = path.join(fixturesDir, 'files', 'aviutl.zip');
+  createZip(zipPath, path.join(workDir, 'program'), {
+    'aviutl.exe': 'dummy aviutl executable for e2e',
+  });
+  // コアのダウンロードは通常経路と違い integrity 検証があるため、
+  // 生成した zip の ssri を release に埋める
+  writeDataSet(fixturesDir, {
+    aviutlReleases: [
+      {
+        version: '1.10',
+        url: `${baseUrl}/files/aviutl.zip`,
+        integrity: { archive: ssriOf(zipPath), file: [] },
+      },
+    ],
+  });
+
+  const { app, userDataDir } = await launchIsolated({
+    config: {
+      dataVersion: '3',
+      installationPath: instPath,
+      dataURL: { main: baseUrl, extra: '' },
+    },
+  });
+  try {
+    const window = await getMainWindow(app);
+    // preload の初期化フロー完了を待つ(完了するとインストール先が入る)
+    await expect(window.locator('#installation-path')).toHaveValue(instPath, {
+      timeout: 120_000,
+    });
+
+    // バージョン選択ドロップダウンから最新版(1.10)をインストールする
+    await window.locator('#install-aviutl').click();
+    await window
+      .locator('#aviutl-version-select .dropdown-item', { hasText: '1.10' })
+      .click();
+    await expect(window.locator('#install-aviutl')).toHaveText(
+      'インストール完了',
+      { timeout: 120_000 },
+    );
+
+    // 実ファイルが置かれ、インストール済みバージョンが表示される
+    expect(existsSync(path.join(instPath, 'aviutl.exe'))).toBe(true);
+    await expect(window.locator('#aviutl-installed-version')).toContainText(
+      'バージョン: 1.10',
+    );
+  } finally {
+    await app.close();
+    close();
+    rmSync(userDataDir, { recursive: true, force: true });
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,117 @@
+import { path7za } from '7zip-bin';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import path from 'node:path';
+
+export const MODIFIED = '2026-01-01T00:00:00+09:00';
+
+/**
+ * Creates a zip archive from the given files using the bundled 7za
+ * (アプリ側の展開が 7z なので生成にも同梱の 7za を使う).
+ * @param {string} zipPath - The destination zip path.
+ * @param {string} srcDir - A working directory for the archive contents.
+ * @param {Record<string, string>} files - File names and contents to archive.
+ */
+export function createZip(
+  zipPath: string,
+  srcDir: string,
+  files: Record<string, string>,
+) {
+  mkdirSync(srcDir, { recursive: true });
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(path.join(srcDir, name), content);
+  }
+  mkdirSync(path.dirname(zipPath), { recursive: true });
+  execFileSync(path7za, ['a', zipPath, path.join(srcDir, '*')]);
+}
+
+/**
+ * Returns the ssri (sha384) of a file, for the release integrity of
+ * core.json.
+ * @param {string} filePath - The file to hash.
+ * @returns {string} The ssri string.
+ */
+export function ssriOf(filePath: string): string {
+  return (
+    'sha384-' +
+    createHash('sha384').update(readFileSync(filePath)).digest('base64')
+  );
+}
+
+export type DataSetOptions = {
+  /** The contents of packages.json's packages field. */
+  packages?: object[];
+  /** The releases field of core.json's aviutl program. */
+  aviutlReleases?: object[];
+};
+
+/**
+ * Writes an apm data set (list/core/convert/packages) into the given
+ * directory.
+ * @param {string} dir - The destination directory.
+ * @param {DataSetOptions} options - The variable parts of the data set.
+ */
+export function writeDataSet(dir: string, options: DataSetOptions = {}) {
+  mkdirSync(dir, { recursive: true });
+  const write = (name: string, data: unknown) =>
+    writeFileSync(path.join(dir, name), JSON.stringify(data));
+  write('list.json', {
+    core: { path: 'core.json', modified: MODIFIED },
+    convert: { path: 'convert.json', modified: MODIFIED },
+    packages: [{ path: 'packages.json', modified: MODIFIED }],
+    scripts: [],
+  });
+  write('core.json', {
+    version: 3,
+    aviutl: {
+      latestVersion: '1.10',
+      files: [{ filename: 'aviutl.exe' }],
+      releases: options.aviutlReleases ?? [],
+    },
+    exedit: {
+      latestVersion: '0.92',
+      files: [{ filename: 'exedit.auf' }],
+      releases: [],
+    },
+  });
+  write('convert.json', {});
+  write('packages.json', { version: 3, packages: options.packages ?? [] });
+}
+
+/**
+ * Serves the fixtures directory over HTTP on a free port of 127.0.0.1.
+ * @param {string} fixturesDir - The directory to serve.
+ * @returns {Promise<{baseUrl: string, close: () => void}>} The base URL and a
+ * function closing the server.
+ */
+export async function serveFixtures(
+  fixturesDir: string,
+): Promise<{ baseUrl: string; close: () => void }> {
+  const server = createServer((req, res) => {
+    const filePath = path.join(
+      fixturesDir,
+      (req.url ?? '/').replace(/^\//, ''),
+    );
+    if (!filePath.startsWith(fixturesDir) || !existsSync(filePath)) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    res.writeHead(200, {
+      'content-type': filePath.endsWith('.zip')
+        ? 'application/zip'
+        : 'application/json',
+    });
+    res.end(readFileSync(filePath));
+  });
+  await new Promise<void>((resolve) =>
+    server.listen(0, '127.0.0.1', () => resolve()),
+  );
+  return {
+    baseUrl: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+    close: () => server.close(),
+  };
+}

--- a/e2e/install.spec.ts
+++ b/e2e/install.spec.ts
@@ -1,54 +1,9 @@
-import { path7za } from '7zip-bin';
 import { expect, test } from '@playwright/test';
-import { execFileSync } from 'node:child_process';
-import {
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
-import { createServer } from 'node:http';
-import type { AddressInfo } from 'node:net';
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { createZip, serveFixtures, writeDataSet } from './fixtures';
 import { getMainWindow, launchIsolated } from './helpers';
-
-const MODIFIED = '2026-01-01T00:00:00+09:00';
-
-/**
- * Writes the apm data files (list/core/convert/packages) into the given
- * directory.
- * @param {string} dir - The destination directory.
- * @param {object[]} packages - The contents of packages.json's packages field.
- */
-function writeDataFiles(dir: string, packages: object[]) {
-  mkdirSync(dir, { recursive: true });
-  const write = (name: string, data: unknown) =>
-    writeFileSync(path.join(dir, name), JSON.stringify(data));
-  write('list.json', {
-    core: { path: 'core.json', modified: MODIFIED },
-    convert: { path: 'convert.json', modified: MODIFIED },
-    packages: [{ path: 'packages.json', modified: MODIFIED }],
-    scripts: [],
-  });
-  write('core.json', {
-    version: 3,
-    aviutl: {
-      latestVersion: '1.10',
-      files: [{ filename: 'aviutl.exe' }],
-      releases: [],
-    },
-    exedit: {
-      latestVersion: '0.92',
-      files: [{ filename: 'exedit.auf' }],
-      releases: [],
-    },
-  });
-  write('convert.json', {});
-  write('packages.json', { version: 3, packages });
-}
 
 /**
  * Writes the fixtures: the initial data set (without the dummy plugin) under
@@ -59,38 +14,30 @@ function writeDataFiles(dir: string, packages: object[]) {
  * @param {string} baseUrl - The base URL of the fixtures server.
  */
 function writeFixtures(fixturesDir: string, workDir: string, baseUrl: string) {
-  const filesDir = path.join(fixturesDir, 'files');
-  mkdirSync(filesDir, { recursive: true });
-
-  // ダミープラグインの zip(アプリ側の展開が 7z なので生成にも同梱の 7za を使う)
-  const pluginDir = path.join(workDir, 'plugin');
-  mkdirSync(pluginDir, { recursive: true });
-  writeFileSync(
-    path.join(pluginDir, 'dummy.auf'),
-    'dummy aviutl plugin for e2e',
+  createZip(
+    path.join(fixturesDir, 'files', 'dummy.zip'),
+    path.join(workDir, 'plugin'),
+    { 'dummy.auf': 'dummy aviutl plugin for e2e' },
   );
-  execFileSync(path7za, [
-    'a',
-    path.join(filesDir, 'dummy.zip'),
-    path.join(pluginDir, '*'),
-  ]);
 
   // 差し替え前のデータ取得先(ダミープラグインを含まない)
-  writeDataFiles(path.join(fixturesDir, 'initial'), []);
+  writeDataSet(path.join(fixturesDir, 'initial'));
   // 差し替え後のデータ取得先(ダミープラグインを含む)
-  writeDataFiles(fixturesDir, [
-    {
-      id: 'e2e/dummyPlugin',
-      name: 'E2E ダミープラグイン',
-      overview: 'E2E テスト用のダミープラグイン',
-      description: 'Playwright のインストールフロー検証用。',
-      developer: 'apm-e2e',
-      pageURL: `${baseUrl}/`,
-      downloadURLs: [`${baseUrl}/files/dummy.zip`],
-      latestVersion: '1.0.0',
-      files: [{ filename: 'dummy.auf' }],
-    },
-  ]);
+  writeDataSet(fixturesDir, {
+    packages: [
+      {
+        id: 'e2e/dummyPlugin',
+        name: 'E2E ダミープラグイン',
+        overview: 'E2E テスト用のダミープラグイン',
+        description: 'Playwright のインストールフロー検証用。',
+        developer: 'apm-e2e',
+        pageURL: `${baseUrl}/`,
+        downloadURLs: [`${baseUrl}/files/dummy.zip`],
+        latestVersion: '1.0.0',
+        files: [{ filename: 'dummy.auf' }],
+      },
+    ],
+  });
 }
 
 test('dataURL の差し替えとパッケージのインストール・アンインストールができる', async () => {
@@ -102,27 +49,7 @@ test('dataURL の差し替えとパッケージのインストール・アンイ
   mkdirSync(initialInstPath, { recursive: true });
   mkdirSync(instPath, { recursive: true });
 
-  const server = createServer((req, res) => {
-    const filePath = path.join(
-      fixturesDir,
-      (req.url ?? '/').replace(/^\//, ''),
-    );
-    if (!filePath.startsWith(fixturesDir) || !existsSync(filePath)) {
-      res.writeHead(404);
-      res.end();
-      return;
-    }
-    res.writeHead(200, {
-      'content-type': filePath.endsWith('.zip')
-        ? 'application/zip'
-        : 'application/json',
-    });
-    res.end(readFileSync(filePath));
-  });
-  await new Promise<void>((resolve) =>
-    server.listen(0, '127.0.0.1', () => resolve()),
-  );
-  const baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  const { baseUrl, close } = await serveFixtures(fixturesDir);
   writeFixtures(fixturesDir, workDir, baseUrl);
 
   // 設定済みプロファイルを事前シードして起動する。dataVersion が無いと
@@ -204,7 +131,7 @@ test('dataURL の差し替えとパッケージのインストール・アンイ
     await expect(row).not.toContainText('インストール済み');
   } finally {
     await app.close();
-    server.close();
+    close();
     rmSync(userDataDir, { recursive: true, force: true });
     rmSync(workDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## 概要

Phase 5 スライス 5: コア(AviUtl 本体)インストールの E2E です。これで主要フロー(起動 → 一覧表示 → パッケージのインストール / アンインストール → コアのインストール)が一通り E2E で固定されました。

- **fixtures.ts の抽出**: フィクスチャの生成(7za での zip 化、list/core/convert/packages 一式の書き出し)と HTTP 配信(空きポート)を `e2e/fixtures.ts` へ共通化し、install スペックを移行
- **core.spec.ts の追加**: コアのインストールは通常のパッケージ経路と違い `release.integrity.archive` の検証(ssri)を通るため、生成した zip の sha384 を core.json の release に埋めています。フロー: バージョン選択ドロップダウン(`#install-aviutl` → `#aviutl-version-select`)から 1.10 を選択 → 「インストール完了」→ `aviutl.exe` の実配置 + `#aviutl-installed-version` の「バージョン: 1.10」表示を検証
- #2359 と同じく一時 userData + 事前シードで起動するため、実プロファイル・実ネットワークに一切依存しません

## テスト

- `yarn lint` / `yarn lint:ts` 緑
- macOS ローカルで `yarn test:e2e` 緑(3 本、計 7.3 秒。core スペックは integrity 検証込みで 2.0 秒)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
