### PR TITLE
fix(security): 展開・パース・ダウンロードの多層防御(#S8)

### DIFF
--- a/src/main/services/download.ts
+++ b/src/main/services/download.ts
@@ -49,6 +49,12 @@ export async function downloadFile(
     log.error(`Refused to download outside the data folder: ${subDir}`);
     return undefined;
   }
+  // 現状ファイル名を decode する箇所は無いが、将来どこかで decode されると
+  // パス区切りに化ける値(%2f・%5c)は入口で拒否しておく
+  if (/%2f|%5c/i.test(opt.filename)) {
+    log.error(`Refused an encoded path separator in the file name: ${url}`);
+    return undefined;
+  }
   if (loadCache && fs.existsSync(retFilePath)) return retFilePath;
 
   try {

--- a/src/shared/parsePackagesXml.test.ts
+++ b/src/shared/parsePackagesXml.test.ts
@@ -121,6 +121,33 @@ describe('parsePackagesXml', () => {
     });
   });
 
+  it('id やバージョンに __proto__ を使われてもプロトタイプを差し替えられない', () => {
+    const xml = `<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package>
+    <id>__proto__</id>
+    <latestVersion>0.1</latestVersion>
+    <files>
+      <file>a.auf</file>
+    </files>
+    <releases>
+      <release version="__proto__">
+        <archiveIntegrity>sha384-CCC</archiveIntegrity>
+      </release>
+    </releases>
+  </package>
+</packages>
+`;
+    const packages = parsePackagesXml(xml);
+    // 汚染ではなく通常のエントリとして保持される
+    expect(Object.keys(packages)).toEqual(['__proto__']);
+    expect(Object.keys(packages['__proto__'].releases)).toEqual(['__proto__']);
+    expect(
+      ({} as Record<string, unknown>).polluted,
+      'Object.prototype が汚染されていない',
+    ).toBeUndefined();
+  });
+
   it('不正な XML は例外を投げる', () => {
     expect(() => parsePackagesXml('<packages><package>')).toThrow();
   });

--- a/src/shared/parsePackagesXml.ts
+++ b/src/shared/parsePackagesXml.ts
@@ -206,7 +206,9 @@ export class PackageInfo {
               this.isContinuous = Boolean(tmpObj.$continuous[0]);
           }
         } else if (key === 'releases') {
-          this.releases = {};
+          // version はリモート由来のままキーになる。__proto__ のような名前で
+          // プロトタイプを差し替えられないよう、継承なしのオブジェクトにする
+          this.releases = Object.create(null) as Record<string, ReleaseInfo>;
           for (const release of parsedPackage[key][0].release) {
             this.releases[release.$version[0]] = {
               archiveIntegrity: release?.archiveIntegrity?.[0],
@@ -244,7 +246,8 @@ export function parsePackagesXml(xmlData: string): PackagesList {
   const packagesInfo = parser.parse(xmlData) as RawPackagesXml;
   if (!packagesInfo.packages) throw new Error('The list is invalid.');
 
-  const packages: PackagesList = {};
+  // id はリモート由来のままキーになるため、releases と同じく継承なしにする
+  const packages: PackagesList = Object.create(null) as PackagesList;
   for (const packageItem of packagesInfo.packages[0].package) {
     packages[packageItem.id[0]] = new PackageInfo(packageItem);
   }

--- a/src/shared/unzip.test.ts
+++ b/src/shared/unzip.test.ts
@@ -1,10 +1,18 @@
 import { path7za } from '7zip-bin';
-import { chmod, mkdtemp, pathExists, remove, writeFile } from 'fs-extra';
+import {
+  chmod,
+  ensureDir,
+  mkdtemp,
+  pathExists,
+  remove,
+  symlink,
+  writeFile,
+} from 'fs-extra';
 import { add } from 'node-7z';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeAll, describe, expect, it } from 'vitest';
-import unzip from './unzip';
+import unzip, { removeSymlinks } from './unzip';
 
 // The prebuilt 7za binary shipped by 7zip-bin is not always installed with
 // the executable bit set (observed on some package manager / CI setups).
@@ -70,4 +78,38 @@ describe('unzip', () => {
     expect(targetPath).toBe(path.join(dir, 'fixture'));
     expect(await pathExists(path.join(targetPath, 'hello.txt'))).toBe(true);
   }, 30000);
+});
+
+describe('removeSymlinks', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => remove(dir)));
+  });
+
+  // Windows の symlink 作成は特権が要るためテスト対象から外す
+  it.skipIf(process.platform === 'win32')(
+    '通常ファイルを残して symlink だけを再帰的に除去する',
+    async () => {
+      const dir = await mkdtemp(path.join(os.tmpdir(), 'apm-symlink-'));
+      tempDirs.push(dir);
+      const outside = path.join(dir, 'outside.txt');
+      await writeFile(outside, 'secret');
+      const extracted = path.join(dir, 'extracted');
+      await ensureDir(path.join(extracted, 'sub'));
+      await writeFile(path.join(extracted, 'normal.txt'), 'normal');
+      await symlink(outside, path.join(extracted, 'link.txt'));
+      await symlink(outside, path.join(extracted, 'sub', 'nested-link.txt'));
+
+      await removeSymlinks(extracted);
+
+      expect(await pathExists(path.join(extracted, 'normal.txt'))).toBe(true);
+      expect(await pathExists(path.join(extracted, 'link.txt'))).toBe(false);
+      expect(
+        await pathExists(path.join(extracted, 'sub', 'nested-link.txt')),
+      ).toBe(false);
+      // リンク先(展開ディレクトリ外)のファイルは消えない
+      expect(await pathExists(outside)).toBe(true);
+    },
+  );
 });

--- a/src/shared/unzip.ts
+++ b/src/shared/unzip.ts
@@ -1,4 +1,5 @@
 import { path7za } from '7zip-bin';
+import { readdir, remove } from 'fs-extra';
 import { extractFull } from 'node-7z';
 import { chmodSync } from 'node:fs';
 import path from 'node:path';
@@ -21,6 +22,24 @@ if (process.platform !== 'win32') {
     chmodSync(pathTo7zip, 0o755);
   } catch {
     // 失敗しても spawn 時に EACCES / ENOENT として顕在化するため何もしない
+  }
+}
+
+/**
+ * Removes symlinks under the extracted folder.
+ * アーカイブ由来の symlink が残ると、後続のコピーや探索が展開ディレクトリの
+ * 外を参照し得る。同梱の 7za は現状 symlink を復元しないが、バイナリ更新や
+ * アーカイブ形式で挙動が変わっても効くよう、展開後の一掃として防御する。
+ * @param {string} dir - The folder to scan recursively.
+ */
+export async function removeSymlinks(dir: string) {
+  for (const dirent of await readdir(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, dirent.name);
+    if (dirent.isSymbolicLink()) {
+      await remove(entryPath);
+    } else if (dirent.isDirectory()) {
+      await removeSymlinks(entryPath);
+    }
   }
 }
 
@@ -59,7 +78,7 @@ async function unzip(zipPath: string, folderName?: string) {
   });
   return new Promise<string>((resolve, reject) => {
     zipStream.once('end', () => {
-      resolve(targetPath);
+      removeSymlinks(targetPath).then(() => resolve(targetPath), reject);
     });
     zipStream.once('error', (err: Error) => {
       reject(


### PR DESCRIPTION
## 概要

Phase 3 の #S8(トラッカー #2379)。展開・パース・ダウンロードの小粒な多層防御 3 点。

## 変更内容

1. **展開後の symlink 一掃**(src/shared/unzip.ts)
   - アーカイブ由来の symlink が残ると後続のコピー・探索が展開ディレクトリ外を参照し得る
   - 実験の結果、**同梱の 7za は `-snl` 付きでも symlink を復元しない**(通常ファイル化する)ため即座の脅威ではないが、バイナリ更新や rar/lzh で挙動が変わっても効くよう展開後に一掃する
2. **parsePackagesXml の `__proto__` 対策**(src/shared/parsePackagesXml.ts)
   - id・バージョン(リモート XML 由来)がそのままオブジェクトキーになるため `Object.create(null)` に。Object.prototype 汚染には元々波及しないが、プロトタイプ差し替えによる追いにくい壊れ方を防ぐ
3. **ダウンロードファイル名の `%2f`/`%5c` 拒否**(src/main/services/download.ts)
   - 現状 decode 経路は無いが、将来 decode が入るとパス区切りに化けて `isParent` 検査をすり抜けるため入口で拒否

## 検証

- lint / lint:ts / test 全緑(178 件、新規 2 件。symlink テストは Windows では特権が要るため skip)
- `yarn package`(Node 22)+ E2E 3 本緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)
