### PR TITLE
docs: stale になっていた AGENTS.md 内の参照を修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,10 +27,10 @@ PR 前に上記 3 つ(lint / lint:ts / test)がすべて緑であること。
 
 ## 既知の固定と理由(上げる前に必ず読む)
 
-| 固定                                                            | 理由                                                                                                                                                                                               |
-| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CI (`build.yml` / `release.yml` / `nodejs.yml`) は Node 22 固定 | Node 24 では electron-forge の package/make/publish が「Copying files」後に無言で失敗する(exit 0 で `.app`/`out` が生成されない。forge 7.11.2 でも再現・ローカルでも同様なので Node 22 で実行する) |
-| Electron ほかメジャー更新は dependabot で ignore                | メジャー更新は計画的に 1 PR = 1 major で実施するため(ROADMAP 参照)                                                                                                                                 |
+| 固定                                                                        | 理由                                                                                                                                                                                               |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CI (`build.yml` / `release.yml` / `nodejs.yml` / `e2e.yml`) は Node 22 固定 | Node 24 では electron-forge の package/make/publish が「Copying files」後に無言で失敗する(exit 0 で `.app`/`out` が生成されない。forge 7.11.2 でも再現・ローカルでも同様なので Node 22 で実行する) |
+| Electron ほかメジャー更新は dependabot で ignore                            | メジャー更新は計画的に 1 PR = 1 major で実施するため(ROADMAP 参照)                                                                                                                                 |
 
 ## 作業スタイル
 
@@ -55,7 +55,7 @@ PR 前に上記 3 つ(lint / lint:ts / test)がすべて緑であること。
 
 ## 落とし穴
 
-- `src/lib/compareVersion.ts` の `compareVersion` は比較不能時に `Number.NaN` を返す。NaN は全比較演算子で false になるため、呼び出し側は必ず `Number.isNaN()` で先に分岐する(`!== 0` 形式の分岐は意味が反転する)
+- `src/shared/compareVersion.ts` の `compareVersion` は比較不能時に `Number.NaN` を返す。NaN は全比較演算子で false になるため、呼び出し側は必ず `Number.isNaN()` で先に分岐する(`!== 0` 形式の分岐は意味が反転する)
 - `src/renderer/main/preload.ts` に残る初期化フロー(migration → initSettings → ensureInstallationPath → changeInstallationPath)は順序が仕様。全ステップ tRPC 呼び出しで Node API 依存は無い(Phase 4 の `sandbox: true` 化の前提)
 - renderer.tsx は React ルートを機能ごとに分けて createRoot しているため、React Context はルート間で共有できない。複数ルートから共有する実行状態は `packages/packagesListCheck.ts` のようにモジュールシングルトン + `useSyncExternalStore` で持つ。ルート間・レガシーとの通知は DOM イベント(`apm-packages-changed` / `apm-core-changed` / `apm-check-packages-list` / `apm-install-package-by-id`)
 - メインワールドの React から import する shared モジュールは electron だけでなく **fs にも依存不可**(renderer の webpack ビルドに Node ポリフィルが無いため、fs-extra が混入するとビルドが落ちる)。表示用の定数・純関数は `src/shared/packageDisplay.ts` のように fs 非依存モジュールへ分離する


### PR DESCRIPTION
## 概要

CLAUDE.md/AGENTS.md 監査で見つかった、コードベースと乖離していた記述 2 件の修正です。

- **compareVersion のパス修正**: 落とし穴セクションの `src/lib/compareVersion.ts` は存在せず、実体は `src/shared/compareVersion.ts` に移動済み。NaN を返す挙動と `Number.isNaN()` での分岐が必要な点は現行どおりのため、パスのみ修正
- **CI の Node 22 固定リストに `e2e.yml` を追加**: 実測で `build.yml` / `release.yml` / `nodejs.yml` / `e2e.yml` の 4 ワークフローが `node-version: '22'` 固定(`electronegativity.yml` のみ `lts/*` だが、electron-forge を使わないため対象外)

表の桁揃えは `prettier --write` による整形です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)