### PR TITLE
fix(main): ダウンロード停滞時に electron-dl をキャンセルする

### DIFF
--- a/src/main/services/download.ts
+++ b/src/main/services/download.ts
@@ -1,5 +1,5 @@
-import { app, BrowserWindow } from 'electron';
-import { download } from 'electron-dl';
+import { app, BrowserWindow, type DownloadItem } from 'electron';
+import { CancelError, download } from 'electron-dl';
 import log from 'electron-log/main';
 import fs, { mkdir } from 'fs-extra';
 import path from 'node:path';
@@ -11,6 +11,64 @@ import { getHash } from '../../shared/getHash';
 // そのため並行実行すると保存先の取り違えや同一ファイルへの同時書き込み
 // (Windows ではロック違反で interrupted)が起きる。呼び出しを直列化して回避する
 let downloadChain: Promise<void> = Promise.resolve();
+
+// 受信バイト数がこの時間増えなかったらダウンロードを停滞と見なして中断する(#2399)
+const STALL_TIMEOUT_MS = 30_000;
+
+/**
+ * Downloads a URL, cancelling the download if no bytes arrive for a while.
+ * @param {BrowserWindow} win - The window that receives the download progress.
+ * @param {string} url - The URL to download.
+ * @param {object} opt - Options passed through to electron-dl.
+ * @param {boolean} opt.overwrite - Whether to overwrite an existing file.
+ * @param {string} opt.directory - The directory to save the file in.
+ * @param {string} opt.filename - Name of the saved file.
+ * @returns {Promise<void>} Resolves when the download completes.
+ */
+async function downloadWithStallGuard(
+  win: BrowserWindow,
+  url: string,
+  opt: { overwrite: boolean; directory: string; filename: string },
+) {
+  // 「開始から N 秒」の全体タイムアウトにはしない。遅い回線で大きなアーカイブを
+  // 落とすケースを打ち切ってしまうため、進んでいる限り待ち続け、止まったら切る。
+  // なお DownloadItem は onStarted(サーバー応答後)でしか取得できないため、
+  // 応答ヘッダが一度も届かないタイプの停滞はここでは中断できない
+  let item: DownloadItem | undefined;
+  let stalled = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let receivedBytes = -1;
+  const resetTimer = () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      stalled = true;
+      item?.cancel();
+    }, STALL_TIMEOUT_MS);
+  };
+  try {
+    await download(win, url, {
+      ...opt,
+      onStarted: (i) => {
+        item = i;
+        resetTimer();
+      },
+      onProgress: (progress) => {
+        if (progress.transferredBytes > receivedBytes) {
+          receivedBytes = progress.transferredBytes;
+          resetTimer();
+        }
+      },
+    });
+  } catch (e) {
+    // 停滞起因の CancelError はログから原因が分かるエラーに変換する
+    if (stalled && e instanceof CancelError) {
+      throw new Error(`Download stalled for ${STALL_TIMEOUT_MS}ms: ${url}`);
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 /**
  * Downloads a file (or copies a local file) into the data folder.
@@ -59,7 +117,9 @@ export async function downloadFile(
 
   try {
     if (url.startsWith('http')) {
-      const run = downloadChain.then(() => download(win, url, opt));
+      const run = downloadChain.then(() =>
+        downloadWithStallGuard(win, url, opt),
+      );
       downloadChain = run.then(
         (): void => undefined,
         (): void => undefined,


### PR DESCRIPTION
## 概要

`downloadFile` は electron-dl の `download()` をタイムアウトなしで await しており、ネットワークが stall すると呼び出し元が永遠に待ち続ける。ダウンロードが直列化されている(`downloadChain`)ため、1 件の stall が後続の全ダウンロードを連鎖的にブロックし、UI は「読み込み中のまま固まる」に見える。#2398 の E2E フレークの引き金でもあった。

Closes #2399

## 変更内容

- `downloadWithStallGuard` を追加: `onStarted` で `DownloadItem` を取得し、`onProgress` の受信バイト数が 30 秒増えなければ `item.cancel()` する
- 停滞起因の `CancelError` は原因が分かるエラー(`Download stalled for ...`)に変換してから既存の `catch` → `undefined` 返却の失敗経路に乗せる
- 全体タイムアウトではなく停滞検知にした理由(遅い回線での大容量取得を壊さない)と、`onStarted` 前の停滞は中断できない制約はコードコメントに記載

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`(187 件)すべて緑
- 実ネットワークでの stall 再現は困難なため、E2E は CI に委ねる

🤖 Generated with [Claude Code](https://claude.com/claude-code)