### PR TITLE
fix(security): 埋め込みブラウザ窓のセッション分離と OPEN_BROWSER IPC の撤去

### DIFF
--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -7,5 +7,4 @@ export const IPC_CHANNELS = {
   OPEN_DIALOG: 'open-dialog',
   OPEN_YES_NO_DIALOG: 'open-yes-no-dialog',
   CLIPBOARD_WRITE_TEXT: 'clipboard-write-text',
-  OPEN_BROWSER: 'open-browser',
 };

--- a/src/lib/ipcWrapper.ts
+++ b/src/lib/ipcWrapper.ts
@@ -103,19 +103,6 @@ export async function openYesNoDialog(title: string, message: string) {
 }
 
 /**
- * Opens the browser window.
- * @param {string} url - A URL to be opened.
- * @param {'core'|'package'} type - A type of the file to be downloaded.
- * @returns {Promise<{ savePath: string; history: string[] } | null>} The save path and history, or null if failed.
- */
-export async function openBrowser(url: string, type: 'core' | 'package') {
-  return (await ipcRenderer.invoke(IPC_CHANNELS.OPEN_BROWSER, url, type)) as {
-    savePath: string;
-    history: string[];
-  } | null;
-}
-
-/**
  * Writes the text into the clipboard as plain text.
  * @param {string} text - plain text.
  */

--- a/src/main/services/browser.ts
+++ b/src/main/services/browser.ts
@@ -1,5 +1,6 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, type DownloadItem, type Event } from 'electron';
 import path from 'node:path';
+import { resolveInside } from '../../shared/apmPath';
 
 const icon =
   process.platform === 'linux'
@@ -30,10 +31,26 @@ export function openBrowser(
     height: 600,
     minWidth: 240,
     minHeight: 320,
-    webPreferences: { sandbox: true },
+    // 任意の外部サイトを表示する窓なので、main 窓の既定セッション
+    // (Cookie・ストレージ)を共有させない。persist: を付けないのは、
+    // 閲覧状態をアプリ終了後まで持ち越す理由が無いため
+    webPreferences: { sandbox: true, partition: 'browser' },
     parent,
     modal: true,
     icon: icon,
+  });
+
+  const ses = browserWindow.webContents.session;
+  // ダウンロードに権限(通知・カメラ等)は不要なので一律拒否する
+  ses.setPermissionRequestHandler((_webContents, _permission, callback) =>
+    callback(false),
+  );
+  // 新窓は作らせない。ポップアップで DL ページを開くサイトのために
+  // http(s) は同じ窓内で開く
+  browserWindow.webContents.setWindowOpenHandler(({ url: popupUrl }) => {
+    if (/^https?:\/\//.test(popupUrl))
+      void browserWindow.webContents.loadURL(popupUrl);
+    return { action: 'deny' };
   });
 
   parent.once('closed', () => {
@@ -51,25 +68,31 @@ export function openBrowser(
       history.push(url);
     });
 
-    browserWindow.webContents.session.once('will-download', (event, item) => {
+    const onWillDownload = (event: Event, item: DownloadItem) => {
       if (!browserWindow.isDestroyed()) browserWindow.hide();
 
-      const ext = path.extname(item.getFilename());
+      // getFilename() はサイト側が決める名前なので、パス区切りを含んでも
+      // データフォルダの外へ出ないよう basename + resolveInside を通す
+      const filename = path.basename(item.getFilename());
+      const ext = path.extname(filename);
       const dir = path.join(app.getPath('userData'), 'Data');
-      if (['.zip', '.lzh', '.7z', '.rar'].includes(ext)) {
-        item.setSavePath(path.join(dir, type, 'archive/', item.getFilename()));
-      } else {
-        item.setSavePath(path.join(dir, type, item.getFilename()));
-      }
+      const subDirs = ['.zip', '.lzh', '.7z', '.rar'].includes(ext)
+        ? [type, 'archive']
+        : [type];
+      item.setSavePath(resolveInside(dir, ...subDirs, filename));
 
       item.once('done', () => {
         history.push(...item.getURLChain(), item.getFilename());
         resolve({ savePath: item.getSavePath(), history: history });
         if (!browserWindow.isDestroyed()) browserWindow.close();
       });
-    });
+    };
+    ses.once('will-download', onWillDownload);
 
     browserWindow.once('closed', () => {
+      // partition は openBrowser 呼び出し間で共有される。DL せずに閉じた
+      // とき once リスナーが残留して次回の DL を横取りしないよう外す
+      ses.removeListener('will-download', onWillDownload);
       resolve(null);
     });
   });

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -1,6 +1,5 @@
 import {
   BrowserWindow,
-  ipcMain,
   Menu,
   nativeTheme,
   shell,
@@ -9,12 +8,10 @@ import {
 import windowStateKeeper from 'electron-window-state';
 import path from 'node:path';
 import { createIPCHandler } from 'trpc-electron/main';
-import { IPC_CHANNELS } from '../common/ipc';
 import { setAboutWindowOpener } from './aboutWindow';
 import { createContext, router } from './api';
 import type Config from './Config';
 import { runAutoUpdate } from './services/appUpdate';
-import { openBrowser } from './services/browser';
 
 declare const SPLASH_WINDOW_WEBPACK_ENTRY: string;
 declare const MAIN_WINDOW_WEBPACK_ENTRY: string;
@@ -149,11 +146,6 @@ export async function launch(config: Config) {
       aboutWindow.show();
     });
     void aboutWindow.loadURL(aboutPath);
-  });
-
-  ipcMain.handle(IPC_CHANNELS.OPEN_BROWSER, async (event, url, type) => {
-    // 実装は services/browser.ts へ抽出済み(main 内部からも呼べるようにするため)
-    return await openBrowser(mainWindow, url, type);
   });
 
   setTimeout(() => {


### PR DESCRIPTION
## 概要

Phase 3 の #S6(トラッカー #2379)。埋め込みブラウザ窓のハードニングと、使われなくなった OPEN_BROWSER IPC の撤去。

**#2383 の上に積んでいます**(windows.ts のコンフリクト回避)。#2383 を先にマージすると base が自動で main に切り替わります。

## 変更内容

1. **OPEN_BROWSER IPC の撤去**(windows.ts / ipcWrapper.ts / ipc.ts)
   - React 移行完了後、埋め込みブラウザは main 内部(services/packages.ts)からリテラル引数でのみ開かれており、renderer 側の呼び出しは残っていない(裏取り済み)。使われない IPC 面は「renderer から任意 URL の窓を開かせ、`type` を保存パスへ注入できる」攻撃面でしかないため、チャンネルごと削除
2. **埋め込みブラウザ窓のハードニング**(services/browser.ts)
   - `partition: 'browser'` で main 窓の既定セッション(Cookie・ストレージ)から分離。persist 無しなのでアプリ終了で破棄
   - `setPermissionRequestHandler` で権限要求(通知・カメラ等)を一律拒否
   - `setWindowOpenHandler` で新窓生成を禁止。ポップアップで DL ページを開くサイトのために http(s) は同窓内で開く
   - 保存先をサイト任せの `item.getFilename()` から `basename` + `resolveInside` 経由に変更し、データフォルダ外への書き込みを構造的に排除
   - 副産物のバグ修正: DL せずに窓を閉じると `will-download` の once リスナーが共有セッションに残留し、**次回のダウンロードを横取りし得た**のを、closed で明示解除

## 挙動変更の注意点

- セッション分離により、埋め込みブラウザ内のログイン状態・Cookie は従来の(main と共有の)ものを引き継がず、アプリ再起動でも消えます。DL サイトでの Cloudflare チャレンジ等が従来より出やすくなる可能性はあります

## 検証

- lint / lint:ts / test 全緑
- `yarn package`(Node 22)+ E2E 3 本緑 — E2E のパッケージ導入は埋め込みブラウザ経由の実 DL を通るため、partition 分離・保存先検証の回帰確認になっています

🤖 Generated with [Claude Code](https://claude.com/claude-code)
