### PR TITLE
docs: 構成セクションの新設とコマンド一覧の補完

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,24 @@
 
 AviUtl Package Manager (apm) — AviUtl のプラグイン・スクリプトを管理する Electron 製デスクトップアプリ。TypeScript + webpack (electron-forge)。UI は React + tRPC(main 窓の全タブ + About 窓)。ビジネスロジックは main プロセス(src/main/services)にあり、preload は初期化フロー・contextBridge・tRPC クライアントのみ。
 
+## 構成
+
+| パス                 | 役割                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `src/main/`          | メインプロセス。`index.ts` = エントリ、`api.ts` = tRPC ルーター、`services/` = ビジネスロジック                          |
+| `src/renderer/`      | 窓ごと(`main` / `about` / `splash`)。forge.config.ts の entryPoints と 1:1 対応                                          |
+| `src/renderer/main/` | main 窓。タブごとのディレクトリ(`aviutl` / `packages` / `nicommons` / `settings` / `others`)+ 初期化フローを持つ preload |
+| `src/lib/`           | renderer から使う electron 依存モジュール(`trpcClient.ts` / `ipcWrapper.ts`)                                             |
+| `src/shared/`        | electron 非依存の純粋モジュール。ユニットテストの主対象                                                                  |
+| `src/common/ipc.ts`  | レガシー IPC のチャンネル名定義                                                                                          |
+
 ## コマンド
 
 ```
-yarn lint       # prettier + eslint
+yarn lint       # prettier + eslint(--check。自動修正は yarn fix)
 yarn lint:ts    # tsc --noEmit
 yarn test       # vitest run (src/**/*.test.ts)
+yarn package    # electron-forge package(ThirdPartyNotices 生成込み)
 yarn test:e2e   # Playwright E2E (e2e/)。パッケージ版を起動するため先に yarn package が必要。--user-data-dir で一時 userData を渡して起動するため実プロファイルは汚さない
 yarn start      # 開発起動 (Node 22 推奨)
 ```


### PR DESCRIPTION
## 概要

#2373 にスタックした AGENTS.md の見直し 2 件です(base は `docs/fix-agents-md-stale-refs`。#2373 マージ後に base を main へ付け替えてください)。

- **「構成」セクションの新設**: `src/shared` / `src/lib` の配置原則はあったものの「どこに何があるか」の地図が無かったため、src 直下のディレクトリと役割の対応表を追加。`src/renderer/` が forge.config.ts の entryPoints(main / about / splash)と 1:1 対応する点、`src/renderer/main/` がタブ単位のディレクトリ構成である点、`src/common/ipc.ts` がレガシー IPC の残存面である点を明記
- **コマンド一覧の補完**: `yarn test:e2e` の前提として文中にのみ登場していた `yarn package` を一覧に追加(ThirdPartyNotices 生成込みであることも明記)。`yarn lint` が check-only で自動修正は `yarn fix` である旨を注記

意図的に載せていないもの: package.json から自明なコマンド(`test:watch` / `release` 等)、すぐ陳腐化する `src/shared/` のファイル一覧。

🤖 Generated with [Claude Code](https://claude.com/claude-code)