### PR TITLE
fix(renderer): ボタン復帰タイマーを操作開始時に解除して多重発火レースを防ぐ

### DIFF
--- a/src/renderer/main/aviutl/BatchInstallButton.tsx
+++ b/src/renderer/main/aviutl/BatchInstallButton.tsx
@@ -31,12 +31,15 @@ function BatchInstallButton(): JSX.Element {
     TRPCReact.packages.installPackage.useMutation();
 
   const finish = (message: string, color: 'success' | 'danger') => {
+    clearTimeout(timer.current);
     setPhase({ kind: 'message', message, color });
     timer.current = setTimeout(() => setPhase({ kind: 'idle' }), 3000);
   };
 
   const onClick = async () => {
     if (phase.kind === 'loading') return;
+    // 前回の復帰タイマーが残っていると loading 中に idle へ戻されるため消す
+    clearTimeout(timer.current);
     setPhase({ kind: 'loading' });
 
     const instPath = getInstallationPath();

--- a/src/renderer/main/aviutl/ProgramRow.tsx
+++ b/src/renderer/main/aviutl/ProgramRow.tsx
@@ -1,5 +1,5 @@
 import type { Core } from 'apm-schema';
-import React, { type JSX, useEffect, useState } from 'react';
+import React, { type JSX, useEffect, useRef, useState } from 'react';
 import { releaseLabel } from '../../../shared/coreVersionText';
 import { TRPCReact } from '../../trpc';
 import { getInstallationPath } from '../instPath';
@@ -31,6 +31,8 @@ function ProgramRow({
   const [instPath, setInstPath] = useState(() => getInstallationPath());
   const [phase, setPhase] = useState<ButtonPhase>('idle');
   const [buttonMessage, setButtonMessage] = useState('');
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => clearTimeout(timer.current), []);
 
   const utils = TRPCReact.useUtils();
   const coreInfoQuery = TRPCReact.core.getCoreInfo.useQuery();
@@ -56,13 +58,16 @@ function ProgramRow({
   const installedText = installedTextsQuery.data?.[program] ?? '';
 
   const showError = (message: string) => {
+    clearTimeout(timer.current);
     setPhase('danger');
     setButtonMessage(message);
-    setTimeout(() => setPhase('idle'), 3000);
+    timer.current = setTimeout(() => setPhase('idle'), 3000);
   };
 
   const onInstall = async (version: string) => {
     if (phase === 'loading') return;
+    // 前回の復帰タイマーが残っていると loading 中に idle へ戻されるため消す
+    clearTimeout(timer.current);
     setPhase('loading');
 
     if (!instPath) {
@@ -110,7 +115,7 @@ function ProgramRow({
     window.dispatchEvent(new Event('apm-packages-changed'));
     setPhase('success');
     setButtonMessage('インストール完了');
-    setTimeout(() => setPhase('idle'), 3000);
+    timer.current = setTimeout(() => setPhase('idle'), 3000);
   };
 
   const buttonClass = `btn dropdown-toggle ${buttonRoundedClass} ${

--- a/src/renderer/main/packages/packagesListCheck.ts
+++ b/src/renderer/main/packages/packagesListCheck.ts
@@ -9,6 +9,7 @@ import type { ActionPhase } from '../usePhase';
 // シングルトンで共有する。
 
 let phase: ActionPhase = { kind: 'idle' };
+let timer: ReturnType<typeof setTimeout> | null = null;
 const listeners = new Set<() => void>();
 
 const setPhase = (next: ActionPhase) => {
@@ -44,6 +45,8 @@ export function getPhase() {
 export async function runPackagesListCheck(
   refreshList: () => Promise<unknown>,
 ) {
+  // 前回の復帰タイマーが残っていると loading 中に idle へ戻されるため消す
+  if (timer !== null) clearTimeout(timer);
   setPhase({ kind: 'loading' });
 
   const overlay = document.getElementById('packages-table-overlay');
@@ -75,5 +78,5 @@ export async function runPackagesListCheck(
     overlay.style.zIndex = '-1';
   }
 
-  setTimeout(() => setPhase({ kind: 'idle' }), 3000);
+  timer = setTimeout(() => setPhase({ kind: 'idle' }), 3000);
 }

--- a/src/renderer/main/settings/DataUrlSettings.tsx
+++ b/src/renderer/main/settings/DataUrlSettings.tsx
@@ -1,4 +1,4 @@
-import React, { type JSX, useState } from 'react';
+import React, { type JSX, useEffect, useRef, useState } from 'react';
 import { TRPCReact } from '../../trpc';
 
 type ButtonPhase = 'idle' | 'loading' | 'success' | 'danger';
@@ -14,6 +14,8 @@ function DataUrlSettings() {
   const [mainUrl, setMainUrl] = useState<string | null>(null);
   const [extraUrls, setExtraUrls] = useState<string | null>(null);
   const [phase, setPhase] = useState<ButtonPhase>('idle');
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => clearTimeout(timer.current), []);
 
   const setDataUrls = TRPCReact.settings.setDataUrls.useMutation();
   const updateInfo = TRPCReact.modList.updateInfo.useMutation();
@@ -24,6 +26,8 @@ function DataUrlSettings() {
   const extraValue = extraUrls ?? data?.extra ?? '';
 
   const onSet = async () => {
+    // 前回の復帰タイマーが残っていると loading 中に idle へ戻されるため消す
+    clearTimeout(timer.current);
     setPhase('loading');
     try {
       const result = await setDataUrls.mutateAsync({
@@ -54,7 +58,7 @@ function DataUrlSettings() {
     } catch {
       setPhase('danger');
     }
-    setTimeout(() => setPhase('idle'), 3000);
+    timer.current = setTimeout(() => setPhase('idle'), 3000);
   };
 
   const buttonClass =

--- a/src/renderer/main/usePhase.ts
+++ b/src/renderer/main/usePhase.ts
@@ -15,13 +15,21 @@ export function usePhase() {
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => () => clearTimeout(timer.current), []);
 
-  const start = () => setPhase({ kind: 'loading' });
+  // 前回の復帰タイマーを残したまま次の遷移をすると、3 秒前の操作の
+  // タイマーが発火して loading 中に idle へ戻される(ボタンが再度押せて
+  // 多重実行につながる)ため、遷移のたびに必ず消す
+  const start = () => {
+    clearTimeout(timer.current);
+    setPhase({ kind: 'loading' });
+  };
   const finish = (message: string, color: 'success' | 'danger' | 'info') => {
+    clearTimeout(timer.current);
     setPhase({ kind: 'message', message, color });
     timer.current = setTimeout(() => setPhase({ kind: 'idle' }), 3000);
   };
   // 旧 openPackageFolder の成功時(メッセージなしで 3 秒後に復帰)
   const finishSilently = () => {
+    clearTimeout(timer.current);
     timer.current = setTimeout(() => setPhase({ kind: 'idle' }), 3000);
   };
   return { phase, start, finish, finishSilently };


### PR DESCRIPTION
## 概要

Phase 4 冒頭の堅牢性スライス #B3(#2379)。アクションボタンの「3 秒後に idle へ復帰する」タイマーを投げっぱなしにしていたため、復帰前(3 秒以内)に同じボタンを再操作すると、**前回のタイマーが発火して loading 中に idle へ戻される**レースがありました。loading 中は disabled が多重実行の防波堤なので、これが解除されると処理中の再クリック(二重インストール等)につながります。

## 変更内容

同型パターン 5 箇所すべてで、フェーズ遷移の前に前回のタイマーを `clearTimeout` するよう統一しました。

- `src/renderer/main/usePhase.ts` — `start` / `finish` / `finishSilently` で解除(共有フック。ManualUpdateTable / PackageActions / monacoEditorRenderer が利用)
- `src/renderer/main/aviutl/BatchInstallButton.tsx` — `onClick` 開始時と `finish` で解除
- `src/renderer/main/aviutl/ProgramRow.tsx` — timer を ref 化し、`onInstall` 開始時・`showError`・成功時で解除。unmount 時の解除も追加
- `src/renderer/main/settings/DataUrlSettings.tsx` — 同上(`onSet` 開始時に解除 + unmount 解除を追加)
- `src/renderer/main/packages/packagesListCheck.ts` — モジュールシングルトンのためモジュール変数でタイマーを保持し、`runPackagesListCheck` 開始時に解除

挙動変更はレース解消のみで、正常系(操作完了 → 3 秒後に idle 復帰)は従来どおりです。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(187 tests / 20 files)全緑
- renderer コンポーネントのためユニットテストは追加していません(テストは shared の純関数優先の方針どおり。E2E の既存 id セレクタが安全網)

Refs #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)