### PR TITLE
refactor(renderer): タブと dropdown を react-bootstrap 化して Bootstrap data API 依存を解消

### DIFF
--- a/src/renderer/main/App.tsx
+++ b/src/renderer/main/App.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useEffect, useRef } from 'react';
+import { Nav, Tab } from 'react-bootstrap';
 import { TRPCReact } from '../trpc';
 import AviutlTab from './aviutl/AviutlTab';
 import NicommonsTab from './nicommons/NicommonsTab';
@@ -38,115 +39,53 @@ function TitleBarAppName(): JSX.Element {
   );
 }
 
-/**
- * One tab button of the shell (旧 index.html のタブナビと同一のマークアップ).
- * @param {object} props - Props.
- * @param {string} props.target - The section id the button toggles.
- * @param {boolean} props.active - Whether the tab is initially active.
- * @param {string} props.label - The label.
- * @returns {JSX.Element} The rendered component.
- */
-function TabButton({
-  target,
-  active,
-  label,
-}: {
-  target: string;
-  active: boolean;
-  label: string;
-}): JSX.Element {
-  return (
-    <button
-      className={'non-draggable nav-link' + (active ? ' active' : '')}
-      id={`${target}-tab`}
-      data-bs-toggle="tab"
-      data-bs-target={`#${target}`}
-      type="button"
-      role="tab"
-      aria-controls={target}
-      aria-selected={active}
-    >
-      {label}
-    </button>
-  );
-}
+const TABS: { id: string; label: string; pane: JSX.Element }[] = [
+  { id: 'aviutl', label: 'AviUtl', pane: <AviutlTab /> },
+  { id: 'packages', label: 'プラグイン&スクリプト', pane: <PackagesTab /> },
+  { id: 'nicommons', label: 'ニコニ・コモンズID', pane: <NicommonsTab /> },
+  { id: 'settings', label: '設定', pane: <SettingsTab /> },
+  { id: 'others', label: 'その他', pane: <OthersTab /> },
+];
 
 /**
  * The shell of the main window: the title bar, the tab nav, and the five
  * tab panes (旧 index.html の body 直下の構造)。
- * タブ切り替えは従来どおり Bootstrap の tab(data-bs-toggle。document 委譲の
- * ため React 描画後のボタンでも動く)がボタンと section の class を直接
- * 切り替える。App 自身は状態を持たないので React がこれらを巻き戻すことは
- * ないが、状態を足すときはタブの React 化(Bootstrap data API 依存の解消)と
- * 合わせて行うこと。
+ * タブ切り替えは react-bootstrap の Tab(旧 Bootstrap の data API は廃止。
+ * About 窓に続く react-bootstrap の採用)。pane は非アクティブでも
+ * マウントしたままにする(旧実装の display:none と同じ。クエリや
+ * イベント購読を生かすため)。
  * @returns {JSX.Element} The rendered component.
  */
 function App(): JSX.Element {
   return (
-    <>
+    <Tab.Container defaultActiveKey="aviutl">
       <Startup />
       <nav className="bg-body-tertiary draggable">
         <TitleBarAppName />
-        <div className="nav nav-tabs" id="nav-tab" role="tablist">
-          <TabButton target="aviutl" active label="AviUtl" />
-          <TabButton
-            target="packages"
-            active={false}
-            label="プラグイン&スクリプト"
-          />
-          <TabButton
-            target="nicommons"
-            active={false}
-            label="ニコニ・コモンズID"
-          />
-          <TabButton target="settings" active={false} label="設定" />
-          <TabButton target="others" active={false} label="その他" />
-        </div>
+        <Nav variant="tabs" id="nav-tab">
+          {TABS.map((tab) => (
+            <Nav.Link
+              key={tab.id}
+              as="button"
+              type="button"
+              eventKey={tab.id}
+              id={`${tab.id}-tab`}
+              className="non-draggable"
+            >
+              {tab.label}
+            </Nav.Link>
+          ))}
+        </Nav>
       </nav>
 
-      <main className="tab-content" id="nav-tabContent">
-        <section
-          className="tab-pane fade show active"
-          id="aviutl"
-          role="tabpanel"
-          aria-labelledby="aviutl"
-        >
-          <AviutlTab />
-        </section>
-        <section
-          className="tab-pane fade"
-          id="packages"
-          role="tabpanel"
-          aria-labelledby="packages"
-        >
-          <PackagesTab />
-        </section>
-        <section
-          className="tab-pane fade"
-          id="nicommons"
-          role="tabpanel"
-          aria-labelledby="nicommons"
-        >
-          <NicommonsTab />
-        </section>
-        <section
-          className="tab-pane fade"
-          id="settings"
-          role="tabpanel"
-          aria-labelledby="settings"
-        >
-          <SettingsTab />
-        </section>
-        <section
-          className="tab-pane fade"
-          id="others"
-          role="tabpanel"
-          aria-labelledby="others"
-        >
-          <OthersTab />
-        </section>
-      </main>
-    </>
+      <Tab.Content as="main" id="nav-tabContent">
+        {TABS.map((tab) => (
+          <Tab.Pane key={tab.id} as="section" eventKey={tab.id} id={tab.id}>
+            {tab.pane}
+          </Tab.Pane>
+        ))}
+      </Tab.Content>
+    </Tab.Container>
   );
 }
 

--- a/src/renderer/main/aviutl/ProgramRow.tsx
+++ b/src/renderer/main/aviutl/ProgramRow.tsx
@@ -1,5 +1,6 @@
 import type { Core } from 'apm-schema';
 import React, { type JSX, useEffect, useRef, useState } from 'react';
+import { Dropdown } from 'react-bootstrap';
 import { releaseLabel } from '../../../shared/coreVersionText';
 import { TRPCReact } from '../../trpc';
 import { getInstallationPath } from '../instPath';
@@ -118,14 +119,6 @@ function ProgramRow({
     timer.current = setTimeout(() => setPhase('idle'), 3000);
   };
 
-  const buttonClass = `btn dropdown-toggle ${buttonRoundedClass} ${
-    phase === 'success'
-      ? 'btn-success'
-      : phase === 'danger'
-        ? 'btn-danger'
-        : 'btn-primary'
-  }`;
-
   return (
     <>
       <div className="d-flex align-items-center flex-grow-1">
@@ -133,51 +126,45 @@ function ProgramRow({
       </div>
       <div>
         <span id={`${program}-installed-version`}>{installedText}</span>
-        <button
-          type="button"
-          className={buttonClass}
-          id={`install-${program}`}
-          data-bs-toggle="dropdown"
-          aria-expanded="false"
-          disabled={phase === 'loading'}
-        >
-          {phase === 'loading' ? (
-            <>
-              <span
-                className="spinner-border spinner-border-sm"
-                role="status"
-                aria-hidden="true"
-              ></span>
-              <span className="visually-hidden">Loading...</span>
-            </>
-          ) : phase === 'idle' ? (
-            ''
-          ) : (
-            buttonMessage
-          )}
-        </button>
-        <div className="dropdown bg-body">
-          <ul
-            className="dropdown-menu dropdown-menu-end"
-            id={`${program}-version-select`}
-            aria-labelledby={`install-${program}`}
+        <Dropdown align="end" className="d-inline-block">
+          <Dropdown.Toggle
+            variant={
+              phase === 'success'
+                ? 'success'
+                : phase === 'danger'
+                  ? 'danger'
+                  : 'primary'
+            }
+            className={buttonRoundedClass}
+            id={`install-${program}`}
+            disabled={phase === 'loading'}
           >
+            {phase === 'loading' ? (
+              <>
+                <span
+                  className="spinner-border spinner-border-sm"
+                  role="status"
+                  aria-hidden="true"
+                ></span>
+                <span className="visually-hidden">Loading...</span>
+              </>
+            ) : phase === 'idle' ? (
+              ''
+            ) : (
+              buttonMessage
+            )}
+          </Dropdown.Toggle>
+          <Dropdown.Menu id={`${program}-version-select`}>
             {releases.map((release) => (
-              <li key={release.version}>
-                <a
-                  className="dropdown-item"
-                  href="#"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    void onInstall(release.version);
-                  }}
-                >
-                  {releaseLabel(release.version, latestVersion)}
-                </a>
-              </li>
+              <Dropdown.Item
+                key={release.version}
+                onClick={() => void onInstall(release.version)}
+              >
+                {releaseLabel(release.version, latestVersion)}
+              </Dropdown.Item>
             ))}
-          </ul>
-        </div>
+          </Dropdown.Menu>
+        </Dropdown>
       </div>
     </>
   );

--- a/src/renderer/main/renderer.tsx
+++ b/src/renderer/main/renderer.tsx
@@ -1,5 +1,4 @@
 import 'bootstrap/dist/css/bootstrap.min.css';
-import 'bootstrap/dist/js/bootstrap.bundle.min';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import '../../../node_modules/bootstrap-icons/font/bootstrap-icons.css';


### PR DESCRIPTION
## 概要

Phase 4(#2379)の「Bootstrap data API 依存の解消」スライスです。`bootstrap.bundle.min` への依存は **App のタブ切り替えと ProgramRow のバージョン選択 dropdown の 2 箇所**だけになっていたため、両者を置き換えて import ごと削除しました。

## 判断の経緯(#2379 の比較メモの決着)

「react-bootstrap 導入 vs 素の React state」を比較する前提だった「react-bootstrap は新規依存」が**誤り**でした — `react-bootstrap@2.10.10` は既に dependencies にあり、About 窓(実装パターンの前例)が使用しています。依存コストが無い以上、

- Popper による位置決め・fade・Escape / 外側クリック / **矢印キー操作**まで旧 data API と同等
- 外側クリック検知などの自前コードを持たなくてよい

の 2 点で react-bootstrap 採用が明確に優位と判断しました(素の state 案も一度実装して E2E green を確認した上での差し替えです)。

## 変更内容

- `App`: タブナビと pane を `Tab.Container` / `Nav` / `Tab.Pane`(as="section"、既存 id 維持)へ。pane は非アクティブでもマウント維持(旧 display:none と同じ)
- `ProgramRow`: dropdown を `Dropdown` / `Dropdown.Toggle`(variant でフェーズ色)/ `Dropdown.Menu` へ。メニューの DOM が ul/li → div/a になりますが、参照する CSS・E2E セレクタはありません
- `renderer.tsx`: `bootstrap.bundle.min` の import を削除(main 窓から Bootstrap JS が消滅)

これで **Bootstrap JS が React 所有の DOM の class を直接書き換える構造が根絶**され、シェル React 化以来 App に残っていた「状態を足すとタブが巻き戻る」注意書きも不要になりました。

## テスト

- `yarn lint` / `yarn lint:ts` / `yarn test`(187 tests)全緑
- **ローカル `yarn package` + `yarn test:e2e`(Node 22)3 本 pass** — `getByRole('tab')` は Tab.Container が付与する role で解決、`#install-aviutl` → `#aviutl-version-select .dropdown-item` クリックのフローも通過
- タブ・dropdown の見た目(fade、メニュー位置)は Windows 実機での目視確認をお願いします

Refs #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)