### PR TITLE
Electron を 42 に更新する

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "css-loader": "^7.1.4",
     "cz-conventional-changelog": "3.3.0",
     "cz-conventional-changelog-ja": "^0.0.2",
-    "electron": "^41.10.6",
+    "electron": "^42.9.3",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4439,10 +4439,10 @@ electron-winstaller@^5.0.0:
   optionalDependencies:
     "@electron/windows-sign" "^1.1.2"
 
-electron@^41.10.6:
-  version "41.10.6"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-41.10.6.tgz#df613dbd30a4f6fd0715468632acd35080e9df78"
-  integrity sha512-NEB7QnVpT2p8S9U5jOCPAtCyhl1WjRT/ODvJP6ec1/dZRUmf/EjYVOBb/dthCmJh4bISqpAroGJ/xRRxX7VwJw==
+electron@^42.9.3:
+  version "42.9.3"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-42.9.3.tgz#b9241a1824923bad97ea6c0e619dd0bac8cae63c"
+  integrity sha512-REQUgPrCWOP0FajNcKCwwjkssirN+MVbemyd6bT+x51OVq58y6IqjtpA4vmm/KEzKXj2MIOebx/gF497CkRAPg==
   dependencies:
     "@electron-internal/extract-zip" "^1.0.1"
     "@electron/get" "^5.0.0"


### PR DESCRIPTION
## 概要

Phase 6 の 3 本目: Electron 41 → **42.9.3** です(1 PR = 1 major)。43.4.1 + forge 6.4.1 の両立はスパイク確認済み。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(142 件)緑
- macOS ローカルで `yarn package` → `yarn test:e2e` 緑(3 本、計 8.6 秒)
- CI の e2e.yml(windows-latest)で Windows のパッケージ版も検証されます

🤖 Generated with [Claude Code](https://claude.com/claude-code)