### PR TITLE
Electron を 43 に更新する

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "css-loader": "^7.1.4",
     "cz-conventional-changelog": "3.3.0",
     "cz-conventional-changelog-ja": "^0.0.2",
-    "electron": "^42.9.3",
+    "electron": "^43.4.1",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4439,10 +4439,10 @@ electron-winstaller@^5.0.0:
   optionalDependencies:
     "@electron/windows-sign" "^1.1.2"
 
-electron@^42.9.3:
-  version "42.9.3"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-42.9.3.tgz#b9241a1824923bad97ea6c0e619dd0bac8cae63c"
-  integrity sha512-REQUgPrCWOP0FajNcKCwwjkssirN+MVbemyd6bT+x51OVq58y6IqjtpA4vmm/KEzKXj2MIOebx/gF497CkRAPg==
+electron@^43.4.1:
+  version "43.4.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-43.4.1.tgz#38fe7deff46c1c848b30ac46ad8e57c942704a34"
+  integrity sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA==
   dependencies:
     "@electron-internal/extract-zip" "^1.0.1"
     "@electron/get" "^5.0.0"


### PR DESCRIPTION
## 概要

Phase 6 の 4 本目: Electron 42 → **43.4.1(最新)** です(1 PR = 1 major)。これで Electron のメジャー更新は完了し、EOL 追走の負債が解消されます。

次のメジャー更新は ROADMAP の順序どおり ESLint 9(flat config)に進みます。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(142 件)緑
- macOS ローカルで `yarn package` → `yarn test:e2e` 緑(3 本、計 7.7 秒)
- CI の e2e.yml(windows-latest)で Windows のパッケージ版も検証されます

🤖 Generated with [Claude Code](https://claude.com/claude-code)