### PR TITLE
fix(main): 更新確認と nicommons 取得の通信エラーで落ちる・固まる問題を修正

### DIFF
--- a/src/main/services/appUpdate.ts
+++ b/src/main/services/appUpdate.ts
@@ -49,73 +49,82 @@ export async function checkUpdate(silent = true) {
     process.arch
   }/${app.getVersion()}`;
 
-  if (repoURL.hostname === 'github.com') {
-    await app.whenReady().then(() => {
-      const request = net.request(feed);
-      request.on('response', async (response) => {
-        const icon = path.join(__dirname, '../icon/apm1024.png');
-        if (response.statusCode === 204) {
-          log.debug('It is up to date.');
-          if (!silent)
-            await dialog.showMessageBox({
-              title: '更新確認完了',
-              message: 'apmは最新のバージョンです。',
-              type: 'info',
-              icon: icon,
-            });
-        } else if (response.statusCode === 404) {
-          log.debug('No updates are found');
-          if (!silent)
-            await dialog.showMessageBox({
-              title: '更新確認失敗',
-              message: 'apmの更新が見つかりませんでした。',
-              type: 'warning',
-              icon: icon,
-            });
-        } else {
-          let body = '';
-          response.on('data', (chunk) => {
-            body += chunk;
-          });
-          response.on('end', async () => {
-            try {
-              const data = JSON.parse(body);
-              if ('name' in data) {
-                const res = dialog.showMessageBoxSync({
-                  title: 'アップデート',
-                  message:
-                    `${data.name}が公開されています。\n` +
-                    `現在のバージョン: v${app.getVersion()}\n` +
-                    'apmを終了して、ダウンロードページを開きますか？',
-                  detail: data?.notes
-                    ? 'リリースノート:\n' + data?.notes
-                    : undefined,
-                  buttons: ['開く', 'キャンセル'],
-                  cancelId: 1,
-                  type: 'info',
-                  icon: icon,
-                });
-                if (res === 0) {
-                  const releasePage = `https://github.com/${repo}/releases/latest`;
-                  await shell.openExternal(releasePage);
-                  app.quit();
-                }
-              }
-            } catch (e) {
-              log.error(e);
-              if (!silent)
-                await dialog.showMessageBox({
-                  title: '更新確認失敗',
-                  message: 'apmの更新を解析できませんでした。',
-                  type: 'error',
-                  icon: icon,
-                });
-            }
-          });
-        }
+  if (repoURL.hostname !== 'github.com') return;
+  await app.whenReady();
+
+  const icon = path.join(__dirname, '../icon/apm1024.png');
+
+  // 旧実装(net.request)はエラーハンドラが無く、オフライン時に uncaught
+  // exception で errorHandler がアプリごと終了させていた。ネットワーク失敗と
+  // タイムアウトはログ + (手動確認時のみ)ダイアログに畳み込む
+  let response: Awaited<ReturnType<typeof net.fetch>>;
+  try {
+    response = await net.fetch(feed, { signal: AbortSignal.timeout(10000) });
+  } catch (e) {
+    log.error(e);
+    if (!silent)
+      await dialog.showMessageBox({
+        title: '更新確認失敗',
+        message: 'apmの更新を確認できませんでした。',
+        type: 'error',
+        icon: icon,
       });
-      request.end();
-    });
+    return;
+  }
+
+  if (response.status === 204) {
+    log.debug('It is up to date.');
+    if (!silent)
+      await dialog.showMessageBox({
+        title: '更新確認完了',
+        message: 'apmは最新のバージョンです。',
+        type: 'info',
+        icon: icon,
+      });
+    return;
+  }
+  if (response.status === 404) {
+    log.debug('No updates are found');
+    if (!silent)
+      await dialog.showMessageBox({
+        title: '更新確認失敗',
+        message: 'apmの更新が見つかりませんでした。',
+        type: 'warning',
+        icon: icon,
+      });
+    return;
+  }
+
+  try {
+    const data = (await response.json()) as { name?: string; notes?: string };
+    if ('name' in data) {
+      const res = dialog.showMessageBoxSync({
+        title: 'アップデート',
+        message:
+          `${data.name}が公開されています。\n` +
+          `現在のバージョン: v${app.getVersion()}\n` +
+          'apmを終了して、ダウンロードページを開きますか？',
+        detail: data?.notes ? 'リリースノート:\n' + data?.notes : undefined,
+        buttons: ['開く', 'キャンセル'],
+        cancelId: 1,
+        type: 'info',
+        icon: icon,
+      });
+      if (res === 0) {
+        const releasePage = `https://github.com/${repo}/releases/latest`;
+        await shell.openExternal(releasePage);
+        app.quit();
+      }
+    }
+  } catch (e) {
+    log.error(e);
+    if (!silent)
+      await dialog.showMessageBox({
+        title: '更新確認失敗',
+        message: 'apmの更新を解析できませんでした。',
+        type: 'error',
+        icon: icon,
+      });
   }
 }
 
@@ -131,7 +140,10 @@ export async function runAutoUpdate(config: Config, isDevEnv: boolean) {
       if (doAutoUpdate === 'download') {
         updateElectronApp({ repo: 'team-apm/apm', logger: log });
       } else if (doAutoUpdate === 'notify') {
-        await checkUpdate();
+        // 応答を待つと窓の生成(launch)が最大タイムアウト分遅れるため
+        // 待たない(旧実装もレスポンスを待たずに起動を続けていた)。
+        // エラーは checkUpdate 内で処理済みなので握りつぶしはない
+        void checkUpdate();
       }
     }
   } catch (e) {

--- a/src/main/services/nicommons.ts
+++ b/src/main/services/nicommons.ts
@@ -3,38 +3,29 @@ import log from 'electron-log/main';
 
 /**
  * Fetches the work data from the nicommons API.
+ * 旧実装(net.request)はエラーハンドラが無く、オフライン時に uncaught
+ * exception になるうえ Promise が永遠に解決されなかった。失敗と
+ * タイムアウトはすべて false(データなし)へ畳み込む。
  * @param {string} id - The nicommons ID.
  * @returns {Promise<unknown>} The work data, or false if it is not found.
  */
-export function getNicommonsData(id: string) {
-  const request = net.request(
-    `https://public-api.commons.nicovideo.jp/v1/works/${id}?with_meta=1`,
-  );
-  return new Promise((resolve) => {
-    request.on('response', (response) => {
-      if (response.statusCode === 404) {
-        log.debug('No data are found in nicommons API.');
-        resolve(false);
-      } else {
-        let body = '';
-        response.on('data', (chunk) => {
-          body += chunk;
-        });
-        response.on('end', () => {
-          try {
-            const data = JSON.parse(body);
-            if ('data' in data) {
-              resolve(data.data);
-            } else {
-              resolve(false);
-            }
-          } catch (e) {
-            log.error(e);
-            resolve(false);
-          }
-        });
-      }
-    });
-    request.end();
-  });
+export async function getNicommonsData(id: string): Promise<unknown> {
+  try {
+    const response = await net.fetch(
+      `https://public-api.commons.nicovideo.jp/v1/works/${id}?with_meta=1`,
+      { signal: AbortSignal.timeout(10000) },
+    );
+    if (response.status === 404) {
+      log.debug('No data are found in nicommons API.');
+      return false;
+    }
+    const data: unknown = await response.json();
+    if (data && typeof data === 'object' && 'data' in data) {
+      return data.data;
+    }
+    return false;
+  } catch (e) {
+    log.error(e);
+    return false;
+  }
 }


### PR DESCRIPTION
## 概要

Phase 4 冒頭の堅牢性スライス #B1(#2379)。`net.request` を使う 2 箇所(`src/main/services/nicommons.ts` / `src/main/services/appUpdate.ts`)に **error ハンドラが無く**、実コード確認の結果、次の 2 つの問題がありました。

1. **オフライン時にクラッシュ相当**: ClientRequest の 'error' イベントにリスナーが無いため uncaught exception となり、`log.errorHandler` が「予期しないエラー」ダイアログを出してアプリを終了させる。`checkUpdate` は起動時の notify 分岐から呼ばれるため、オフラインで起動しただけで発生する
2. **応答が無いと永久に固まる**: タイムアウトが無く、失敗時は Promise が解決されないため、nicommons タブ(tRPC query)や手動更新確認ボタンが loading のまま戻らない

## 変更内容

- 両方を `net.fetch` + `AbortSignal.timeout(10 秒)` に置き換え(コールバックの入れ子も解消)
- 失敗経路はすべてログ + 畳み込み: `getNicommonsData` は false(データなし)、`checkUpdate` は手動確認時(`silent = false`)のみ「apmの更新を確認できませんでした。」ダイアログ
- **起動時間は維持**: 旧実装はレスポンスを待たずに起動を続けていたため、`runAutoUpdate` の notify 分岐では `await` しない(`void checkUpdate()`)。checkUpdate 内で全エラーを処理するので握りつぶしにはならない
- 204 / 404 / 更新あり(JSON 解析 → ダイアログ → リリースページ → 終了)の各分岐の挙動・文言は従来どおり

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(187 tests)全緑
- electron の net / dialog / app に依存する main サービスのためユニットテストは追加していません(テストは shared の純関数優先の方針どおり)

Refs #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)