### PR TITLE
fix(security): 窓内ナビゲーションを既定 deny に反転し全窓へ適用

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -1,4 +1,11 @@
-import { BrowserWindow, ipcMain, Menu, nativeTheme, shell } from 'electron';
+import {
+  BrowserWindow,
+  ipcMain,
+  Menu,
+  nativeTheme,
+  shell,
+  type WebContents,
+} from 'electron';
 import windowStateKeeper from 'electron-window-state';
 import path from 'node:path';
 import { createIPCHandler } from 'trpc-electron/main';
@@ -16,6 +23,25 @@ declare const ABOUT_WINDOW_WEBPACK_ENTRY: string;
 declare const ABOUT_WINDOW_PRELOAD_WEBPACK_ENTRY: string;
 
 const isDevEnv = process.env.NODE_ENV === 'development';
+
+/**
+ * Denies all in-window navigations and window creations, opening http(s)
+ * URLs in the external browser instead.
+ * @param {WebContents} contents - The webContents to harden.
+ */
+function hardenNavigation(contents: WebContents) {
+  // アプリの窓は SPA で正当なページ内遷移が無いため、既定 deny にする。
+  // スキーム判定を http(s):// 完全一致にするのは、/^http/ だと
+  // httpevil: のような偽スキームまで外部ブラウザへ渡してしまうため
+  contents.on('will-navigate', (event, url) => {
+    event.preventDefault();
+    if (/^https?:\/\//.test(url)) void shell.openExternal(url);
+  });
+  contents.setWindowOpenHandler(({ url }) => {
+    if (/^https?:\/\//.test(url)) void shell.openExternal(url);
+    return { action: 'deny' };
+  });
+}
 
 const icon =
   process.platform === 'linux'
@@ -37,6 +63,8 @@ export async function launch(config: Config) {
     show: false,
     icon: icon,
   });
+
+  hardenNavigation(splashWindow.webContents);
 
   splashWindow.once('ready-to-show', () => {
     splashWindow.show();
@@ -83,18 +111,7 @@ export async function launch(config: Config) {
 
   Menu.setApplicationMenu(null);
 
-  mainWindow.webContents.on('will-navigate', async (event, url) => {
-    if (url.match(/^http/)) {
-      event.preventDefault();
-      await shell.openExternal(url);
-    }
-  });
-  mainWindow.webContents.setWindowOpenHandler((details) => {
-    if (details.url.match(/^http/)) {
-      void shell.openExternal(details.url);
-    }
-    return { action: 'deny' };
-  });
+  hardenNavigation(mainWindow.webContents);
 
   nativeTheme.on('updated', () => {
     mainWindow.setTitleBarOverlay(getTitleBarColor());
@@ -119,6 +136,9 @@ export async function launch(config: Config) {
         sandbox: true,
       },
     });
+    // about 窓は従来ハンドラ未設定で、リンクを踏むと窓ごと外部サイトへ
+    // 遷移できてしまっていた
+    hardenNavigation(aboutWindow.webContents);
     ipcHandler.attachWindow(aboutWindow);
     aboutWindow.once('close', () => {
       if (!aboutWindow.isDestroyed()) {


### PR DESCRIPTION
## 概要

Phase 3 の #S5(トラッカー #2379)。窓内ナビゲーションの制御を既定 allow から既定 deny へ反転する。

## 変更内容(src/main/windows.ts)

- 従来の `will-navigate` は http(s) だけ `preventDefault` + 外部ブラウザ化し、**それ以外のスキーム(file: 等)は窓内遷移が既定で許可**されていた。SPA なので正当なページ内遷移は無く、常に `preventDefault` + http(s) のみ `shell.openExternal` に変更
- スキーム判定を `/^http/` から `https?://` 完全一致へ(`httpevil:` のような偽スキームの外部化を防ぐ)
- `hardenNavigation()` ヘルパーに集約し、従来 main 窓にしか無かった制御を **splash 窓・about 窓にも適用**。about 窓はハンドラ自体が無く、リンクを踏むと窓ごと外部サイトへ遷移できた
- 埋め込みブラウザ窓(services/browser.ts)は「任意サイトを閲覧して DL する」のが目的のため対象外。こちらの防御(partition 分離・permission handler 等)は #S6 スライスで行う

## 検証

- lint / lint:ts / test 全緑
- `yarn package`(Node 22)+ E2E 3 本緑(起動・パッケージ導入・アンインストール・コア導入が既定 deny 下で回帰なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
