### PR TITLE
fix(main): v1 からの移行がデータ取得先のリセットでクラッシュする問題を修正

### DIFF
--- a/src/main/Config.ts
+++ b/src/main/Config.ts
@@ -69,6 +69,10 @@ export default class Config extends Store<StoreType> {
     hasMain: () => this.has('dataURL.main'),
     getMain: () => this.get('dataURL.main', ''),
     setMain: (url: string) => this.set('dataURL.main', url),
+    // conf は set(key, undefined) を拒否するため、未設定へ戻すのは delete で
+    // 行う。delete の型はトップレベルキー限定だが、実行時は get/set と同じく
+    // ドット記法に対応しているためキャストする
+    deleteMain: () => this.delete('dataURL.main' as keyof StoreType),
 
     hasExtra: () => this.has('dataURL.extra'),
     getExtra: () => this.get('dataURL.extra', ''),

--- a/src/main/services/migration.test.ts
+++ b/src/main/services/migration.test.ts
@@ -105,15 +105,18 @@ describe('migration service', () => {
       expect(mocks.showMessageBox).toHaveBeenCalledOnce();
     });
 
-    it('v1(旧デフォルト URL)からの移行は setMain(undefined) で例外になる(#2397 のバグ)', async () => {
-      // 本来は確認なしで v2 を経由して 3 まで進むべき経路。conf が
-      // undefined の set を拒否するため現行実装はクラッシュする。
-      // #2397 の修正時にこのテストを成功系へ書き換えること
+    it('v1(旧デフォルト URL)からは確認なしで v2 を経由して 3 まで進む', async () => {
+      // かつて setMain(undefined) が conf に拒否されクラッシュしていた経路
+      // (#2397)。デフォルト利用者は dataURL.main が未設定へ戻る
       config.dataURL.setMain(OLD_DEFAULT_DATA_URL);
 
-      await expect(migrationGlobal(win, config)).rejects.toThrow(
-        'Use `delete()` to clear values',
-      );
+      const result = await migrationGlobal(win, config);
+
+      expect(result).toBe(true);
+      expect(config.getDataVersion()).toBe('3');
+      expect(config.dataURL.hasMain()).toBe(false);
+      // v2→3 の案内ダイアログの 1 回だけ(v1→2 の確認は旧デフォルトなら出ない)
+      expect(mocks.showMessageBox).toHaveBeenCalledOnce();
     });
 
     it('v1(カスタム URL)でキャンセルを選ぶと false(起動中止)', async () => {

--- a/src/main/services/migration.ts
+++ b/src/main/services/migration.ts
@@ -139,7 +139,9 @@ async function migration1to2Global(
   // 2. Triggers initialization
   config.delete('modDate');
   // 3. Triggers initialization
-  if (useDefaultDataURL) config.dataURL.setMain(undefined);
+  // 旧実装の setMain(undefined) は conf が TypeError で拒否し、この移行が
+  // 必ずクラッシュしていた(#2397)
+  if (useDefaultDataURL) config.dataURL.deleteMain();
 
   // Finalize
   config.setDataVersion('2');


### PR DESCRIPTION
## 概要

#T1 の特性化テストで発見した現行バグ(#2397)の修正です。

`migration1to2Global` の `config.dataURL.setMain(undefined)` が conf の「undefined の set は不可(delete() を使う)」制約で TypeError になり、**デフォルトのデータ取得先を使っていた v1 ユーザーの移行が必ず失敗**していました。

## 変更内容

- `Config.dataURL.deleteMain()` を追加し、未設定へ戻す操作を delete で行う(conf の delete の型はトップレベルキー限定ですが、実行時は get/set と同じくドット記法対応のためキャスト。理由はコードコメントに記載)
- `migration.ts` の該当行を `deleteMain()` に置き換え
- 特性化テストの「throw を固定」していたケースを成功系(v1 → v3 へ収束・main が未設定へ復帰・ダイアログは v2→3 の案内 1 回のみ)へ書き換え

## テスト

`yarn lint` / `yarn lint:ts` / `yarn test`(242 tests)全緑

Closes #2397
Refs #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)