### PR TITLE
test(e2e): Windows ランナーでの E2E フレークを緩和する(終了処理の確実化 + リトライ)

### DIFF
--- a/e2e/core.spec.ts
+++ b/e2e/core.spec.ts
@@ -1,18 +1,19 @@
-import { expect, test } from '@playwright/test';
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { createZip, serveFixtures, ssriOf, writeDataSet } from './fixtures';
-import { getMainWindow, launchIsolated } from './helpers';
+import { expect, getMainWindow, test } from './helpers';
 
-test('AviUtl 本体のインストールができる', async () => {
+test('AviUtl 本体のインストールができる', async ({ cleanup, launchApp }) => {
   // --- フィクスチャと配信サーバ ---
   const workDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-core-'));
+  cleanup(() => rmSync(workDir, { recursive: true, force: true }));
   const fixturesDir = path.join(workDir, 'fixtures');
   const instPath = path.join(workDir, 'aviutl');
   mkdirSync(instPath, { recursive: true });
 
   const { baseUrl, close } = await serveFixtures(fixturesDir);
+  cleanup(close);
   const zipPath = path.join(fixturesDir, 'files', 'aviutl.zip');
   createZip(zipPath, path.join(workDir, 'program'), {
     'aviutl.exe': 'dummy aviutl executable for e2e',
@@ -29,39 +30,32 @@ test('AviUtl 本体のインストールができる', async () => {
     ],
   });
 
-  const { app, userDataDir } = await launchIsolated({
+  const app = await launchApp({
     config: {
       dataVersion: '3',
       installationPath: instPath,
       dataURL: { main: baseUrl, extra: '' },
     },
   });
-  try {
-    const window = await getMainWindow(app);
-    // preload の初期化フロー完了を待つ(完了するとインストール先が入る)
-    await expect(window.locator('#installation-path')).toHaveValue(instPath, {
-      timeout: 120_000,
-    });
+  const window = await getMainWindow(app);
+  // preload の初期化フロー完了を待つ(完了するとインストール先が入る)
+  await expect(window.locator('#installation-path')).toHaveValue(instPath, {
+    timeout: 120_000,
+  });
 
-    // バージョン選択ドロップダウンから最新版(1.10)をインストールする
-    await window.locator('#install-aviutl').click();
-    await window
-      .locator('#aviutl-version-select .dropdown-item', { hasText: '1.10' })
-      .click();
-    await expect(window.locator('#install-aviutl')).toHaveText(
-      'インストール完了',
-      { timeout: 120_000 },
-    );
+  // バージョン選択ドロップダウンから最新版(1.10)をインストールする
+  await window.locator('#install-aviutl').click();
+  await window
+    .locator('#aviutl-version-select .dropdown-item', { hasText: '1.10' })
+    .click();
+  await expect(window.locator('#install-aviutl')).toHaveText(
+    'インストール完了',
+    { timeout: 120_000 },
+  );
 
-    // 実ファイルが置かれ、インストール済みバージョンが表示される
-    expect(existsSync(path.join(instPath, 'aviutl.exe'))).toBe(true);
-    await expect(window.locator('#aviutl-installed-version')).toContainText(
-      'バージョン: 1.10',
-    );
-  } finally {
-    await app.close();
-    close();
-    rmSync(userDataDir, { recursive: true, force: true });
-    rmSync(workDir, { recursive: true, force: true });
-  }
+  // 実ファイルが置かれ、インストール済みバージョンが表示される
+  expect(existsSync(path.join(instPath, 'aviutl.exe'))).toBe(true);
+  await expect(window.locator('#aviutl-installed-version')).toContainText(
+    'バージョン: 1.10',
+  );
 });

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,9 +1,12 @@
 import {
   _electron,
+  test as base,
   type ElectronApplication,
+  expect,
   type Page,
 } from '@playwright/test';
-import { existsSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -30,39 +33,141 @@ export function packagedExecutablePath(): string {
   return path.join(outDir, 'apm');
 }
 
+const timedOut = Symbol('timedOut');
+
 /**
- * Launches the packaged app with an isolated (temporary) userData directory
- * so that tests never touch the real profile.
- * @param {object} [options] - Launch options.
- * @param {Record<string, unknown>} [options.config] - Initial contents of
- * config.json (electron-store). Omit to start from a clean profile.
- * @returns {Promise<{app: ElectronApplication, userDataDir: string}>} The
- * launched app and the userData directory (remove it after closing the app).
+ * Awaits the promise, giving up after the given time.
+ * @param {Promise<T>} promise - The promise to await.
+ * @param {number} ms - The time limit in milliseconds.
+ * @returns {Promise<T | typeof timedOut>} The result, or timedOut symbol.
  */
-export async function launchIsolated(options?: {
-  config?: Record<string, unknown>;
-}): Promise<{ app: ElectronApplication; userDataDir: string }> {
-  const executablePath = packagedExecutablePath();
-  if (!existsSync(executablePath)) {
-    throw new Error(
-      `パッケージ版が見つからない(先に yarn package を実行する): ${executablePath}`,
-    );
+async function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+): Promise<T | typeof timedOut> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<typeof timedOut>((resolve) => {
+        timer = setTimeout(() => resolve(timedOut), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
   }
-  const userDataDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-userdata-'));
-  if (options?.config) {
-    // electron-store の実体は userData/config.json の素の JSON なので、
-    // 起動前に書いておくだけで設定済み状態を再現できる
-    writeFileSync(
-      path.join(userDataDir, 'config.json'),
-      JSON.stringify(options.config),
-    );
-  }
-  const app = await _electron.launch({
-    executablePath,
-    args: [`--user-data-dir=${userDataDir}`],
-  });
-  return { app, userDataDir };
 }
+
+/**
+ * Closes the app, force-killing the process tree if the graceful close does
+ * not finish in time.
+ * app.close() は「アプリが自発的に終了する」のを無期限に待つため、main
+ * プロセスが固まっている(同期ダイアログ表示中・ダウンロード停滞等)と
+ * 永遠に返らない。放置すると worker プロセスの終了処理でも同じ graceful
+ * close が走って二重にハングするので、ここで時間を区切って必ず殺し切る。
+ * @param {ElectronApplication} app - The launched Electron application.
+ */
+async function closeOrKill(app: ElectronApplication): Promise<void> {
+  const proc = app.process();
+  const exited = new Promise<void>((resolve) => {
+    if (proc.exitCode !== null || proc.signalCode !== null) resolve();
+    else proc.once('exit', () => resolve());
+  });
+  const closed = await withTimeout(
+    // kill 後に reject されても unhandled rejection にしない
+    app.close().catch((): undefined => undefined),
+    15_000,
+  );
+  if (closed === timedOut) {
+    if (process.platform === 'win32') {
+      // ChildProcess.kill() は renderer 等の子プロセスまでは殺せないため、
+      // Windows はプロセスツリーごと taskkill する
+      try {
+        execFileSync('taskkill', ['/pid', String(proc.pid), '/t', '/f'], {
+          stdio: 'ignore',
+        });
+      } catch {
+        // 競合してすでに終了していた場合は何もしない
+      }
+    } else {
+      proc.kill('SIGKILL');
+    }
+  }
+  await withTimeout(exited, 10_000);
+}
+
+type LaunchOptions = {
+  /**
+   * Initial contents of config.json (electron-store). Omit to start from a
+   * clean profile.
+   */
+  config?: Record<string, unknown>;
+};
+
+type Fixtures = {
+  /**
+   * Registers a teardown function. Registered functions run in LIFO order
+   * after the test, even when the test itself times out (テスト本体の
+   * try/finally はタイムアウト時に完走しないため、後始末は必ずこちらに
+   * 登録する).
+   */
+  cleanup: (fn: () => void | Promise<void>) => void;
+  /**
+   * Launches the packaged app with an isolated (temporary) userData
+   * directory so that tests never touch the real profile. Closing the app
+   * and removing the directory are registered to the cleanup fixture.
+   */
+  launchApp: (options?: LaunchOptions) => Promise<ElectronApplication>;
+};
+
+export const test = base.extend<Fixtures>({
+  // Playwright は第 1 引数の分割代入パターンから依存 fixture を検出するため、
+  // 依存なしでも {} 以外(_ 等の識別子)は書けない
+  // eslint-disable-next-line no-empty-pattern
+  cleanup: async ({}, use) => {
+    const fns: (() => void | Promise<void>)[] = [];
+    await use((fn) => {
+      fns.push(fn);
+    });
+    for (const fn of fns.reverse()) await fn();
+  },
+  launchApp: async ({ cleanup }, use) => {
+    await use(async (options) => {
+      const executablePath = packagedExecutablePath();
+      if (!existsSync(executablePath)) {
+        throw new Error(
+          `パッケージ版が見つからない(先に yarn package を実行する): ${executablePath}`,
+        );
+      }
+      const userDataDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-userdata-'));
+      if (options?.config) {
+        // electron-store の実体は userData/config.json の素の JSON なので、
+        // 起動前に書いておくだけで設定済み状態を再現できる
+        writeFileSync(
+          path.join(userDataDir, 'config.json'),
+          JSON.stringify(options.config),
+        );
+      }
+      const app = await _electron.launch({
+        executablePath,
+        args: [`--user-data-dir=${userDataDir}`],
+      });
+      cleanup(async () => {
+        await closeOrKill(app);
+        // 強制 kill 直後はファイルロックが残ることがあるためリトライ付き
+        rmSync(userDataDir, {
+          recursive: true,
+          force: true,
+          maxRetries: 5,
+          retryDelay: 200,
+        });
+      });
+      return app;
+    });
+  },
+});
+
+export { expect };
 
 /**
  * Returns the main window, waiting for it if it has not opened yet.

--- a/e2e/install.spec.ts
+++ b/e2e/install.spec.ts
@@ -1,9 +1,8 @@
-import { expect, test } from '@playwright/test';
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { createZip, serveFixtures, writeDataSet } from './fixtures';
-import { getMainWindow, launchIsolated } from './helpers';
+import { expect, getMainWindow, test } from './helpers';
 
 /**
  * Writes the fixtures: the initial data set (without the dummy plugin) under
@@ -40,9 +39,13 @@ function writeFixtures(fixturesDir: string, workDir: string, baseUrl: string) {
   });
 }
 
-test('dataURL の差し替えとパッケージのインストール・アンインストールができる', async () => {
+test('dataURL の差し替えとパッケージのインストール・アンインストールができる', async ({
+  cleanup,
+  launchApp,
+}) => {
   // --- フィクスチャと配信サーバ ---
   const workDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-'));
+  cleanup(() => rmSync(workDir, { recursive: true, force: true }));
   const fixturesDir = path.join(workDir, 'fixtures');
   const initialInstPath = path.join(workDir, 'aviutl-initial');
   const instPath = path.join(workDir, 'aviutl');
@@ -50,89 +53,83 @@ test('dataURL の差し替えとパッケージのインストール・アンイ
   mkdirSync(instPath, { recursive: true });
 
   const { baseUrl, close } = await serveFixtures(fixturesDir);
+  cleanup(close);
   writeFixtures(fixturesDir, workDir, baseUrl);
 
   // 設定済みプロファイルを事前シードして起動する。dataVersion が無いと
   // migration がダイアログを出すため必ず '3' を入れる。初期のデータ取得先も
   // フィクスチャに向け、テスト全体を実ネットワーク非依存にする
-  const { app, userDataDir } = await launchIsolated({
+  const app = await launchApp({
     config: {
       dataVersion: '3',
       installationPath: initialInstPath,
       dataURL: { main: `${baseUrl}/initial/`, extra: '' },
     },
   });
-  try {
-    const window = await getMainWindow(app);
-    // preload の初期化フロー完了を待つ(完了するとインストール先が入る)
-    await expect(window.locator('#installation-path')).toHaveValue(
-      initialInstPath,
-      { timeout: 120_000 },
-    );
+  const window = await getMainWindow(app);
+  // preload の初期化フロー完了を待つ(完了するとインストール先が入る)
+  await expect(window.locator('#installation-path')).toHaveValue(
+    initialInstPath,
+    { timeout: 120_000 },
+  );
 
-    // フォルダ選択のネイティブダイアログはモックして固定のパスを返す
-    const mockOpenDialog = (dir: string) =>
-      app.evaluate(({ dialog }, filePath) => {
-        dialog.showOpenDialog = () =>
-          Promise.resolve({ canceled: false, filePaths: [filePath] });
-      }, dir);
+  // フォルダ選択のネイティブダイアログはモックして固定のパスを返す
+  const mockOpenDialog = (dir: string) =>
+    app.evaluate(({ dialog }, filePath) => {
+      dialog.showOpenDialog = () =>
+        Promise.resolve({ canceled: false, filePaths: [filePath] });
+    }, dir);
 
-    // インストール先をテスト用フォルダへ変更
-    await mockOpenDialog(instPath);
-    await window
-      .getByRole('button', { name: 'AviUtlインストールフォルダを選択' })
-      .click();
-    await expect(window.locator('#installation-path')).toHaveValue(instPath, {
-      timeout: 120_000,
-    });
+  // インストール先をテスト用フォルダへ変更
+  await mockOpenDialog(instPath);
+  await window
+    .getByRole('button', { name: 'AviUtlインストールフォルダを選択' })
+    .click();
+  await expect(window.locator('#installation-path')).toHaveValue(instPath, {
+    timeout: 120_000,
+  });
 
-    // 差し替え前のデータにはダミープラグインが存在しない
-    await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
-    const row = window.locator('#packages-list li', {
-      hasText: 'E2E ダミープラグイン',
-    });
-    await expect(row).toHaveCount(0);
+  // 差し替え前のデータにはダミープラグインが存在しない
+  await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
+  const row = window.locator('#packages-list li', {
+    hasText: 'E2E ダミープラグイン',
+  });
+  await expect(row).toHaveCount(0);
 
-    // データ取得先をダミープラグイン入りのデータへ変更
-    await window.getByRole('tab', { name: '設定' }).click();
-    await window.locator('#data-url').fill(baseUrl);
-    await window.locator('#set-data-url').click();
-    await expect(window.locator('#set-data-url')).toHaveText('設定完了', {
-      timeout: 60_000,
-    });
+  // データ取得先をダミープラグイン入りのデータへ変更
+  await window.getByRole('tab', { name: '設定' }).click();
+  await window.locator('#data-url').fill(baseUrl);
+  await window.locator('#set-data-url').click();
+  await expect(window.locator('#set-data-url')).toHaveText('設定完了', {
+    timeout: 60_000,
+  });
 
-    // パッケージ一覧を再取得するとダミープラグインが現れる
-    await window.locator('#check-packages-list').click();
-    await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
-    await expect(row).toBeVisible({ timeout: 120_000 });
+  // パッケージ一覧を再取得するとダミープラグインが現れる
+  await window.locator('#check-packages-list').click();
+  await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
+  await expect(row).toBeVisible({ timeout: 120_000 });
 
-    // インストール(ダウンロード用ブラウザ窓が zip 直リンクを開き、
-    // ユーザー操作なしでダウンロードが完了する)
-    await row.click();
-    await window.locator('#install-package').click();
-    await expect(window.locator('#install-package')).toHaveText(
-      'インストール完了',
-      { timeout: 120_000 },
-    );
+  // インストール(ダウンロード用ブラウザ窓が zip 直リンクを開き、
+  // ユーザー操作なしでダウンロードが完了する)
+  await row.click();
+  await window.locator('#install-package').click();
+  await expect(window.locator('#install-package')).toHaveText(
+    'インストール完了',
+    { timeout: 120_000 },
+  );
 
-    // 実ファイルが置かれ、一覧の表示もインストール済みになる
-    expect(existsSync(path.join(instPath, 'dummy.auf'))).toBe(true);
-    await expect(row).toContainText('インストール済み');
+  // 実ファイルが置かれ、一覧の表示もインストール済みになる
+  expect(existsSync(path.join(instPath, 'dummy.auf'))).toBe(true);
+  await expect(row).toContainText('インストール済み');
 
-    // アンインストールすると実ファイルが消え、一覧の表示も戻る
-    // (インストール後の一覧再取得で選択が外れている場合に備えて再選択する)
-    await row.click();
-    await window.locator('#uninstall-package').click();
-    await expect(window.locator('#uninstall-package')).toHaveText(
-      'アンインストール完了',
-      { timeout: 120_000 },
-    );
-    expect(existsSync(path.join(instPath, 'dummy.auf'))).toBe(false);
-    await expect(row).not.toContainText('インストール済み');
-  } finally {
-    await app.close();
-    close();
-    rmSync(userDataDir, { recursive: true, force: true });
-    rmSync(workDir, { recursive: true, force: true });
-  }
+  // アンインストールすると実ファイルが消え、一覧の表示も戻る
+  // (インストール後の一覧再取得で選択が外れている場合に備えて再選択する)
+  await row.click();
+  await window.locator('#uninstall-package').click();
+  await expect(window.locator('#uninstall-package')).toHaveText(
+    'アンインストール完了',
+    { timeout: 120_000 },
+  );
+  expect(existsSync(path.join(instPath, 'dummy.auf'))).toBe(false);
+  await expect(row).not.toContainText('インストール済み');
 });

--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -1,34 +1,29 @@
-import { expect, test } from '@playwright/test';
-import { rmSync } from 'node:fs';
-import { getMainWindow, launchIsolated } from './helpers';
+import { expect, getMainWindow, test } from './helpers';
 
-test('起動して main 窓が開き、パッケージ一覧が描画される', async () => {
+test('起動して main 窓が開き、パッケージ一覧が描画される', async ({
+  launchApp,
+}) => {
   // クリーンな userData で起動し、実データでの初回起動フローを検証する
-  const { app, userDataDir } = await launchIsolated();
-  try {
-    const window = await getMainWindow(app);
+  const app = await launchApp();
+  const window = await getMainWindow(app);
 
-    const pageErrors: Error[] = [];
-    window.on('pageerror', (error) => pageErrors.push(error));
+  const pageErrors: Error[] = [];
+  window.on('pageerror', (error) => pageErrors.push(error));
 
-    await expect(window).toHaveTitle('AviUtl Package Manager');
+  await expect(window).toHaveTitle('AviUtl Package Manager');
 
-    // 初期表示は AviUtl タブ(インストール先が表示される)
-    await expect(window.locator('#installation-path')).toBeVisible();
+  // 初期表示は AviUtl タブ(インストール先が表示される)
+  await expect(window.locator('#installation-path')).toBeVisible();
 
-    // プラグイン&スクリプトタブへ切り替えると一覧が描画される
-    // (初回はパッケージ一覧のダウンロードを含むため長めに待つ)
-    await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
-    await expect(window.locator('#packages-list li').first()).toBeVisible({
-      timeout: 240_000,
-    });
+  // プラグイン&スクリプトタブへ切り替えると一覧が描画される
+  // (初回はパッケージ一覧のダウンロードを含むため長めに待つ)
+  await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
+  await expect(window.locator('#packages-list li').first()).toBeVisible({
+    timeout: 240_000,
+  });
 
-    expect(
-      pageErrors.map((e) => e.message),
-      'renderer で uncaught exception が発生していない',
-    ).toEqual([]);
-  } finally {
-    await app.close();
-    rmSync(userDataDir, { recursive: true, force: true });
-  }
+  expect(
+    pageErrors.map((e) => e.message),
+    'renderer で uncaught exception が発生していない',
+  ).toEqual([]);
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,6 +6,14 @@ export default defineConfig({
   testDir: './e2e',
   // 初回起動はパッケージ一覧のダウンロードを含むため長めに取る
   timeout: 300_000,
+  // launch.spec は実データ(CDN)依存で、CI ランナーのネットワーク都合で
+  // 散発的に落ちることがあるためリトライを 1 回だけ許す
+  retries: process.env.CI ? 1 : 0,
+  use: {
+    // 既定(0 = 無制限)だと click 等がテストタイムアウトまで待ち続けて
+    // 失敗箇所が分からなくなるため、単一操作は有限で打ち切る
+    actionTimeout: 60_000,
+  },
   // Electron アプリを同時に複数起動しない
   workers: 1,
   fullyParallel: false,


### PR DESCRIPTION
## 症状

PR #2386・#2396 の CI(windows-latest)で launch.spec が散発的に失敗していた(いずれも再実行で pass):

- `起動して main 窓が開き、パッケージ一覧が描画される` が `Test timeout of 300000ms exceeded`
- 併せて `worker-0 process did not exit within 300000ms after stop, force-killed it` / `Worker teardown timeout of 300000ms exceeded` が連鎖し、1 回のフレークで 10 分超を浪費

## 原因

失敗の引き金と、被害を拡大させていた構造の 2 段構え。

**引き金(根絶不能):** launch.spec は 3 テスト中唯一、実データ(jsdelivr CDN)への実ネットワーク依存で初回起動フローを検証する。ダウンロード経路(electron-dl 経由の `downloadFile`)にはタイムアウトが無く、ランナーのネットワークが stall すると一覧が永遠に描画されない。

**被害の拡大(今回の修正対象):** 後始末がテスト本体の `finally` にあった。

1. テストがタイムアウトすると Playwright はテスト関数を見捨てるため、`finally` の `app.close()` / `rmSync` が完走せず Electron プロセスが残留する
2. 残留プロセスは worker 終了時にも graceful close で回収が試みられるが、main プロセスが固まっている場合(`showMessageBoxSync` 等の同期ダイアログ表示中・ダウンロード停滞等)は CDP が応答せず `app.close()` は無期限に待つ — これが「worker が終了しない」の正体
3. 結果、テストタイムアウト 300 秒 + worker teardown 300 秒の二重ペナルティ

## 対策

- **後始末を fixture 化**(`cleanup` / `launchApp`): fixture の teardown はテスト本体がタイムアウトしても別枠で実行される。スペック側の HTTP サーバ・作業ディレクトリの片付けも LIFO 登録に置き換え、従来の `finally` と同じ順序を維持
- **`closeOrKill`**: graceful close に 15 秒の期限を設け、超過時は Windows では `taskkill /t /f` でプロセスツリーごと、その他は SIGKILL で強制終了。userData の削除はロック残留に備えてリトライ付き
- **CI のみ `retries: 1`**: 実ネットワーク起因の失敗自体は残るため、フレーク時のコストが数十秒に下がったうえで 1 回だけ再試行して緑にする
- **`actionTimeout: 60_000`**: 既定(無制限)だと click 等の失敗がテスト全体のタイムアウトに化けて切り分け不能になるため有限化

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(178 件)すべて緑
- `yarn package` → `yarn test:e2e` 3 テスト pass(9.0 秒)
- main プロセスを `while(true)` で意図的にフリーズさせる一時スペックで、teardown が 18.8 秒(close 期限 15 秒 + kill)で完走し残留プロセスが無いことを確認(検証用スペックはコミットに含めていない)

## 残課題(別 issue 候補)

- `downloadFile`(electron-dl)にタイムアウトが無い — stall 時にアプリ側が永遠に待つのは製品挙動なので、挙動変更として別途検討
- `log.errorHandler` の `showMessageBoxSync` は main プロセスのイベントループごと止めるため、ヘッドレス環境ではハング要因になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)