### PR TITLE
refactor(renderer): 設定・nicommons・その他タブの pane を単一の React ルートに統合

### DIFF
--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -101,48 +101,13 @@
 				aria-labelledby="packages"
 			></section>
 
+			<!-- 中身は React(nicommons/NicommonsTab.tsx)が描画する -->
 			<section
 				class="tab-pane fade"
 				id="nicommons"
 				role="tabpanel"
 				aria-labelledby="nicommons"
-			>
-				<div class="container-lg">
-					<div class="row card border-top-0 border-bottom-0 rounded-0">
-						<div class="card-body d-flex flex-column py-2">
-							<div class="row pb-2 border-bottom">
-								<div class="col-auto">
-									<button
-										type="button"
-										class="btn btn-copy btn-primary"
-										id="copy-nicommons-id-textarea"
-										data-clipboard-target="#nicommons-id-textarea"
-									>
-										コピー
-									</button>
-								</div>
-								<div class="col">
-									<textarea
-										rows="1"
-										name="nicommons-id-textarea"
-										id="nicommons-id-textarea"
-										class="form-control"
-										readonly
-									></textarea>
-								</div>
-							</div>
-							<div class="row flex-grow-1 overflow-auto">
-								<div class="col">
-									<ul
-										class="list-group list-group-flush"
-										id="nicommons-id-list"
-									></ul>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</section>
+			></section>
 
 			<!-- 中身は React(settings/SettingsTab.tsx)が描画する -->
 			<section
@@ -152,14 +117,13 @@
 				aria-labelledby="settings"
 			></section>
 
+			<!-- 中身は React(others/OthersTab.tsx)が描画する -->
 			<section
 				class="tab-pane fade"
 				id="others"
 				role="tabpanel"
 				aria-labelledby="others"
-			>
-				<div id="others-root"></div>
-			</section>
+			></section>
 		</main>
 	</body>
 </html>

--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -144,56 +144,13 @@
 				</div>
 			</section>
 
+			<!-- 中身は React(settings/SettingsTab.tsx)が描画する -->
 			<section
 				class="tab-pane fade"
 				id="settings"
 				role="tabpanel"
 				aria-labelledby="settings"
-			>
-				<div class="container-lg py-2">
-					<div class="row my-2">
-						<div class="card">
-							<div class="card-body">
-								<h3 class="card-title">設定</h3>
-								<div id="settings-data-url-root"></div>
-								<div class="row mb-3">
-									<label for="container" class="form-label"
-										>追加テキストデータ</label
-									>
-									<div class="col-sm-9">
-										<div id="container" class="border rounded"></div>
-									</div>
-									<div class="col-sm-3">
-										<!-- ボタンは React(monacoEditorRenderer.tsx)が描画する -->
-										<div id="save-editor-data-root"></div>
-									</div>
-								</div>
-								<div id="settings-preferences-root"></div>
-								<hr />
-								<div class="row mb-3">
-									<h4>手動更新</h4>
-									<div id="manual-update-react-root" class="d-none"></div>
-									<table class="table table-borderless table-striped">
-										<thead>
-											<tr>
-												<th scope="col" class="col-sm-3"></th>
-												<th scope="col" class="col-sm-3">リスト更新日時</th>
-												<th scope="col" class="col-sm-3">最終更新日時</th>
-												<th scope="col" class="col-sm-3"></th>
-											</tr>
-										</thead>
-										<!-- 行は React(settings/ManualUpdateTable.tsx)が描画する -->
-										<tbody
-											class="align-middle"
-											id="manual-update-tbody"
-										></tbody>
-									</table>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
-			</section>
+			></section>
 
 			<section
 				class="tab-pane fade"

--- a/src/renderer/main/monacoEditorRenderer.tsx
+++ b/src/renderer/main/monacoEditorRenderer.tsx
@@ -13,7 +13,6 @@ import schema from 'apm-schema/v3/schema/packages.json';
 // Enum values must be taken from the `monaco` instance passed to onMount.
 import type { editor } from 'monaco-editor';
 import React, { useRef } from 'react';
-import { createPortal } from 'react-dom';
 import { TRPCReact } from '../trpc';
 import { getInstallationPath } from './instPath';
 import { usePhase } from './usePhase';
@@ -146,7 +145,8 @@ loader.config({
 
 /**
  *  A small code editor for apm-data, with validation against apm-schema.
- * 保存ボタン(旧 lib/buttonTransition によるボタンフロー)も portal で描画する。
+ * SettingsTab の「追加テキストデータ」行に、エディタ列と保存ボタン列を
+ * 描画する(旧 lib/buttonTransition によるボタンフロー込み)。
  * @returns {React.ReactElement} React component
  */
 export const MonacoEditorRenderer: React.FC = () => {
@@ -256,45 +256,46 @@ export const MonacoEditorRenderer: React.FC = () => {
     });
   };
 
-  const saveButtonRoot = document.getElementById('save-editor-data-root');
   const saveColor =
     save.phase.kind === 'message' ? save.phase.color : 'primary';
 
   return (
     <>
-      <MonacoEditor
-        height="50vh"
-        defaultLanguage="json"
-        path={modelUri}
-        beforeMount={editorWillMount}
-        onMount={editorDidMount}
-      />
-      {saveButtonRoot &&
-        createPortal(
-          <button
-            type="button"
-            className={`btn btn-${saveColor} w-100`}
-            id="save-editor-data"
-            disabled={save.phase.kind === 'loading'}
-            onClick={() => void saveEditorData()}
-          >
-            {save.phase.kind === 'loading' ? (
-              <>
-                <span
-                  className="spinner-border spinner-border-sm"
-                  role="status"
-                  aria-hidden="true"
-                ></span>
-                <span className="visually-hidden">Loading...</span>
-              </>
-            ) : save.phase.kind === 'message' ? (
-              save.phase.message
-            ) : (
-              '保存 (Ctrl + S)'
-            )}
-          </button>,
-          saveButtonRoot,
-        )}
+      <div className="col-sm-9">
+        <div id="container" className="border rounded">
+          <MonacoEditor
+            height="50vh"
+            defaultLanguage="json"
+            path={modelUri}
+            beforeMount={editorWillMount}
+            onMount={editorDidMount}
+          />
+        </div>
+      </div>
+      <div className="col-sm-3">
+        <button
+          type="button"
+          className={`btn btn-${saveColor} w-100`}
+          id="save-editor-data"
+          disabled={save.phase.kind === 'loading'}
+          onClick={() => void saveEditorData()}
+        >
+          {save.phase.kind === 'loading' ? (
+            <>
+              <span
+                className="spinner-border spinner-border-sm"
+                role="status"
+                aria-hidden="true"
+              ></span>
+              <span className="visually-hidden">Loading...</span>
+            </>
+          ) : save.phase.kind === 'message' ? (
+            save.phase.message
+          ) : (
+            '保存 (Ctrl + S)'
+          )}
+        </button>
+      </div>
     </>
   );
 };

--- a/src/renderer/main/nicommons/NicommonsTab.tsx
+++ b/src/renderer/main/nicommons/NicommonsTab.tsx
@@ -87,10 +87,13 @@ function NicommonsRow({
 }
 
 /**
- * The nicommons ID list: installed packages with a nicommons ID, with
- * checkboxes that build the space-separated ID list in the textarea.
+ * The whole pane of the nicommons ID tab (旧 index.html の section#nicommons
+ * の中身): installed packages with a nicommons ID, with checkboxes that
+ * build the space-separated ID list in the textarea.
  * 旧 package.ts の displayNicommonsIdList に相当する。データ取得は tRPC 経由で
  * main プロセス。レガシー側からの再描画通知は apm-packages-changed イベント。
+ * コピーボタンは preload が初期化する ClipboardJS が処理する(セレクタ指定の
+ * ClipboardJS は委譲リスナーのため、React が後から描画する要素でも動く)。
  * @returns {JSX.Element} The rendered component.
  */
 function NicommonsTab(): JSX.Element {
@@ -164,36 +167,68 @@ function NicommonsTab(): JSX.Element {
     ];
   }, [packages, installedIdsQuery.data]);
 
-  // チェック状態に応じて textarea(レガシー DOM、コピーは ClipboardJS)を更新
-  useEffect(() => {
-    const textarea = document.getElementById(
-      'nicommons-id-textarea',
-    ) as HTMLTextAreaElement | null;
-    if (!textarea) return;
-    textarea.value = items
-      .filter((item) => !uncheckedIds.has(item.nicommons))
-      .map((item) => item.nicommons)
-      .join(' ');
-  }, [items, uncheckedIds]);
+  const idListText = useMemo(
+    () =>
+      items
+        .filter((item) => !uncheckedIds.has(item.nicommons))
+        .map((item) => item.nicommons)
+        .join(' '),
+    [items, uncheckedIds],
+  );
 
   return (
-    <>
-      {items.map((item) => (
-        <NicommonsRow
-          key={item.nicommons}
-          item={item}
-          checked={!uncheckedIds.has(item.nicommons)}
-          onChange={(checked) =>
-            setUncheckedIds((prev) => {
-              const next = new Set(prev);
-              if (checked) next.delete(item.nicommons);
-              else next.add(item.nicommons);
-              return next;
-            })
-          }
-        />
-      ))}
-    </>
+    <div className="container-lg">
+      <div className="row card border-top-0 border-bottom-0 rounded-0">
+        <div className="card-body d-flex flex-column py-2">
+          <div className="row pb-2 border-bottom">
+            <div className="col-auto">
+              <button
+                type="button"
+                className="btn btn-copy btn-primary"
+                id="copy-nicommons-id-textarea"
+                data-clipboard-target="#nicommons-id-textarea"
+              >
+                コピー
+              </button>
+            </div>
+            <div className="col">
+              <textarea
+                rows={1}
+                name="nicommons-id-textarea"
+                id="nicommons-id-textarea"
+                className="form-control"
+                readOnly
+                value={idListText}
+              ></textarea>
+            </div>
+          </div>
+          <div className="row flex-grow-1 overflow-auto">
+            <div className="col">
+              <ul
+                className="list-group list-group-flush"
+                id="nicommons-id-list"
+              >
+                {items.map((item) => (
+                  <NicommonsRow
+                    key={item.nicommons}
+                    item={item}
+                    checked={!uncheckedIds.has(item.nicommons)}
+                    onChange={(checked) =>
+                      setUncheckedIds((prev) => {
+                        const next = new Set(prev);
+                        if (checked) next.delete(item.nicommons);
+                        else next.add(item.nicommons);
+                        return next;
+                      })
+                    }
+                  />
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/renderer/main/renderer.tsx
+++ b/src/renderer/main/renderer.tsx
@@ -19,12 +19,14 @@ window.addEventListener('DOMContentLoaded', () => {
       <SettingsTab />
     </TrpcProvider>,
   );
-  createRoot(document.getElementById('others-root')).render(
+  // その他タブは pane 全体を 1 ルートで描画する
+  createRoot(document.getElementById('others')).render(
     <TrpcProvider>
       <OthersTab />
     </TrpcProvider>,
   );
-  createRoot(document.getElementById('nicommons-id-list')).render(
+  // ニコニ・コモンズ ID タブは pane 全体を 1 ルートで描画する
+  createRoot(document.getElementById('nicommons')).render(
     <TrpcProvider>
       <NicommonsTab />
     </TrpcProvider>,

--- a/src/renderer/main/renderer.tsx
+++ b/src/renderer/main/renderer.tsx
@@ -6,37 +6,17 @@ import '../../../node_modules/bootstrap-icons/font/bootstrap-icons.css';
 import '../main.css';
 import './index.css';
 import AviutlTab from './aviutl/AviutlTab';
-import { MonacoEditorRenderer } from './monacoEditorRenderer';
 import NicommonsTab from './nicommons/NicommonsTab';
 import OthersTab from './others/OthersTab';
 import PackagesTab from './packages/PackagesTab';
-import DataUrlSettings from './settings/DataUrlSettings';
-import ManualUpdateTable from './settings/ManualUpdateTable';
-import PreferencesSettings from './settings/PreferencesSettings';
+import SettingsTab from './settings/SettingsTab';
 import { TrpcProvider } from './TrpcProvider';
 
 window.addEventListener('DOMContentLoaded', () => {
-  const root = createRoot(document.getElementById('container'));
-  root.render(
+  // 設定タブは pane 全体を 1 ルートで描画する
+  createRoot(document.getElementById('settings')).render(
     <TrpcProvider>
-      <MonacoEditorRenderer />
-    </TrpcProvider>,
-  );
-
-  createRoot(document.getElementById('settings-data-url-root')).render(
-    <TrpcProvider>
-      <DataUrlSettings />
-    </TrpcProvider>,
-  );
-  createRoot(document.getElementById('settings-preferences-root')).render(
-    <TrpcProvider>
-      <PreferencesSettings />
-    </TrpcProvider>,
-  );
-  // 手動更新テーブルは portal で #manual-update-tbody(tbody)へ描画する
-  createRoot(document.getElementById('manual-update-react-root')).render(
-    <TrpcProvider>
-      <ManualUpdateTable />
+      <SettingsTab />
     </TrpcProvider>,
   );
   createRoot(document.getElementById('others-root')).render(

--- a/src/renderer/main/settings/ManualUpdateTable.tsx
+++ b/src/renderer/main/settings/ManualUpdateTable.tsx
@@ -1,5 +1,4 @@
 import React, { type JSX, useEffect, useSyncExternalStore } from 'react';
-import { createPortal } from 'react-dom';
 import { TRPCReact } from '../../trpc';
 import { getInstallationPath } from '../instPath';
 import {
@@ -69,7 +68,8 @@ function formatDates(dates: { modDate: number; checkDate: number } | null) {
 }
 
 /**
- * The manual-update table (core / packages / apm) of the settings tab.
+ * The rows of the manual-update table (core / packages / apm) of the
+ * settings tab, rendered in the tbody of SettingsTab.
  * 旧 core.ts の checkLatestVersion・displayInstalledVersion(日付部分)と
  * 旧 package.ts の updateModDates・checkPackagesList のボタンフローに相当する。
  * パッケージデータの更新フローは packagesListCheck(シングルトン)が持ち、
@@ -150,10 +150,7 @@ function ManualUpdateTable(): JSX.Element {
     } | null,
   );
 
-  const tbody = document.getElementById('manual-update-tbody');
-  if (!tbody) return <></>;
-
-  return createPortal(
+  return (
     <>
       <tr>
         <th scope="row">AviUtl・拡張編集データ</th>
@@ -209,8 +206,7 @@ function ManualUpdateTable(): JSX.Element {
           </div>
         </td>
       </tr>
-    </>,
-    tbody,
+    </>
   );
 }
 

--- a/src/renderer/main/settings/SettingsTab.tsx
+++ b/src/renderer/main/settings/SettingsTab.tsx
@@ -1,0 +1,56 @@
+import React, { type JSX } from 'react';
+import { MonacoEditorRenderer } from '../monacoEditorRenderer';
+import DataUrlSettings from './DataUrlSettings';
+import ManualUpdateTable from './ManualUpdateTable';
+import PreferencesSettings from './PreferencesSettings';
+
+/**
+ * The whole pane of the settings tab (旧 index.html の section#settings の
+ * 中身): データ取得先・追加テキストデータ(Monaco エディタ)・環境設定・
+ * 手動更新テーブル。
+ * @returns {JSX.Element} The rendered component.
+ */
+function SettingsTab(): JSX.Element {
+  return (
+    <div className="container-lg py-2">
+      <div className="row my-2">
+        <div className="card">
+          <div className="card-body">
+            <h3 className="card-title">設定</h3>
+            <DataUrlSettings />
+            <div className="row mb-3">
+              <label htmlFor="container" className="form-label">
+                追加テキストデータ
+              </label>
+              <MonacoEditorRenderer />
+            </div>
+            <PreferencesSettings />
+            <hr />
+            <div className="row mb-3">
+              <h4>手動更新</h4>
+              <table className="table table-borderless table-striped">
+                <thead>
+                  <tr>
+                    <th scope="col" className="col-sm-3"></th>
+                    <th scope="col" className="col-sm-3">
+                      リスト更新日時
+                    </th>
+                    <th scope="col" className="col-sm-3">
+                      最終更新日時
+                    </th>
+                    <th scope="col" className="col-sm-3"></th>
+                  </tr>
+                </thead>
+                <tbody className="align-middle" id="manual-update-tbody">
+                  <ManualUpdateTable />
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SettingsTab;


### PR DESCRIPTION
## 概要

Phase 4 完全 React 化(#2379)のタブ移行、残り 3 タブです(#2391 の続き)。1 スライス = 1 コミットの 2 コミット構成。

## コミット 1: 設定タブ

section#settings の中身を `SettingsTab` へ移し、4 個の createRoot(Monaco エディタ / データ取得先 / 環境設定 / 手動更新テーブル)を pane 全体の 1 ルートに置き換え。

- `MonacoEditorRenderer` は「追加テキストデータ」行のエディタ列 + 保存ボタン列を描画する形にし、保存ボタンの portal を廃止
- `ManualUpdateTable` は tbody への portal を廃止し、SettingsTab の tbody 内へ直接 tr 群を描画
- preload(setting.ts)は DOM 非依存のため、この pane はレガシーとの DOM 共有なしで React 完全所有

## コミット 2: nicommons・その他タブ

- `NicommonsTab` を pane 全体(コピー・textarea・一覧)へ拡張し、textarea への直接 DOM 書き込みを React の制御値に置き換え。コピーボタンは引き続き preload 初期化の ClipboardJS が処理(セレクタ指定の ClipboardJS は委譲リスナーのため、React が後から描画する要素でも動作することを確認済み)
- その他タブは `OthersTab` が既に pane 全体を描画していたため、マウント先を section#others へ移して中間 div を削除

## 到達点

**main 窓の 5 タブすべてが pane 単位の React ルート**になりました。index.html はタブナビ + 空 section のみの 94 行(移行開始前 550 行)、createRoot は 5 個(タブごとに 1 つ)。残りは シェル(タブナビ・title-bar)→ preload 初期化フロー移設 → 後片付け(trpcIdNamespace 削除等)です。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(187 tests)全緑
- **各コミット時点でローカル `yarn package` + `yarn test:e2e`(Node 22)3 本 pass**(install.spec は設定タブの #data-url → #set-data-url → #check-packages-list フローを通過)

Refs #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)