### PR TITLE
fix(main): showMessageBoxSync を非同期の showMessageBox に置き換え

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, MessageBoxSyncOptions } from 'electron';
+import { app, BrowserWindow, dialog, MessageBoxOptions } from 'electron';
 import debug from 'electron-debug';
 import log from 'electron-log/main';
 import Store from 'electron-store';
@@ -19,8 +19,12 @@ log.initialize({ preload: false });
 
 log.errorHandler.startCatching({
   showDialog: false,
-  onError: () => {
-    const options: MessageBoxSyncOptions = {
+  // showMessageBoxSync は main のイベントループごと止めるため使わない。
+  // ヘッドレス環境(CI の E2E 等)では誰も応答できず quit にも到達しない
+  // ハードハングになる(#2401)。electron-log は onError の戻り値(Promise)を
+  // 待たずにログを書くので、ダイアログ応答後の quit でもログは失われない
+  onError: async () => {
+    const options: MessageBoxOptions = {
       title: 'エラー',
       message: `予期しないエラーが発生したため、AviUtl Package Managerを終了します。\nログファイル: ${
         log.transports.file.getFile().path
@@ -28,7 +32,7 @@ log.errorHandler.startCatching({
       type: 'error',
     };
     if (app.isReady()) {
-      dialog.showMessageBoxSync(options);
+      await dialog.showMessageBox(options);
     } else {
       dialog.showErrorBox(options.title, options.message);
     }

--- a/src/main/services/appUpdate.ts
+++ b/src/main/services/appUpdate.ts
@@ -98,7 +98,9 @@ export async function checkUpdate(silent = true) {
   try {
     const data = (await response.json()) as { name?: string; notes?: string };
     if ('name' in data) {
-      const res = dialog.showMessageBoxSync({
+      // showMessageBoxSync はイベントループを止め、ヘッドレス環境で
+      // ハードハングするため使わない(#2401)
+      const { response } = await dialog.showMessageBox({
         title: 'アップデート',
         message:
           `${data.name}が公開されています。\n` +
@@ -110,7 +112,7 @@ export async function checkUpdate(silent = true) {
         type: 'info',
         icon: icon,
       });
-      if (res === 0) {
+      if (response === 0) {
         const releasePage = `https://github.com/${repo}/releases/latest`;
         await shell.openExternal(releasePage);
         app.quit();


### PR DESCRIPTION
## 概要

main プロセスに 2 箇所残っていた `dialog.showMessageBoxSync` を非同期の `showMessageBox` に置き換える(#2401 の案 A)。

同期ダイアログは main プロセスのイベントループを完全に止めるため、ヘッドレス環境(CI の E2E 等)では誰も応答できず、`app.quit()` にも Playwright の `electronApp.close()` にも到達しないハードハングになる(PR #2398 の調査で判明した潜在ハング要因)。非同期化によりダイアログ表示中もイベントループが生き、応答が無くても外部からの終了要求が処理できるため、「CI タイムアウトまでのハードハング」が「通常のテスト失敗」に変わる。

## 変更内容

- **`src/main/index.ts`(errorHandler の `onError`)**: async 化して「ダイアログ応答 → quit」の順序を維持。electron-log の `ErrorHandler.handle` は `onError` の戻り値を `result === false` と同期比較するだけで Promise を待たないため、エラーログはダイアログ応答前に確実に書かれる(同期版より安全な順序になる)
- **`src/main/services/appUpdate.ts`(`checkUpdate` の更新通知ダイアログ)**: 同じ関数内の他ダイアログ(オフライン時・最新時・404 時)はすでに `await dialog.showMessageBox` だったため、残っていた同期呼び出しを統一

`app.isReady()` 前の `showErrorBox` は Electron の仕様上 ready 前は Linux で stderr 出力になるため据え置き。

## 確認

- `yarn lint` / `yarn lint:ts` / `yarn test`(20 ファイル 187 テスト)すべて緑

Closes #2401

🤖 Generated with [Claude Code](https://claude.com/claude-code)
