### PR TITLE
build(security): dev CSP から cdn.jsdelivr.net を撤去しパッケージ版と同一化する

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -53,10 +53,11 @@ const config: ForgeConfig = {
     new WebpackPlugin({
       mainConfig: mainConfig,
       devServer: { liveReload: false },
-      // TODO(security): cdn.jsdelivr.net / 'unsafe-inline' / blob: は CDN 版 Monaco のための暫定緩和。
-      // セキュリティフェーズで Monaco をローカルバンドルに切り替えて回収する
+      // パッケージ版 main 窓(src/renderer/main/index.html)の CSP と同一に保つ。
+      // worker-src blob: と style-src 'unsafe-inline' は Monaco/Bootstrap のため撤去不可
+      // (理由は index.html のコメント参照)
       devContentSecurityPolicy:
-        "default-src 'self'; script-src-elem 'self' https://cdn.jsdelivr.net; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' https://cdn.jsdelivr.net; img-src 'self' data: https://*.nicovideo.jp https://*.nicoseiga.jp https://nicovideo.cdn.nimg.jp",
+        "default-src 'self'; script-src-elem 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://*.nicovideo.jp https://*.nicoseiga.jp https://nicovideo.cdn.nimg.jp",
       renderer: {
         config: rendererConfig,
         entryPoints: [


### PR DESCRIPTION
## Description

forge.config.ts の `devContentSecurityPolicy` から `https://cdn.jsdelivr.net`(script-src-elem / style-src / font-src の 3 箇所)を撤去し、直前の `TODO(security)` コメントを削除しました。dev CSP はパッケージ版 main 窓(src/renderer/main/index.html)の CSP と完全に同一になります。

`worker-src blob:`(Monaco の AMD loader が worker を blob 経由で起動)と `style-src 'unsafe-inline'`(Monaco / Bootstrap の動的スタイル)は撤去不可のため残しています(AGENTS.md 落とし穴参照)。

## Related Issue

なし(#2356 の CSP 回収のフォローアップ)

## Motivation and Context

Monaco のローカル同梱化(#2356)でパッケージ版 CSP からは CDN 許可を撤去済みでしたが、dev 専用 CSP には CDN 版 Monaco のための暫定緩和が残っていました。dev 起動でも Monaco は dev サーバ配信の `main_window/vs` から読み込む(`document.currentScript.src` 基準の `loader.config`、#2356 の dev 404 修正込み)ため、CDN 許可は不要です。src に残る jsdelivr 参照は apm-data のデータ URL 既定値のみで、これは main プロセスが fetch するため renderer CSP の対象外です。

dev と本番で CSP を同一に保つことで、「dev では動くが本番で CSP に塞がれる」(またはその逆の緩和の残骸)を防ぎます。

## How Has This Been Tested?

- Mac の dev 起動(`yarn start` + `--remote-debugging-port=9222`)で CDP 検証 4 項目 ALL PASS:
  1. CSP violation ゼロ(`securitypolicyviolation` をドキュメント開始時から収集)
  2. Monaco ロード成功(CDN は塞がれているためローカル読込の証明)
  3. jsdelivr へのリソース要求ゼロ・ローカル `main_window/vs` から 7 リソース読込
  4. JSON worker 動作(不正 JSON に markers 付与 = `worker-src blob:` の必要性も同時確認)
- dev サーバ応答ヘッダの CSP がパッケージ版 main 窓と一致することを `curl -I` で確認
- `yarn lint` / `yarn lint:ts` / `yarn test`(142 件)すべて緑

## Screenshots (if appropriate):

なし

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

(いずれも該当なし: dev 環境の CSP 引き締めのみで機能変更なし)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)