### PR TITLE
fix(main): macOS の再アクティブ化で tRPC リスナーと nativeTheme リスナーが増殖する問題を修正

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -45,6 +45,13 @@ const icon =
     ? path.join(__dirname, '../icon/apm1024.png')
     : undefined;
 
+// macOS では全窓を閉じてもアプリが生き残り、Dock からの activate で
+// launch() が再実行される。trpc-electron の createIPCHandler は
+// ipcMain.on で登録し解除 API が無いため、再実行のたびに作ると
+// リスナーが純増して全リクエストが多重処理される(mutation の二重実行)。
+// ハンドラはプロセスで 1 個だけ作り、窓は attachWindow で追加する
+let ipcHandler: ReturnType<typeof createIPCHandler> | null = null;
+
 /**
  * Launch the app.
  * @param {Config} config - The config instance.
@@ -98,20 +105,28 @@ export async function launch(config: Config) {
     },
   });
 
-  // ipcMain へのリスナー登録は 1 回だけにし、窓の追加は attachWindow で行う
-  // (窓を開くたびに createIPCHandler を呼ぶとリスナーが重複する)
-  const ipcHandler = createIPCHandler({
-    router,
-    createContext,
-    windows: [mainWindow],
-  });
+  if (ipcHandler) {
+    ipcHandler.attachWindow(mainWindow);
+  } else {
+    ipcHandler = createIPCHandler({
+      router,
+      createContext,
+      windows: [mainWindow],
+    });
+  }
 
   Menu.setApplicationMenu(null);
 
   hardenNavigation(mainWindow.webContents);
 
-  nativeTheme.on('updated', () => {
+  const onThemeUpdated = () => {
     mainWindow.setTitleBarOverlay(getTitleBarColor());
+  };
+  nativeTheme.on('updated', onThemeUpdated);
+  // 解除しないと launch() の再実行ごとにリスナーが溜まり、破棄済みの
+  // mainWindow への setTitleBarOverlay で例外になる
+  mainWindow.on('closed', () => {
+    nativeTheme.removeListener('updated', onThemeUpdated);
   });
 
   mainWindow.once('show', () => {
@@ -136,7 +151,7 @@ export async function launch(config: Config) {
     // about 窓は従来ハンドラ未設定で、リンクを踏むと窓ごと外部サイトへ
     // 遷移できてしまっていた
     hardenNavigation(aboutWindow.webContents);
-    ipcHandler.attachWindow(aboutWindow);
+    ipcHandler?.attachWindow(aboutWindow);
     aboutWindow.once('close', () => {
       if (!aboutWindow.isDestroyed()) {
         aboutWindow.destroy();


### PR DESCRIPTION
## 概要

Phase 4 冒頭の堅牢性スライス #B2(#2379)。未検証だった指摘を実コードで確認したところ、次の 2 点が事実でした(macOS では `window-all-closed` で quit しないため、全窓を閉じて Dock から再アクティブ化すると `launch()` が丸ごと再実行されます)。

1. **tRPC ハンドラの重複**: trpc-electron の `createIPCHandler` は `ipcMain.on` で登録し解除 API がありません(dist を確認)。`launch()` 再実行のたびにハンドラが純増し、以後の全 tRPC リクエストが**多重処理**されます(query は結果が同じでも、mutation はインストール・設定書き込み等の二重実行)。windows.ts の既存コメントは「窓ごとに呼ぶな」と警告していましたが、launch 全体の再入では同じ問題が起きていました
2. **nativeTheme リスナーのリーク**: `nativeTheme.on('updated')` が破棄済みの旧 mainWindow を掴んだまま残り、再アクティブ化後にテーマを変更すると destroyed window への `setTitleBarOverlay` で例外 → `log.errorHandler` が「予期しないエラー」ダイアログを出してアプリを終了させます

## 変更内容

- `ipcHandler` をモジュールシングルトン化: 初回だけ `createIPCHandler`、2 回目以降は `attachWindow(mainWindow)` のみ(窓の detach は trpc-electron が webContents の destroyed で自前処理するため考慮不要)
- `nativeTheme` の updated リスナーを名前付きにし、`mainWindow` の closed で `removeListener`

Windows では launch() は 1 回しか実行されないため挙動変化はありません。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(187 tests)全緑
- macOS 実機で確認: 全窓を閉じる → Dock から再アクティブ化 → 各タブ操作、の手動スモークは私(メンテナ)側での確認をお願いします

Refs #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)