### PR TITLE
fix(security): インストール経路のコマンドインジェクションとパストラバーサルを塞ぐ

### DIFF
--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -12,11 +12,12 @@ import {
   writeJson,
 } from 'fs-extra';
 import * as matcher from 'matcher';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { isParent } from '../../shared/apmPath';
 import { getHash } from '../../shared/getHash';
 import { install, verifyFilesByCount } from '../../shared/install';
+import { buildInstallerArgs } from '../../shared/installerArgs';
 import { checkIntegrity, verifyFile } from '../../shared/integrity';
 import {
   computePackagesStatus,
@@ -491,14 +492,11 @@ export async function installPackageArchive(
       };
 
       const exePath = await searchFiles(unzippedPath);
-      const command =
-        '"' +
-        exePath[0][0] +
-        '" ' +
-        packageItem.info.installArg
-          .replace('"$instpath"', '$instpath')
-          .replace('$instpath', '"' + instPath + '"'); // Prevent double quoting
-      execSync(command);
+      // シェルを介さないため installArg のメタ文字がコマンドとして解釈されない
+      execFileSync(
+        exePath[0][0],
+        buildInstallerArgs(packageItem.info.installArg, instPath),
+      );
 
       installResult = verifyFilesByCount(instPath, packageItem.info.files);
     } else {

--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -14,7 +14,7 @@ import {
 import * as matcher from 'matcher';
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
-import { isParent } from '../../shared/apmPath';
+import { isParent, resolveInside } from '../../shared/apmPath';
 import { getHash } from '../../shared/getHash';
 import { install, verifyFilesByCount } from '../../shared/install';
 import { buildInstallerArgs } from '../../shared/installerArgs';
@@ -844,6 +844,9 @@ export async function installScriptArchive(
       'old_*',
     ];
     const scriptRoot = (await searchScriptRoot(unzippedPath))[0];
+    // folder は scripts.json(リモート)由来。インストール先の外に出る指定を
+    // 書き込み前に弾く
+    const scriptFolder = resolveInside(instPath, 'script', matchInfo.folder);
     const entriesToCopy = (
       await fsReaddir(scriptRoot, {
         withFileTypes: true,
@@ -853,14 +856,14 @@ export async function installScriptArchive(
       .map((p) => {
         return {
           src: path.join(scriptRoot, p.name),
-          dest: path.join(instPath, 'script', matchInfo.folder, p.name),
+          dest: resolveInside(scriptFolder, p.name),
           filename: path
             .join('script', matchInfo.folder, p.name)
             .replaceAll('\\', '/'),
           isDirectory: p.isDirectory(),
         };
       });
-    await mkdir(path.join(instPath, 'script', matchInfo.folder), {
+    await mkdir(scriptFolder, {
       recursive: true,
     });
     await Promise.all(

--- a/src/shared/apmPath.test.ts
+++ b/src/shared/apmPath.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { isParent, pathRelated } from './apmPath';
+import { isParent, pathRelated, resolveInside } from './apmPath';
 
 describe('isParent', () => {
   it('returns true for a direct child path', () => {
@@ -33,5 +33,47 @@ describe('pathRelated', () => {
     const pathA = path.join('/data', 'apm');
     const pathB = path.join('/other', 'apm');
     expect(pathRelated(pathA, pathB)).toBe(false);
+  });
+});
+
+describe('resolveInside', () => {
+  const instPath = path.resolve('/data', 'aviutl');
+
+  it('インストール先の中のパスをそのまま解決する', () => {
+    expect(resolveInside(instPath, 'plugins/foo.auf')).toBe(
+      path.join(instPath, 'plugins', 'foo.auf'),
+    );
+  });
+
+  it('複数のセグメントを結合できる', () => {
+    expect(resolveInside(instPath, 'script', 'developer', 'a.anm')).toBe(
+      path.join(instPath, 'script', 'developer', 'a.anm'),
+    );
+  });
+
+  it('親ディレクトリへ脱出するパスを拒否する', () => {
+    expect(() => resolveInside(instPath, '../evil.exe')).toThrow();
+    expect(() => resolveInside(instPath, 'plugins/../../evil.exe')).toThrow();
+    expect(() => resolveInside(instPath, 'script', '../../..', 'evil')).toThrow(
+      /invalid path/,
+    );
+  });
+
+  it('絶対パス指定を拒否する', () => {
+    expect(() =>
+      resolveInside(instPath, path.resolve('/etc/passwd')),
+    ).toThrow();
+  });
+
+  it('インストール先そのものを指すパスを拒否する', () => {
+    // copy 先が instPath 自体になる指定は書き込み対象として不正
+    expect(() => resolveInside(instPath, '.')).toThrow();
+    expect(() => resolveInside(instPath, '')).toThrow();
+  });
+
+  it('途中に .. があっても中に留まるなら許可する', () => {
+    expect(resolveInside(instPath, 'plugins/../script/a.anm')).toBe(
+      path.join(instPath, 'script', 'a.anm'),
+    );
   });
 });

--- a/src/shared/apmPath.ts
+++ b/src/shared/apmPath.ts
@@ -20,3 +20,25 @@ export function isParent(parent: string, child: string) {
 export function pathRelated(pathA: string, pathB: string) {
   return isParent(pathA, pathB) || isParent(pathB, pathA);
 }
+
+/**
+ * Resolves a path under {parent}, rejecting anything that escapes it.
+ *
+ * パッケージデータのファイル名・フォルダ名はリモート由来なので、結合結果が
+ * インストール先の外を指していないか確かめてから書き込みに使う。文字列として
+ * '..' を検査するのではなく解決後の位置で判定するのは、絶対パス指定や
+ * 正規化で外へ出る形(`a/../../b`)も同じ関門で弾くため。
+ * @param {string} parent - A path expected to contain the result.
+ * @param {string[]} segments - Path segments to join under {parent}.
+ * @returns {string} The resolved path inside {parent}.
+ */
+export function resolveInside(parent: string, ...segments: string[]) {
+  const resolvedParent = path.resolve(parent);
+  const resolved = path.resolve(resolvedParent, path.join(...segments));
+  if (!isParent(resolvedParent, resolved)) {
+    throw new Error(
+      `An invalid path outside the installation folder was specified. ${resolved}`,
+    );
+  }
+  return resolved;
+}

--- a/src/shared/install.test.ts
+++ b/src/shared/install.test.ts
@@ -161,4 +161,16 @@ describe('install', () => {
       ),
     ).rejects.toThrow('Could not verify that the files was installed.');
   });
+
+  it('インストール先の外へ出る filename を拒否して書き込まない', async () => {
+    const src = await makeTempDir('apm-install-src-');
+    const inst = await makeTempDir('apm-install-dst-');
+    const outside = path.join(inst, '..', 'escaped.auf');
+    await writeFile(path.join(src, 'escaped.auf'), 'evil');
+
+    await expect(
+      install(src, inst, [{ filename: '../escaped.auf' }]),
+    ).rejects.toThrow(/invalid path/);
+    expect(await pathExists(outside)).toBe(false);
+  });
 });

--- a/src/shared/install.ts
+++ b/src/shared/install.ts
@@ -1,5 +1,6 @@
 import { copy, existsSync } from 'fs-extra';
 import path from 'node:path';
+import { resolveInside } from './apmPath';
 import { safeRemove } from './safeRemove';
 
 export type Files = {
@@ -66,7 +67,9 @@ export async function install(
               path.basename(file.filename),
             )
           : path.join(unzippedPath, path.basename(file.filename)),
-        path.join(instPath, file.filename),
+        // filename はリモート由来。削除側(safeRemove)と同じくインストール先の
+        // 外を指していないか確かめてから書き込む
+        resolveInside(instPath, file.filename),
       ];
       if (file.isUninstallOnly) {
         if (existsSync(filePath[0]) && !existsSync(filePath[1]))

--- a/src/shared/installerArgs.test.ts
+++ b/src/shared/installerArgs.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { buildInstallerArgs } from './installerArgs';
+
+describe('buildInstallerArgs', () => {
+  it('空白区切りの引数を配列にする', () => {
+    expect(buildInstallerArgs('/S /NORESTART', 'C:\\aviutl')).toEqual([
+      '/S',
+      '/NORESTART',
+    ]);
+  });
+
+  it('installArg が未定義なら空配列を返す', () => {
+    expect(buildInstallerArgs(undefined, 'C:\\aviutl')).toEqual([]);
+    expect(buildInstallerArgs('', 'C:\\aviutl')).toEqual([]);
+  });
+
+  it('$instpath をインストール先に置換する', () => {
+    expect(buildInstallerArgs('/D=$instpath', 'C:\\aviutl')).toEqual([
+      '/D=C:\\aviutl',
+    ]);
+  });
+
+  it('引用符付きの $instpath も同じ 1 引数になる', () => {
+    // 旧実装は '"$instpath"' を '$instpath' に戻してから引用符を付け直していた。
+    // 引用符は引数の区切りを打ち消すだけなので結果は引用符なしと等価
+    expect(buildInstallerArgs('/DIR="$instpath"', 'C:\\aviutl')).toEqual([
+      '/DIR=C:\\aviutl',
+    ]);
+  });
+
+  it('パスに空白が含まれても 1 引数のまま渡す', () => {
+    expect(
+      buildInstallerArgs('/DIR="$instpath"', 'C:\\Program Files\\aviutl'),
+    ).toEqual(['/DIR=C:\\Program Files\\aviutl']);
+    expect(
+      buildInstallerArgs('/DIR=$instpath', 'C:\\Program Files\\aviutl'),
+    ).toEqual(['/DIR=C:\\Program Files\\aviutl']);
+  });
+
+  it('引用符で囲まれた空白は引数を分割しない', () => {
+    expect(buildInstallerArgs('/LOG="my log.txt" /S', 'C:\\aviutl')).toEqual([
+      '/LOG=my log.txt',
+      '/S',
+    ]);
+  });
+
+  it('連続する空白を区切りとして畳み込む', () => {
+    expect(buildInstallerArgs('  /S   /D=$instpath  ', 'C:\\a')).toEqual([
+      '/S',
+      '/D=C:\\a',
+    ]);
+  });
+
+  it('空文字列の引数を 1 トークンとして残す', () => {
+    expect(buildInstallerArgs('/S "" /D=$instpath', 'C:\\a')).toEqual([
+      '/S',
+      '',
+      '/D=C:\\a',
+    ]);
+  });
+
+  it('シェルのメタ文字を展開せずただの文字として扱う', () => {
+    // execFileSync に shell 無しで渡す前提。& や | が別コマンドの起動に
+    // ならないことをトークン境界で固定する
+    expect(buildInstallerArgs('/S & calc.exe', 'C:\\aviutl')).toEqual([
+      '/S',
+      '&',
+      'calc.exe',
+    ]);
+    expect(buildInstallerArgs('"/S && calc.exe"', 'C:\\aviutl')).toEqual([
+      '/S && calc.exe',
+    ]);
+  });
+
+  it('$instpath 由来の値をコマンドとして再解釈しない', () => {
+    expect(buildInstallerArgs('/D=$instpath', 'C:\\a & calc.exe')).toEqual([
+      '/D=C:\\a & calc.exe',
+    ]);
+  });
+
+  it('$instpath が複数あればすべて置換する', () => {
+    expect(buildInstallerArgs('/D=$instpath /L=$instpath', 'C:\\a')).toEqual([
+      '/D=C:\\a',
+      '/L=C:\\a',
+    ]);
+  });
+});

--- a/src/shared/installerArgs.ts
+++ b/src/shared/installerArgs.ts
@@ -1,0 +1,65 @@
+/** The placeholder in `installArg` replaced with the installation path. */
+const INSTALL_PATH_PLACEHOLDER = '$instpath';
+
+/**
+ * Splits an `installArg` string into an argument array.
+ *
+ * 引用符はシェルと同じく引数の区切りを打ち消す用途にのみ使い、トークンからは
+ * 取り除く(`/DIR="$instpath"` → `/DIR=<instPath>`)。シェルを介さず
+ * execFileSync へ渡すため、メタ文字(`&` `|` `;` など)は展開されず
+ * ただの文字として実行ファイルに届く。
+ * @param {string} installArg - The raw `installArg` from the package data.
+ * @returns {string[]} The tokenized arguments.
+ */
+function tokenize(installArg: string): string[] {
+  const args: string[] = [];
+  let current = '';
+  let hasToken = false;
+  let quote: '"' | "'" | null = null;
+
+  for (const char of installArg) {
+    if (quote) {
+      if (char === quote) quote = null;
+      else current += char;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      // 空文字列の引数("" のみ)も 1 トークンとして残す
+      hasToken = true;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (hasToken || current !== '') {
+        args.push(current);
+        current = '';
+        hasToken = false;
+      }
+      continue;
+    }
+    current += char;
+    hasToken = true;
+  }
+  if (hasToken || current !== '') args.push(current);
+
+  return args;
+}
+
+/**
+ * Builds the argument array passed to a package installer.
+ *
+ * `$instpath` はトークン化した後に置換するため、インストール先のパスに空白や
+ * シェルメタ文字が含まれていても引数の境界は動かない。
+ * @param {string | undefined} installArg - The raw `installArg` from the package data.
+ * @param {string} instPath - An installation path.
+ * @returns {string[]} The arguments for the installer.
+ */
+export function buildInstallerArgs(
+  installArg: string | undefined,
+  instPath: string,
+): string[] {
+  if (!installArg) return [];
+  return tokenize(installArg).map((arg) =>
+    arg.replaceAll(INSTALL_PATH_PLACEHOLDER, instPath),
+  );
+}


### PR DESCRIPTION
Phase 1(緊急セキュリティ修正)の 2 件。どちらもリモートのパッケージデータを信頼して危険な操作に渡していた箇所で、フラットレビューでの指摘を実コードで確認したうえで修正した。トラッカーは #2379。

## 1. インストーラ引数のコマンドインジェクション

`installArg` は packages.json 由来の自由文字列だが、実行ファイルのパスと連結して `execSync` に渡していた。悪意あるデータ配布元が `installArg: "/S & powershell ..."` を配れば、ユーザーのインストール操作で任意コマンドが実行できる状態だった。`instPath` も同じ文字列に補間されるため二次的な経路にもなっていた。

シェルを介さない `execFileSync` へ移し、引数はトークン化した配列で渡す。`$instpath` の置換はトークン化の**後**に行うため、インストール先のパスに空白やシェルメタ文字が含まれても引数の境界は動かない。トークナイズは `src/shared/installerArgs.ts` の純関数に切り出してテストした。

## 2. インストール先の外へ書き込めるパストラバーサル

パッケージデータの `filename` と scripts.json の `folder` はリモート由来だが、コピー先の `path.join` に検証が無く、`../../` を含む値でインストール先の外へファイルを配置できた。削除側の `safeRemove` は同じ攻撃を `isParent` で弾いており、**書き込み側だけ防御が欠けている非対称**な状態だった。

解決後の位置がインストール先の内側かを確かめる `resolveInside` を `apmPath` に追加し、`install()` の配置先と script インストールのコピー先に通した。文字列として `..` を検査するのではなく解決後の位置で判定するため、絶対パス指定や正規化で外へ出る形も同じ関門で弾ける。

## 影響範囲

公式 apm-data の全 285 パッケージに `installer` / `installArg` の使用は無く、1 の経路はサードパーティのデータ専用。2 も正規のパッケージは配下パスしか使わないため、既存パッケージの挙動は変わらない。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(160 件、新規 18 件)すべて緑
- `yarn package` + `yarn test:e2e` 3 本緑(パッケージ導入 / アンインストール / コア導入の実フロー)
- 旧実装で `installArg` に `; touch PWNED` を渡すと実際にファイルが作られることを再現し、新実装では作られず引数として渡るだけになることを実行で確認
- `filename: '../Startup/evil.auf'` が拒否され外部にファイルが作られないこと、通常の `plugins/good.auf` は従来どおり配置されることを実行で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
