### PR TITLE
build: TypeScript 6.0 へ更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "style-loader": "^4.0.0",
     "ts-loader": "^9.6.2",
     "ts-node": "^10.9.2",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.67.0",
     "vitest": "^3.2.7"
   },

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -1,0 +1,2 @@
+// CSS は webpack の css-loader が処理する(TS 6.0 から副作用 import も解決チェックされる)
+declare module '*.css';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,18 +2,20 @@
   "compilerOptions": {
     "target": "ES2022",
     "allowJs": true,
-    "module": "commonjs",
+    "module": "nodenext",
     "skipLibCheck": true,
     "esModuleInterop": true,
+    // TS 6.0 から strict が既定で有効。strict 化は挙動リスクを伴うため
+    // メジャー更新と混ぜず、従来の設定(noImplicitAny のみ)を明示して維持する
+    "strict": false,
     "noImplicitAny": true,
     "sourceMap": true,
-    "baseUrl": ".",
+    // TS 6.0 から rootDir の暗黙推論が廃止(TS5011)。include が webpack.*.ts 等
+    // リポジトリ直下も含むため "." を明示する
+    "rootDir": ".",
     "outDir": "dist",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "resolveJsonModule": true,
-    "paths": {
-      "*": ["node_modules/*"]
-    },
     "jsx": "react-jsx"
   },
   "include": ["src/**/*", "e2e/**/*", "webpack.*.ts", "*.config.ts"]

--- a/webpack.plugins.ts
+++ b/webpack.plugins.ts
@@ -6,9 +6,7 @@ import type {
   WebpackPluginInstance,
 } from 'webpack';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const ForkTsCheckerWebpackPlugin: typeof IForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
 const relocateLoader: {
   initAssetCache: (compilation: Compilation, outputAssetBase: string) => void;
 } = require('@vercel/webpack-asset-relocator-loader');

--- a/yarn.lock
+++ b/yarn.lock
@@ -570,9 +570,9 @@
   optionalDependencies:
     undici "^7.24.4"
 
-"@electron/node-gyp@git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2":
+"@electron/node-gyp@https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2":
   version "10.2.0-electron.1"
-  resolved "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2"
+  resolved "https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2"
   dependencies:
     env-paths "^2.2.0"
     exponential-backoff "^3.1.1"
@@ -9936,10 +9936,10 @@ typescript@~5.4.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
   integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
-typescript@~5.9.3:
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+typescript@~6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 uglify-js@^3.1.4:
   version "3.19.3"


### PR DESCRIPTION
## 概要

TypeScript を 5.9.3 → 6.0.3 へ更新する(次期 Phase 2、トラッカー #2379)。dependabot の #2292 はロックファイルが古く CI 全赤のため、こちらで置き換える。

## 変更内容

1. **stale な eslint-disable の除去**(webpack.plugins.ts)
   - `no-var-requires` は typescript-eslint v8 で廃止済みで unused directive 警告になっていた
   - TS 6.0 では `eslint --fix-dry-run` がこの directive を除去した後の再 lint 中に `no-floating-promises` の修正候補生成でクラッシュする(#2292 の Lint 失敗の正体)。除去でクラッシュ経路ごと解消
2. **tsconfig の TS 6.0 追従**(TS 5.9 でも有効な設定のみ)
   - `baseUrl` + `paths`(node_modules 全通し)を削除 — node 解決で元々不要なボイラープレート
   - `moduleResolution: node`(node10、TS 7.0 で廃止予定)→ `nodenext`。`type: module` が無いので emit は従来どおり CommonJS
   - **TS 6.0 は `strict` が既定で有効**になるため、従来の設定(`noImplicitAny` のみ)を `strict: false` で明示して維持。strict 化すると既存コードで 69 件のエラーが出るため、メジャー更新と混ぜず別スライスで行う
   - `rootDir: "."` を明示(TS5011: 暗黙推論の廃止。ts-loader のビルドが止まる)
   - CSS の ambient 宣言を追加(TS2882: 副作用 import も解決チェックされるようになった)
3. **typescript 6.0.3 へ更新** — typescript-eslint 8.67.0 の peer 依存 `>=4.8.4 <6.1.0` の範囲内

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(160 件)すべて緑
- `yarn package`(Node 22)成功 + `yarn test:e2e` 3 本緑(パッケージ導入・アンインストール・コア導入)
- 副次効果: `tsc --noEmit` が約 8 秒 → 約 1.5 秒に短縮

## 補足

- マージ後、#2292 は close してよい(このブランチが上位互換)
- strict 化(69 件の修正)は別 issue/スライスとして #2379 に追記予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
