### PR TITLE
fix(security): tRPC 境界で packageItem.info を検証し、コピー元のパストラバーサルを塞ぐ

### DIFF
--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -7,6 +7,10 @@ import {
   type IpcMainInvokeEvent,
 } from 'electron';
 import type { CreateContextOptions } from 'trpc-electron/main';
+import {
+  isHttpUrl,
+  validatePackageInfo,
+} from '../shared/packageInfoValidation';
 import { openAboutWindow } from './aboutWindow';
 import { getConfig } from './Config';
 import {
@@ -111,7 +115,8 @@ const packageItemInput = (
   const { id, info } = value as Record<string, unknown>;
   if (typeof id !== 'string' || typeof info !== 'object' || info === null)
     throw new TypeError('id is expected to be a string and info an object.');
-  return { id, info: info as Record<string, unknown> };
+  // renderer は非信頼。パス・コマンド・URL に到達するフィールドはここで検証する
+  return { id, info: validatePackageInfo(info) };
 };
 
 const installPackageInput = (
@@ -164,6 +169,9 @@ const installScriptFlowInput = (
   const { instPath, url } = value as Record<string, unknown>;
   if (typeof instPath !== 'string' || typeof url !== 'string')
     throw new TypeError('instPath and url are expected to be strings.');
+  // ブラウザ窓で開く URL なので http(s) 以外(file: 等)を通さない
+  if (!isHttpUrl(url))
+    throw new TypeError('url is expected to be a http(s) URL.');
   return { instPath, url };
 };
 

--- a/src/shared/apmPath.ts
+++ b/src/shared/apmPath.ts
@@ -37,7 +37,7 @@ export function resolveInside(parent: string, ...segments: string[]) {
   const resolved = path.resolve(resolvedParent, path.join(...segments));
   if (!isParent(resolvedParent, resolved)) {
     throw new Error(
-      `An invalid path outside the installation folder was specified. ${resolved}`,
+      `An invalid path outside the base folder was specified. ${resolved}`,
     );
   }
   return resolved;

--- a/src/shared/install.test.ts
+++ b/src/shared/install.test.ts
@@ -162,6 +162,23 @@ describe('install', () => {
     ).rejects.toThrow('Could not verify that the files was installed.');
   });
 
+  it('展開ディレクトリの外を指す archivePath をコピー元にできない', async () => {
+    const src = await makeTempDir('apm-install-src-');
+    const inst = await makeTempDir('apm-install-dst-');
+    // 展開ディレクトリの外にあるファイル(instPath 内へ持ち出される標的)
+    await writeFile(path.join(src, '..', 'apm-install-secret.txt'), 'secret');
+
+    await expect(
+      install(src, inst, [
+        { filename: 'plugins/apm-install-secret.txt', archivePath: '..' },
+      ]),
+    ).rejects.toThrow(/invalid path/);
+    expect(
+      await pathExists(path.join(inst, 'plugins/apm-install-secret.txt')),
+    ).toBe(false);
+    await remove(path.join(src, '..', 'apm-install-secret.txt'));
+  });
+
   it('インストール先の外へ出る filename を拒否して書き込まない', async () => {
     const src = await makeTempDir('apm-install-src-');
     const inst = await makeTempDir('apm-install-dst-');

--- a/src/shared/install.ts
+++ b/src/shared/install.ts
@@ -60,8 +60,10 @@ export async function install(
     const filesToInstall = files.filter((file) => !file.isObsolete);
     for (const file of filesToInstall) {
       const filePath = [
+        // archivePath もリモート由来。展開ディレクトリの外(任意のローカル
+        // ファイル)をコピー元にされないよう、書き込み先と同じ関門を通す
         file.archivePath
-          ? path.join(
+          ? resolveInside(
               unzippedPath,
               file.archivePath,
               path.basename(file.filename),

--- a/src/shared/packageInfoValidation.test.ts
+++ b/src/shared/packageInfoValidation.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isHttpUrl,
+  isSafeRelativePath,
+  validatePackageInfo,
+} from './packageInfoValidation';
+
+describe('isSafeRelativePath', () => {
+  it('通常の相対パスを許可する', () => {
+    expect(isSafeRelativePath('plugin.auf')).toBe(true);
+    expect(isSafeRelativePath('plugins/plugin.auf')).toBe(true);
+    expect(isSafeRelativePath('script/dev/a.anm')).toBe(true);
+    expect(isSafeRelativePath('日本語 フォルダ/ファイル.txt')).toBe(true);
+  });
+
+  it('.. セグメントを含むパスを拒否する', () => {
+    expect(isSafeRelativePath('..')).toBe(false);
+    expect(isSafeRelativePath('../evil.auf')).toBe(false);
+    expect(isSafeRelativePath('plugins/../../evil.auf')).toBe(false);
+    expect(isSafeRelativePath('plugins\\..\\evil.auf')).toBe(false);
+  });
+
+  it('絶対パス・ドライブレター・UNC を拒否する', () => {
+    expect(isSafeRelativePath('/etc/passwd')).toBe(false);
+    expect(isSafeRelativePath('C:\\Windows\\evil.dll')).toBe(false);
+    expect(isSafeRelativePath('\\\\server\\share\\evil')).toBe(false);
+  });
+
+  it('空文字列と制御文字を拒否する', () => {
+    expect(isSafeRelativePath('')).toBe(false);
+    expect(isSafeRelativePath('a\0b')).toBe(false);
+    expect(isSafeRelativePath('a\nb')).toBe(false);
+  });
+
+  it('.. を含むだけのファイル名は許可する', () => {
+    expect(isSafeRelativePath('archive..zip')).toBe(true);
+    expect(isSafeRelativePath('a..b/file.txt')).toBe(true);
+  });
+});
+
+describe('isHttpUrl', () => {
+  it('http(s) の URL を許可する', () => {
+    expect(isHttpUrl('https://example.com/a.zip')).toBe(true);
+    expect(isHttpUrl('http://example.com/a.zip')).toBe(true);
+  });
+
+  it('http(s) 以外のスキームを拒否する', () => {
+    expect(isHttpUrl('file:///etc/passwd')).toBe(false);
+    expect(isHttpUrl('ftp://example.com/a.zip')).toBe(false);
+    expect(isHttpUrl('javascript:alert(1)')).toBe(false);
+    expect(isHttpUrl('example.com/a.zip')).toBe(false);
+  });
+});
+
+describe('validatePackageInfo', () => {
+  const validInfo = {
+    id: 'author/package',
+    name: 'テスト',
+    files: [{ filename: 'plugins/plugin.auf' }],
+    downloadURLs: ['https://example.com/'],
+  };
+
+  it('正常な info をそのまま返す', () => {
+    expect(validatePackageInfo(validInfo)).toBe(validInfo);
+  });
+
+  it('スキーマ外の表示用制約(名前の長さ等)は検証しない', () => {
+    // 境界で守るのはセキュリティ不変条件のみ。サードパーティデータの
+    // 緩い形(dataURL 自由入力の確定方針)を壊さない
+    const loose = {
+      ...validInfo,
+      name: 'とても長い名前'.repeat(10),
+      unknownField: true,
+    };
+    expect(validatePackageInfo(loose)).toBe(loose);
+  });
+
+  it('オブジェクトでない info を拒否する', () => {
+    expect(() => validatePackageInfo(null)).toThrow(TypeError);
+    expect(() => validatePackageInfo('info')).toThrow(TypeError);
+  });
+
+  it('files が配列でなければ拒否する', () => {
+    expect(() => validatePackageInfo({ ...validInfo, files: {} })).toThrow(
+      /files/,
+    );
+    const noFiles: Partial<typeof validInfo> = { ...validInfo };
+    delete noFiles.files;
+    expect(() => validatePackageInfo(noFiles)).toThrow(/files/);
+  });
+
+  it('外へ出る filename / archivePath を拒否する', () => {
+    expect(() =>
+      validatePackageInfo({
+        ...validInfo,
+        files: [{ filename: '../evil.auf' }],
+      }),
+    ).toThrow(/unsafe filename/);
+    expect(() =>
+      validatePackageInfo({
+        ...validInfo,
+        files: [{ filename: 'plugin.auf', archivePath: '../../outside' }],
+      }),
+    ).toThrow(/unsafe archivePath/);
+  });
+
+  it('パス区切りや制御文字を含む installer を拒否する', () => {
+    expect(() =>
+      validatePackageInfo({ ...validInfo, installer: 'dir/setup.exe' }),
+    ).toThrow(/unsafe installer/);
+    expect(() =>
+      validatePackageInfo({ ...validInfo, installer: '..' }),
+    ).toThrow(/unsafe installer/);
+    expect(
+      validatePackageInfo({ ...validInfo, installer: 'setup.exe' }),
+    ).toBeTruthy();
+  });
+
+  it('制御文字を含む installArg を拒否する', () => {
+    expect(() =>
+      validatePackageInfo({ ...validInfo, installArg: '/S\nmalicious' }),
+    ).toThrow(/unsafe installArg/);
+    // 通常のメタ文字は execFileSync 側で無害化されるため境界では通す
+    expect(
+      validatePackageInfo({ ...validInfo, installArg: '/S /D=$instpath' }),
+    ).toBeTruthy();
+  });
+
+  it('http(s) 以外の directURL / downloadURLs を拒否する', () => {
+    expect(() =>
+      validatePackageInfo({ ...validInfo, directURL: 'file:///C:/a.zip' }),
+    ).toThrow(/directURL/);
+    expect(() =>
+      validatePackageInfo({
+        ...validInfo,
+        downloadURLs: ['https://example.com/', 'file:///C:/'],
+      }),
+    ).toThrow(/downloadURLs/);
+  });
+});

--- a/src/shared/packageInfoValidation.ts
+++ b/src/shared/packageInfoValidation.ts
@@ -1,0 +1,104 @@
+// tRPC 境界(renderer は非信頼)で packageItem.info のセキュリティ不変条件を
+// 検証する。apm-schema の JSON Schema 全体を強制しないのは、name の文字数上限の
+// ような表示用制約まで強制するとサードパーティ dataURL の緩いデータが
+// インストールできなくなるため(dataURL 自由入力の確定方針と衝突する)。
+// ここで守るのはパス・コマンド・URL に到達するフィールドだけで、
+// 形の細部はサービス層(resolveInside / safeRemove / execFileSync)が二重に守る。
+
+/** Control characters (C0 and DEL) that never appear in legitimate values. */
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/;
+
+/**
+ * Returns whether the value is a relative path that stays inside its base.
+ * @param {string} value - A path from remote package data.
+ * @returns {boolean} Whether the path is safe to join under a base folder.
+ */
+export function isSafeRelativePath(value: string): boolean {
+  if (value === '' || CONTROL_CHARS.test(value)) return false;
+  // 絶対パス(/ 始まり・\ 始まり・ドライブレター)は基点を無視できてしまう
+  if (value.startsWith('/') || value.startsWith('\\')) return false;
+  if (/^[A-Za-z]:/.test(value)) return false;
+  // 正規化で外へ出る形は resolveInside でも弾けるが、境界では文字列の時点で
+  // 「.. セグメントを含む名前」ごと拒否する(正当なデータに現れないため)
+  return value.split(/[/\\]/).every((segment) => segment !== '..');
+}
+
+/**
+ * Returns whether the value is a http(s) URL.
+ * @param {string} value - A URL from remote package data.
+ * @returns {boolean} Whether the URL uses http or https.
+ */
+export function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//.test(value);
+}
+
+/**
+ * Validates the security invariants of a package info object.
+ * Throws a TypeError when a field that reaches paths, commands, or URLs
+ * has an unsafe value.
+ * @param {unknown} info - A package info sent over the tRPC boundary.
+ * @returns {Record<string, unknown>} The validated info.
+ */
+export function validatePackageInfo(info: unknown): Record<string, unknown> {
+  if (typeof info !== 'object' || info === null)
+    throw new TypeError('info is expected to be an object.');
+  const record = info as Record<string, unknown>;
+
+  const { files, installer, installArg, directURL, downloadURLs } = record;
+
+  if (!Array.isArray(files))
+    throw new TypeError('info.files is expected to be an array.');
+  for (const file of files) {
+    if (typeof file !== 'object' || file === null)
+      throw new TypeError('info.files entries are expected to be objects.');
+    const { filename, archivePath } = file as Record<string, unknown>;
+    if (typeof filename !== 'string' || !isSafeRelativePath(filename))
+      throw new TypeError(`An unsafe filename was specified. ${filename}`);
+    if (
+      archivePath !== undefined &&
+      (typeof archivePath !== 'string' || !isSafeRelativePath(archivePath))
+    )
+      throw new TypeError(
+        `An unsafe archivePath was specified. ${archivePath}`,
+      );
+  }
+
+  if (installer !== undefined) {
+    // installer は展開ディレクトリ内をファイル名一致で探すのに使う。
+    // パス区切りを含む値は探索と一致し得ず、不正指定でしかない
+    if (
+      typeof installer !== 'string' ||
+      installer === '' ||
+      installer === '.' ||
+      installer === '..' ||
+      /[/\\]/.test(installer) ||
+      CONTROL_CHARS.test(installer)
+    )
+      throw new TypeError(`An unsafe installer was specified. ${installer}`);
+  }
+
+  if (
+    installArg !== undefined &&
+    (typeof installArg !== 'string' || CONTROL_CHARS.test(installArg))
+  )
+    throw new TypeError('An unsafe installArg was specified.');
+
+  if (
+    directURL !== undefined &&
+    (typeof directURL !== 'string' || !isHttpUrl(directURL))
+  )
+    throw new TypeError(`A non-http(s) directURL was specified. ${directURL}`);
+
+  if (downloadURLs !== undefined) {
+    if (
+      !Array.isArray(downloadURLs) ||
+      !downloadURLs.every((u) => typeof u === 'string' && isHttpUrl(u))
+    )
+      throw new TypeError(
+        'downloadURLs is expected to be an array of http(s) URLs.',
+      );
+  }
+
+  return record;
+}


### PR DESCRIPTION
## 概要

Phase 3(境界ハードニング)の中核 #S3(トラッカー #2379)。「リモートデータと renderer を非信頼として扱う」の入口側で、tRPC 境界に `packageItem.info` のセキュリティ不変条件検証を追加する。あわせて #2380 の取りこぼし(コピー元のパストラバーサル)を塞ぐ。

## 変更内容

1. **展開ディレクトリ外を指す `archivePath` のコピー元を拒否**([install.ts](../blob/main/src/shared/install.ts))
   - #2380 はコピー**先**だけを守っていたが、コピー**元**は `path.join(unzippedPath, file.archivePath, ...)` のままで、`archivePath: "../.."` 等により展開ディレクトリ外の任意ローカルファイルを instPath 内へ持ち出しコピーできた。コピー先と同じ `resolveInside` を通す
2. **`src/shared/packageInfoValidation.ts`(新規)**: tRPC 境界の検証モジュール
   - `files[].filename` / `archivePath`: 絶対パス・ドライブレター・UNC・`..` セグメント・制御文字を拒否
   - `installer`: パス区切り・制御文字を含む値を拒否(展開ディレクトリ内のファイル名一致検索にしか使わないため)
   - `installArg`: 制御文字を拒否(メタ文字は #2380 の execFileSync 化で既に無害)
   - `directURL` / `downloadURLs`: `http(s)://` 以外のスキーム(file: 等)を拒否
   - `installScript` の `url` も http(s) に限定
3. **設計判断**: apm-schema の JSON Schema 全体は強制しない。`name` の 25 文字制限のような表示用制約まで強制すると、サードパーティ dataURL の緩いデータがインストール不能になり「dataURL 自由入力を維持」の確定方針と衝突するため。境界で守るのはパス・コマンド・URL に到達するフィールドのみで、サービス層の `resolveInside` / `safeRemove` / `execFileSync` が二重に守る

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(176 件、新規 16 件)すべて緑
- `yarn package`(Node 22)+ `yarn test:e2e` 3 本緑(通常パッケージのインストール・アンインストールの回帰なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
