### PR TITLE
Electron を 40 に更新する

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -29,8 +29,13 @@ apm の開発方針の単一ソース。変更は PR 経由で行う(履歴 = �
 
 ## 次の一手
 
-**Phase 5: 品質・E2E(Playwright)。**
+**Phase 6: 残りのメジャー依存更新。**
 
-セキュリティ(Phase 4)は完了した: main 窓の `sandbox: true` 化(v3.12.0)、contextBridge の最小化(残る露出は electron-trpc の `electronTRPC` と electron-log の `__electronLog` の必須分のみ)、CSP の回収(Monaco を CDN 読み込みからローカル同梱の AMD ビルドへ切り替え、`cdn.jsdelivr.net` 許可を撤去)。CSP に残る緩和は Monaco が worker を blob 経由で起動するための `worker-src blob:` と、Monaco / Bootstrap の動的スタイルのための `style-src 'unsafe-inline'` のみ(いずれも実測で外せないことを確認済み)。
+品質・E2E(Phase 5)は完了した: Playwright の E2E が CI(windows-latest)で回り、主要フロー(起動 → 一覧表示 → パッケージのインストール / アンインストール → コアのインストール)を固定した。E2E はパッケージ版を一時 userData(`--user-data-dir`)+ ローカルフィクスチャ配信で起動するため、実プロファイル・実ネットワークに依存しない。
 
-Done の定義: Playwright の E2E が CI で回り、主要フロー(起動 → 一覧表示 → インストール)が固定されること。
+メジャー更新は決定事項どおり 1 PR = 1 major で、E2E を安全網に進める:
+
+1. **Electron 39 → 43**(1 major ずつ。43.4.1 + forge 6.4.1 でパッケージ生成・E2E 緑をスパイク確認済み)
+2. **ESLint 8 → 9**(flat config 化。ツールチェーンのみで出荷物に影響なし)
+3. **tRPC 10 → 11 + @tanstack/react-query 4 → 5**(ペア更新が必須。electron-trpc の tRPC 11 対応状況の確認から)
+4. **forge 6.4.1 → 7 は最後**(「既知の固定」の解除。preload の webpack ビルド破損が論点なので、E2E + 3 OS ビルドで検証してから)

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "css-loader": "^7.1.4",
     "cz-conventional-changelog": "3.3.0",
     "cz-conventional-changelog-ja": "^0.0.2",
-    "electron": "^39.8.10",
+    "electron": "^40.10.6",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -557,6 +557,11 @@
     xterm-addon-fit "^0.5.0"
     xterm-addon-search "^0.8.0"
 
+"@electron-internal/extract-zip@^1.0.1":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz#6782c0f6066e60b7fd286fe7a5c7600f7650d420"
+  integrity sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==
+
 "@electron/asar@^3.2.1", "@electron/asar@^3.2.5":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@electron/asar/-/asar-3.3.1.tgz#cd14e897770d9844673dd7c1dc8944e086e1e0ea"
@@ -580,6 +585,20 @@
     sumchecker "^3.0.1"
   optionalDependencies:
     global-agent "^3.0.0"
+
+"@electron/get@^5.0.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@electron/get/-/get-5.1.0.tgz#f96ca2a0e89b27490ff8f7b5a392bd4df6942998"
+  integrity sha512-3kSBtG8ObcTVfXanm5vVJ6UnBLEVmVsRk1M+vGqCuMBV+XLCbJYuWQful+yIy0GQDsSlK0kHEriEHn7SPk4EnA==
+  dependencies:
+    debug "^4.1.1"
+    env-paths "^3.0.0"
+    graceful-fs "^4.2.11"
+    progress "^2.0.3"
+    semver "^7.6.3"
+    sumchecker "^3.0.1"
+  optionalDependencies:
+    undici "^7.24.4"
 
 "@electron/node-gyp@https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2":
   version "10.2.0-electron.1"
@@ -1999,12 +2018,12 @@
   dependencies:
     undici-types "~6.19.2"
 
-"@types/node@^22.7.7":
-  version "22.20.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.20.1.tgz#84e7cdf63cdaa20c134aa317ccc901aa21e16f0e"
-  integrity sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==
+"@types/node@^24.9.0":
+  version "24.13.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.13.3.tgz#49f18bd3c647866dcda51a0756c145e14590ce16"
+  integrity sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~7.18.0"
 
 "@types/normalize-package-data@^2.4.4":
   version "2.4.4"
@@ -4420,14 +4439,14 @@ electron-winstaller@^5.0.0:
   optionalDependencies:
     "@electron/windows-sign" "^1.1.2"
 
-electron@^39.8.10:
-  version "39.8.10"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-39.8.10.tgz#998d9c5b9e7601debb70bd7355e8d4dfd6d70f43"
-  integrity sha512-zbYtGPYUI7PzqLAzkk21Rk6j67WN0hxn0Mq/njErZo1d0HSf33is4f8ICI5fMLy5vYe0JtCtM5sYunNOaochSQ==
+electron@^40.10.6:
+  version "40.10.6"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-40.10.6.tgz#4d6fedded9b2a789f3b42ece9b251961192d87f9"
+  integrity sha512-TGjlkOU9Lg6K4KjDbsErywCWCIDaNgLh0q+xj0nlpRoQhevI7VBIxBTtJI/V30lypyLAaXMpnP9O9jui1/qRFw==
   dependencies:
-    "@electron/get" "^2.0.0"
-    "@types/node" "^22.7.7"
-    extract-zip "^2.0.1"
+    "@electron-internal/extract-zip" "^1.0.1"
+    "@electron/get" "^5.0.0"
+    "@types/node" "^24.9.0"
 
 electron@latest:
   version "34.2.0"
@@ -4499,6 +4518,11 @@ env-paths@^2.2.0, env-paths@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
+
+env-paths@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-3.0.0.tgz#2f1e89c2f6dbd3408e1b1711dd82d62e317f58da"
+  integrity sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==
 
 environment@^1.0.0:
   version "1.1.0"
@@ -10092,15 +10116,20 @@ undici-types@~6.20.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 undici@7.28.0:
   version "7.28.0"
   resolved "https://registry.yarnpkg.com/undici/-/undici-7.28.0.tgz#97d64564198b285bc281f0e8e29597e3d11fe7ec"
   integrity sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==
+
+undici@^7.24.4:
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-7.29.0.tgz#ae0f6f62e06e057a9cbb7b2b5fde2bb74f791b8f"
+  integrity sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==
 
 unique-filename@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## 概要

Phase 6(メジャー依存更新)の 1 本目: Electron 39 → **40.10.6** です。ROADMAP の決定事項どおり 1 PR = 1 major で刻みます。

事前スパイクで最新の **43.4.1 + forge 6.4.1** の組み合わせでもパッケージ生成・E2E がすべて緑であることを確認済みなので、既知の固定(forge 6.4.1)と衝突せずに 43 まで到達できる見込みです。以降 41 → 42 → 43 を同様に 1 PR ずつ出します。

ROADMAP の「次の一手」を Phase 6 へ更新するコミットを同梱しています(Phase 5 完了の記録と、メジャー更新の順序: Electron → ESLint 9 → tRPC 11 + react-query 5 → forge 7 は最後)。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(142 件)緑
- macOS ローカルで `yarn package` → `yarn test:e2e` 緑(3 本、計 7.7 秒)
- CI の e2e.yml(windows-latest)で Windows のパッケージ版も検証されます

🤖 Generated with [Claude Code](https://claude.com/claude-code)
