### PR TITLE
fix(security): integrity 検証を手動ダウンロード経路にも適用

### DIFF
--- a/src/main/services/packages.ts
+++ b/src/main/services/packages.ts
@@ -565,47 +565,6 @@ export async function installPackageFlow(
       log.error('Failed downloading a file.');
       return 'downloadFailed';
     }
-
-    const integrityForArchive = packageItem.info.releases?.find(
-      (r) => r.version === packageItem.info.latestVersion,
-    )?.integrity?.archive;
-
-    if (integrityForArchive) {
-      // Verify file integrity
-      while (!(await verifyFile(resolvedArchivePath, integrityForArchive))) {
-        const dialogResult =
-          (
-            await dialog.showMessageBox(win, {
-              title: 'エラー',
-              message:
-                'ダウンロードされたファイルは破損しています。再ダウンロードしますか？',
-              type: 'warning',
-              buttons: ['はい', 'いいえ'],
-              cancelId: 1,
-            })
-          ).response === 0;
-
-        if (!dialogResult) {
-          log.error(
-            `The downloaded archive file is corrupt. URL:${packageItem.info.directURL}`,
-          );
-          return 'corrupt';
-        }
-
-        // 再ダウンロード先が subDir 'core' なのは旧実装のままの挙動
-        resolvedArchivePath = await downloadFile(
-          win,
-          packageItem.info.directURL,
-          { subDir: 'core' },
-        );
-        if (!resolvedArchivePath) {
-          log.error(
-            `Failed downloading the archive file. URL:${packageItem.info.directURL}`,
-          );
-          return 'redownloadFailed';
-        }
-      }
-    }
   } else {
     const downloadResult = await openBrowser(
       win,
@@ -619,6 +578,63 @@ export async function installPackageFlow(
     }
 
     resolvedArchivePath = downloadResult.savePath;
+  }
+
+  // integrity があるなら取得経路(直リンク・手動 DL・archivePath 渡し)に
+  // よらず検証する。無いパッケージ(公式データの約 1/4)を弾かないのは、
+  // 検証必須化すると既存パッケージのインストールが広く壊れるため
+  const integrityForArchive = packageItem.info.releases?.find(
+    (r) => r.version === packageItem.info.latestVersion,
+  )?.integrity?.archive;
+
+  if (integrityForArchive) {
+    while (!(await verifyFile(resolvedArchivePath, integrityForArchive))) {
+      const dialogResult =
+        (
+          await dialog.showMessageBox(win, {
+            title: 'エラー',
+            message:
+              'ダウンロードされたファイルは破損しています。再ダウンロードしますか？',
+            type: 'warning',
+            buttons: ['はい', 'いいえ'],
+            cancelId: 1,
+          })
+        ).response === 0;
+
+      if (!dialogResult) {
+        log.error(
+          `The downloaded archive file is corrupt. URL:${packageItem.info.directURL}`,
+        );
+        return 'corrupt';
+      }
+
+      if (direct) {
+        // 再ダウンロード先が subDir 'core' なのは旧実装のままの挙動
+        resolvedArchivePath = await downloadFile(
+          win,
+          packageItem.info.directURL,
+          { subDir: 'core' },
+        );
+        if (!resolvedArchivePath) {
+          log.error(
+            `Failed downloading the archive file. URL:${packageItem.info.directURL}`,
+          );
+          return 'redownloadFailed';
+        }
+      } else {
+        // 手動 DL・archivePath 渡しの経路はブラウザ窓での再取得になる
+        const redownloadResult = await openBrowser(
+          win,
+          packageItem.info.downloadURLs[0],
+          'package',
+        );
+        if (!redownloadResult) {
+          log.info('The installation was canceled.');
+          return 'canceled';
+        }
+        resolvedArchivePath = redownloadResult.savePath;
+      }
+    }
   }
 
   const installResult = await installPackageArchive(


### PR DESCRIPTION
## 概要

Phase 3 の #S4(トラッカー #2379)。integrity(ssri)検証を取得経路によらず適用する。

## 裏取りで確認した現状

- 直リンク(`direct`)ダウンロードだけが `verifyFile` を通る
- **埋め込みブラウザでの手動 DL と、script リダイレクト等で archivePath を直接渡す経路は、integrity 情報があっても無検証**でインストールされていた
- 公式 apm-data は 285 件中 214 件(75%)が integrity 保有

## 変更内容(src/main/services/packages.ts)

- 検証ブロックを direct 分岐内からアーカイブ解決後の共通処理へ移動。integrity を持つパッケージは手動 DL でも検証される
- 破損時の再取得: direct は従来どおり `downloadFile`(subDir 'core' の旧挙動も維持)、手動系はブラウザ窓の再表示(キャンセルで中断)
- **integrity が無いパッケージは従来どおり無検証で通す**。必須化すると未保有の 71 件が壊れるため。scripts.json はスキーマに integrity フィールド自体が無く、こちらは apm-data / apm-schema 側の課題(将来の upstream issue 候補)

## 検証

- lint / lint:ts / test 全緑、`yarn package`(Node 22)+ E2E 3 本緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)
