### PR TITLE
feat(security): 未承認オリジンの dataURL に一度だけ確認ダイアログを表示

### DIFF
--- a/src/main/Config.ts
+++ b/src/main/Config.ts
@@ -7,6 +7,7 @@ type StoreType = {
     main: string;
     extra: string;
     packages: string[];
+    approvedOrigins: string[];
   };
   modDate: {
     core: number;
@@ -76,6 +77,12 @@ export default class Config extends Store<StoreType> {
     hasPackages: () => this.has('dataURL.packages'),
     getPackages: () => this.get('dataURL.packages', [] as string[]),
     setPackages: (urls: string[]) => this.set('dataURL.packages', urls),
+
+    // 確認ダイアログで一度承認したデータ取得先のオリジン(#2377)
+    getApprovedOrigins: () =>
+      this.get('dataURL.approvedOrigins', [] as string[]),
+    setApprovedOrigins: (origins: string[]) =>
+      this.set('dataURL.approvedOrigins', origins),
   };
 
   public modDate = {

--- a/src/main/api.ts
+++ b/src/main/api.ts
@@ -332,9 +332,25 @@ export const router = t.router({
     ),
     setDataUrls: procedure
       .input(dataUrlsInput)
-      .mutation(({ input }) =>
-        setDataUrls(getConfig(), input.mainUrl, input.extraDataUrls),
-      ),
+      .mutation(async ({ input, ctx }) => {
+        const win = BrowserWindow.fromWebContents(ctx.event.sender);
+        if (!win) throw new Error('The calling window was not found.');
+        return await setDataUrls(
+          getConfig(),
+          input.mainUrl,
+          input.extraDataUrls,
+          async (message) =>
+            (
+              await dialog.showMessageBox(win, {
+                title: '確認',
+                message,
+                type: 'warning',
+                buttons: ['続行', 'キャンセル'],
+                cancelId: 1,
+              })
+            ).response === 0,
+        );
+      }),
     getDataUrls: procedure.query(() => {
       const config = getConfig();
       return {

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, remove } from 'fs-extra';
 import * as os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_DATA_URL } from '../../shared/dataUrl';
 import Config from '../Config';
 import { ensureExtraDataUrl, setDataUrls } from './settings';
@@ -49,13 +49,16 @@ describe('settings service', () => {
   });
 
   describe('setDataUrls', () => {
+    const alwaysApprove = async () => true;
+
     it('検証が通ると main と extra(改行結合)を書き込む', async () => {
       const config = await makeConfig();
 
-      const result = setDataUrls(
+      const result = await setDataUrls(
         config,
         'https://example.com/data/',
         'https://a.example/x.json\nhttps://b.example/y.json',
+        alwaysApprove,
       );
 
       expect(result.errors).toEqual([]);
@@ -65,13 +68,15 @@ describe('settings service', () => {
       );
     });
 
-    it('メインが空なら既定 URL が書き込まれる', async () => {
+    it('メインが空なら既定 URL が書き込まれ、確認は出ない', async () => {
       const config = await makeConfig();
+      const confirm = vi.fn(alwaysApprove);
 
-      const result = setDataUrls(config, '', '');
+      const result = await setDataUrls(config, '', '', confirm);
 
       expect(result.mainUrl).toBe(DEFAULT_DATA_URL);
       expect(config.dataURL.getMain()).toBe(DEFAULT_DATA_URL);
+      expect(confirm).not.toHaveBeenCalled();
     });
 
     it('検証エラー時は config を変更しない', async () => {
@@ -79,15 +84,79 @@ describe('settings service', () => {
       config.dataURL.setMain('https://example.com/data/');
       config.dataURL.setExtra('https://example.com/x.json');
 
-      const result = setDataUrls(
+      const result = await setDataUrls(
         config,
         'https://example.com/broken.json',
         'not-a-json-url',
+        alwaysApprove,
       );
 
       expect(result.errors.length).toBeGreaterThan(0);
       expect(config.dataURL.getMain()).toBe('https://example.com/data/');
       expect(config.dataURL.getExtra()).toBe('https://example.com/x.json');
+    });
+
+    it('未知オリジンは承認するとオリジンが記録され、次回は確認されない', async () => {
+      const config = await makeConfig();
+      const confirm = vi.fn(alwaysApprove);
+
+      await setDataUrls(config, 'https://example.com/data/', '', confirm);
+      expect(confirm).toHaveBeenCalledTimes(1);
+      expect(config.dataURL.getApprovedOrigins()).toEqual([
+        'https://example.com',
+      ]);
+
+      await setDataUrls(config, 'https://example.com/other/', '', confirm);
+      expect(confirm).toHaveBeenCalledTimes(1);
+    });
+
+    it('確認をキャンセルすると canceled を返し config を変更しない', async () => {
+      const config = await makeConfig();
+
+      const result = await setDataUrls(
+        config,
+        'https://evil.example/data/',
+        '',
+        async () => false,
+      );
+
+      expect(result.canceled).toBe(true);
+      expect(config.dataURL.hasMain()).toBe(false);
+      expect(config.dataURL.getApprovedOrigins()).toEqual([]);
+    });
+
+    it('平文 http は確認メッセージに警告として含まれる', async () => {
+      const config = await makeConfig();
+      const messages: string[] = [];
+
+      await setDataUrls(
+        config,
+        'http://insecure.example/data/',
+        '',
+        async (m) => {
+          messages.push(m);
+          return true;
+        },
+      );
+
+      expect(messages[0]).toContain('http://insecure.example/data/');
+      expect(messages[0]).toContain('改ざん');
+    });
+
+    it('localhost は確認なしで保存できる(E2E フィクスチャの経路)', async () => {
+      const config = await makeConfig();
+      const confirm = vi.fn(alwaysApprove);
+
+      const result = await setDataUrls(
+        config,
+        'http://localhost:3000/data/',
+        '',
+        confirm,
+      );
+
+      expect(result.canceled).toBe(false);
+      expect(confirm).not.toHaveBeenCalled();
+      expect(config.dataURL.getMain()).toBe('http://localhost:3000/data/');
     });
   });
 });

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -1,6 +1,8 @@
 import * as os from 'node:os';
 import {
+  collectDataUrlCautions,
   type DataUrlValidationResult,
+  DEFAULT_DATA_URL,
   validateDataUrls,
 } from '../../shared/dataUrl';
 import type Config from '../Config';
@@ -23,22 +25,71 @@ export function ensureExtraDataUrl(config: Config): {
 }
 
 /**
+ * Builds the Japanese confirmation message for unapproved data URLs.
+ * @param {ReturnType<typeof collectDataUrlCautions>} cautions - The cautions.
+ * @returns {string} The dialog message.
+ */
+function buildCautionMessage(
+  cautions: ReturnType<typeof collectDataUrlCautions>,
+) {
+  const lines = [
+    '初めて使うデータ取得先が含まれています。信頼できる配布元か確認してください。',
+    '',
+    ...cautions.unknownOrigins.map((origin) => `・${origin}`),
+  ];
+  if (cautions.insecureUrls.length > 0) {
+    lines.push(
+      '',
+      '次の取得先は暗号化されない http のため、通信内容が改ざんされる恐れがあります。',
+      ...cautions.insecureUrls.map((url) => `・${url}`),
+    );
+  }
+  lines.push('', '続行しますか？');
+  return lines.join('\n');
+}
+
+/**
  * Validates the data files URLs and saves them to the config only when valid.
- * 旧 setting.ts の setDataUrl のうち、検証と設定書き込みの部分と同一の挙動。
+ * 旧 setting.ts の setDataUrl のうち、検証と設定書き込みの部分と同一の挙動に
+ * 加え、未承認オリジン・平文 http を含むときは保存前に一度だけ確認する
+ * (#2377。dataURL 自由入力の確定方針のため拒否はしない)。
+ * ダイアログ表示を confirm として注入するのは、このモジュールを
+ * electron 非依存に保ちユニットテスト可能にするため。
  * @param {Config} config - The config instance.
  * @param {string} mainUrl - The main data files URL. Empty means the default URL.
  * @param {string} extraDataUrls - Newline-separated extra data files URLs.
- * @returns {DataUrlValidationResult} The validation result.
+ * @param {(message: string) => Promise<boolean>} confirm - Shows a confirmation dialog.
+ * @returns {Promise<DataUrlValidationResult & { canceled: boolean }>} The validation result.
  */
-export function setDataUrls(
+export async function setDataUrls(
   config: Config,
   mainUrl: string,
   extraDataUrls: string,
-): DataUrlValidationResult {
+  confirm: (message: string) => Promise<boolean>,
+): Promise<DataUrlValidationResult & { canceled: boolean }> {
   const result = validateDataUrls(mainUrl, extraDataUrls);
-  if (result.errors.length === 0) {
-    config.dataURL.setMain(result.mainUrl);
-    config.dataURL.setExtra(result.extraUrls.join(os.EOL));
+  if (result.errors.length > 0) return { ...result, canceled: false };
+
+  const approvedOrigins = [
+    new URL(DEFAULT_DATA_URL).origin,
+    ...config.dataURL.getApprovedOrigins(),
+  ];
+  const cautions = collectDataUrlCautions(
+    [result.mainUrl, ...result.extraUrls],
+    approvedOrigins,
+  );
+  if (cautions.unknownOrigins.length > 0 || cautions.insecureUrls.length > 0) {
+    if (!(await confirm(buildCautionMessage(cautions))))
+      return { ...result, canceled: true };
+    config.dataURL.setApprovedOrigins([
+      ...new Set([
+        ...config.dataURL.getApprovedOrigins(),
+        ...cautions.unknownOrigins,
+      ]),
+    ]);
   }
-  return result;
+
+  config.dataURL.setMain(result.mainUrl);
+  config.dataURL.setExtra(result.extraUrls.join(os.EOL));
+  return { ...result, canceled: false };
 }

--- a/src/renderer/main/settings/DataUrlSettings.tsx
+++ b/src/renderer/main/settings/DataUrlSettings.tsx
@@ -30,6 +30,12 @@ function DataUrlSettings() {
         mainUrl: mainValue,
         extraDataUrls: extraValue,
       });
+      // 未承認オリジンの確認ダイアログでキャンセルされたときは保存されて
+      // いないので、成功でも失敗でもなく入力へ戻る
+      if (result.canceled) {
+        setPhase('idle');
+        return;
+      }
       setMainUrl(result.mainUrl);
       for (const message of result.errors) {
         await openDialog.mutateAsync({

--- a/src/shared/dataUrl.test.ts
+++ b/src/shared/dataUrl.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_DATA_URL, validateDataUrls } from './dataUrl';
+import {
+  collectDataUrlCautions,
+  DEFAULT_DATA_URL,
+  validateDataUrls,
+} from './dataUrl';
 
 /**
  * validateDataUrls の特性化テスト。
@@ -77,5 +81,61 @@ describe('validateDataUrls', () => {
       '有効なURLまたは場所を入力してください。(bad-extra)',
       '有効なJsonファイルのURLまたは場所を入力してください。(bad-extra)',
     ]);
+  });
+});
+
+describe('collectDataUrlCautions', () => {
+  it('未承認オリジンを重複なく列挙する', () => {
+    const result = collectDataUrlCautions(
+      [
+        'https://a.example/data/',
+        'https://a.example/x.json',
+        'https://b.example/y.json',
+      ],
+      [],
+    );
+    expect(result.unknownOrigins).toEqual([
+      'https://a.example',
+      'https://b.example',
+    ]);
+    expect(result.insecureUrls).toEqual([]);
+  });
+
+  it('承認済みオリジンは平文 http でも対象外', () => {
+    const result = collectDataUrlCautions(
+      ['https://a.example/data/', 'http://b.example/x.json'],
+      ['https://a.example', 'http://b.example'],
+    );
+    expect(result.unknownOrigins).toEqual([]);
+    expect(result.insecureUrls).toEqual([]);
+  });
+
+  it('未承認の平文 http は insecureUrls にも載る', () => {
+    const result = collectDataUrlCautions(['http://b.example/x.json'], []);
+    expect(result.unknownOrigins).toEqual(['http://b.example']);
+    expect(result.insecureUrls).toEqual(['http://b.example/x.json']);
+  });
+
+  it('スキームはオリジンの一部として区別する', () => {
+    // https を承認していても平文 http は別オリジンとして確認対象
+    const result = collectDataUrlCautions(
+      ['http://a.example/x.json'],
+      ['https://a.example'],
+    );
+    expect(result.unknownOrigins).toEqual(['http://a.example']);
+  });
+
+  it('ローカルパスと loopback は対象外', () => {
+    const result = collectDataUrlCautions(
+      [
+        'C:\\packages\\local.json',
+        '/home/user/local.json',
+        'http://localhost:3000/data/',
+        'http://127.0.0.1/x.json',
+      ],
+      [],
+    );
+    expect(result.unknownOrigins).toEqual([]);
+    expect(result.insecureUrls).toEqual([]);
   });
 });

--- a/src/shared/dataUrl.ts
+++ b/src/shared/dataUrl.ts
@@ -5,6 +5,52 @@ import path from 'node:path';
 export const DEFAULT_DATA_URL =
   'https://cdn.jsdelivr.net/gh/team-apm/apm-data@main/v3/';
 
+export type DataUrlCautions = {
+  /** Origins that are not approved yet. */
+  unknownOrigins: string[];
+  /** Plain-http URLs whose traffic can be tampered with. */
+  insecureUrls: string[];
+};
+
+/** Hostnames that never need a confirmation (developer loopback). */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+/**
+ * Collects the data URLs that deserve a one-time confirmation.
+ * dataURL は自由入力を維持する確定方針のため、ここで拒否はしない。
+ * 未知オリジンと平文 http の列挙だけを行い、確認するかは呼び出し側の責務。
+ * ローカルパスと loopback を対象外にするのは、自作パッケージ検証という
+ * ユースケース(および E2E フィクスチャ)がリモート攻撃面ではないため。
+ * @param {string[]} urls - The data URLs to inspect (local paths are skipped).
+ * @param {string[]} approvedOrigins - Origins already approved by the user.
+ * @returns {DataUrlCautions} The unknown origins and plain-http URLs.
+ */
+export function collectDataUrlCautions(
+  urls: string[],
+  approvedOrigins: string[],
+): DataUrlCautions {
+  const approved = new Set(approvedOrigins);
+  const unknownOrigins: string[] = [];
+  const insecureUrls: string[] = [];
+  for (const url of urls) {
+    if (!/^https?:\/\//.test(url)) continue;
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      continue;
+    }
+    if (LOOPBACK_HOSTS.has(parsed.hostname)) continue;
+    // 承認済みオリジンは平文 http も含めて再確認しない(承認は
+    // 「このオリジンを信頼する」の意味で一度だけ)
+    if (approved.has(parsed.origin)) continue;
+    if (parsed.protocol === 'http:') insecureUrls.push(url);
+    if (!unknownOrigins.includes(parsed.origin))
+      unknownOrigins.push(parsed.origin);
+  }
+  return { unknownOrigins, insecureUrls };
+}
+
 export type DataUrlValidationResult = {
   /** The normalized main data files URL (the default URL when the input is empty). */
   mainUrl: string;


### PR DESCRIPTION
## 概要

Phase 3 の #S7 + #2377 の中間案(トラッカー #2379)。dataURL 自由入力の確定方針は維持したまま、**初めて使うオリジンの保存時に一度だけ確認ダイアログ**を出す。

Closes #2377

## 変更内容

- **未承認オリジンの確認**: データ取得先の保存時、既定(apm-data の jsdelivr)と承認済み以外のオリジンが含まれると警告ダイアログを表示。「続行」でオリジンを config(`dataURL.approvedOrigins`)に記録し、以後は確認しない
- **平文 http の警告(#S7)**: 未承認の `http://` 取得先は「通信内容が改ざんされる恐れ」を警告文に併記。スキームはオリジンの一部なので、https を承認済みでも平文 http へ変えると別途確認になる。**禁止はしない**(確認して進めば従来どおり使える)
- **対象外**: ローカルパスと loopback(localhost / 127.0.0.1 / ::1)。自作パッケージ検証のユースケースと E2E フィクスチャ(`http://localhost`)の経路を保つ
- キャンセル時は保存せず、設定ボタンは入力状態に戻る
- 判定は `src/shared/dataUrl.ts` の純関数、ダイアログは confirm 注入で settings サービスは electron 非依存のままユニットテスト

## 検証

- lint / lint:ts / test 全緑(185 件、新規 9 件)
- `yarn package`(Node 22)+ E2E 3 本緑 — **dataURL 差し替えテスト(http://localhost)がダイアログで固まらないことを確認**

## 動作イメージ

初回のみ:

> 初めて使うデータ取得先が含まれています。信頼できる配布元か確認してください。
>
> ・https://example.com
>
> (平文 http の場合)次の取得先は暗号化されない http のため、通信内容が改ざんされる恐れがあります。
>
> 続行しますか？ [続行] [キャンセル]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
