### PR TITLE
refactor(main): core と package のインストールフローを installFlow へ共通化

### DIFF
--- a/src/main/services/core.test.ts
+++ b/src/main/services/core.test.ts
@@ -4,6 +4,7 @@ import {
   ensureDir,
   mkdtemp,
   pathExists,
+  readFile,
   remove,
   writeFile,
   writeJson,
@@ -11,6 +12,7 @@ import {
 import { execFileSync } from 'node:child_process';
 import * as os from 'node:os';
 import path from 'node:path';
+import { fromData } from 'ssri';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import ApmJson from '../ApmJson';
 import Config from '../Config';
@@ -267,6 +269,51 @@ describe('core service', () => {
       expect(
         await installCoreProgram(win, config, 'aviutl', '1.10', instPath),
       ).toBe('corrupt');
+    });
+
+    it('integrity 不一致の再ダウンロードに失敗すると redownloadFailed', async () => {
+      const withIntegrity = structuredClone(coreInfo);
+      withIntegrity.aviutl.releases[0].integrity.archive =
+        'sha384-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+      await writeCachedCoreInfo(withIntegrity);
+      mocks.downloadFile.mockResolvedValueOnce(await makeCoreZip());
+      mocks.showMessageBox.mockResolvedValueOnce({ response: 0 });
+      mocks.downloadFile.mockResolvedValueOnce(undefined);
+
+      expect(
+        await installCoreProgram(win, config, 'aviutl', '1.10', instPath),
+      ).toBe('redownloadFailed');
+      expect(mocks.downloadFile).toHaveBeenLastCalledWith(
+        win,
+        'https://example.com/aviutl110.zip',
+        { subDir: 'core' },
+      );
+    });
+
+    it('integrity 不一致でも再ダウンロードで検証が通れば success', async () => {
+      const zipPath = await makeCoreZip();
+      const withIntegrity = structuredClone(coreInfo);
+      withIntegrity.aviutl.releases[0].integrity.archive = fromData(
+        await readFile(zipPath),
+        { algorithms: ['sha384'] },
+      ).toString();
+      await writeCachedCoreInfo(withIntegrity);
+      const corruptPath = path.join(
+        mocks.userDataDir.value,
+        'Data/core',
+        'corrupt.zip',
+      );
+      await writeFile(corruptPath, 'tampered');
+      mocks.downloadFile.mockResolvedValueOnce(corruptPath);
+      mocks.showMessageBox.mockResolvedValueOnce({ response: 0 });
+      mocks.downloadFile.mockResolvedValueOnce(zipPath);
+
+      expect(
+        await installCoreProgram(win, config, 'aviutl', '1.10', instPath),
+      ).toBe('success');
+      expect(await pathExists(path.join(instPath, 'aviutl.exe'))).toBe(true);
+      const apmJson = await ApmJson.load(instPath);
+      expect(await apmJson.get('core.aviutl')).toBe('1.10');
     });
   });
 

--- a/src/main/services/core.ts
+++ b/src/main/services/core.ts
@@ -1,16 +1,17 @@
 import type { Core, Program } from 'apm-schema';
-import { app, type BrowserWindow, dialog } from 'electron';
+import { app, type BrowserWindow } from 'electron';
 import log from 'electron-log/main';
 import { existsSync, readJson } from 'fs-extra';
 import path from 'node:path';
 import { installedVersionText } from '../../shared/coreVersionText';
 import { install, verifyFilesByCount } from '../../shared/install';
-import { checkIntegrity, verifyFile } from '../../shared/integrity';
+import { checkIntegrity } from '../../shared/integrity';
 import unzip from '../../shared/unzip';
 import ApmJson from '../ApmJson';
 import type Config from '../Config';
 import { addAviUtlShortcut, removeAviUtlShortcut } from '../shortcut';
 import { downloadFile } from './download';
+import { runInstallFlow } from './installFlow';
 import { migrationByFolder } from './migration';
 import { getCoreDataUrl, getInfo, updateInfo } from './modList';
 import { convertPackageIds, refreshPackagesList } from './packageList';
@@ -174,54 +175,40 @@ export async function installCoreProgram(
   const progInfo = coreInfo[program] as Program;
   const release = progInfo.releases.find((r) => r.version === version);
   const url = release.url;
-  let archivePath = await downloadFile(win, url, {
-    loadCache: true,
-    subDir: 'core',
-  });
 
-  if (!archivePath) {
-    log.error('Failed downloading a file.');
-    return 'downloadFailed';
-  }
-
-  const integrityForArchive = release.integrity.archive;
-
-  if (integrityForArchive) {
-    // Verify file integrity
-    while (!(await verifyFile(archivePath, integrityForArchive))) {
-      const dialogResult = await dialog.showMessageBox(win, {
-        title: 'エラー',
-        message:
-          'ダウンロードされたファイルは破損しています。再ダウンロードしますか？',
-        type: 'warning',
-        buttons: ['はい', 'いいえ'],
-        cancelId: 1,
+  return await runInstallFlow<'downloadFailed' | 'redownloadFailed'>(win, {
+    resolveArchive: async () => {
+      const archivePath = await downloadFile(win, url, {
+        loadCache: true,
+        subDir: 'core',
       });
-
-      if (dialogResult.response !== 0) {
-        log.error(`The downloaded archive file is corrupt. URL:${url}`);
-        return 'corrupt';
+      if (!archivePath) {
+        log.error('Failed downloading a file.');
+        return { failure: 'downloadFailed' as const };
       }
-
-      archivePath = await downloadFile(win, url, { subDir: 'core' });
+      return { archivePath };
+    },
+    integrity: release.integrity.archive,
+    corruptLogUrl: url,
+    redownloadArchive: async () => {
+      const archivePath = await downloadFile(win, url, { subDir: 'core' });
       if (!archivePath) {
         log.error(`Failed downloading the archive file. URL:${url}`);
-        return 'redownloadFailed';
+        return { failure: 'redownloadFailed' as const };
       }
-    }
-  }
+      return { archivePath };
+    },
+    install: async (archivePath) => {
+      const unzippedPath = await unzip(archivePath);
+      // install() の戻り値を検証しないのは旧実装のままの挙動
+      // (core は配置数の検証をせず、throw しなければ成功とみなす)
+      await install(unzippedPath, instPath, progInfo.files, true);
 
-  try {
-    const unzippedPath = await unzip(archivePath);
-    await install(unzippedPath, instPath, progInfo.files, true);
-
-    const apmJson = await ApmJson.load(instPath);
-    await apmJson.setCore(program, version);
-    return 'success';
-  } catch (e) {
-    log.error(e);
-    return 'installFailed';
-  }
+      const apmJson = await ApmJson.load(instPath);
+      await apmJson.setCore(program, version);
+      return true;
+    },
+  });
 }
 
 /**

--- a/src/main/services/installFlow.ts
+++ b/src/main/services/installFlow.ts
@@ -1,0 +1,71 @@
+import { type BrowserWindow, dialog } from 'electron';
+import log from 'electron-log/main';
+import { verifyFile } from '../../shared/integrity';
+
+/**
+ * アーカイブ取得の結果。取得できたらそのパス、できなければ呼び出し元固有の
+ * 失敗ステータス(downloadFailed / canceled 等)を返す。
+ */
+export type ArchiveResolution<TFailure extends string> =
+  { archivePath: string } | { failure: TFailure };
+
+/**
+ * Runs the common install flow: resolve the archive, verify its integrity
+ * (with a re-download loop), then install it.
+ * installCoreProgram と installPackageFlow に重複していた同型骨格の一本化。
+ * 取得経路・再取得経路・配置処理の挙動差は畳まず、コールバックとして
+ * 呼び出し元に残す(ログ出力もそれぞれのコールバック側の責務)。
+ * @param {BrowserWindow} win - A browser window used for dialogs.
+ * @param {object} flow - The flow definition.
+ * @param {() => Promise<ArchiveResolution<TFailure>>} flow.resolveArchive - Resolves the archive to install.
+ * @param {string} [flow.integrity] - The ssri integrity of the archive. Skips verification if falsy.
+ * @param {string} [flow.corruptLogUrl] - The URL logged when the user refuses to re-download.
+ * @param {() => Promise<ArchiveResolution<TFailure>>} flow.redownloadArchive - Re-resolves the archive after a verification failure.
+ * @param {(archivePath: string) => Promise<boolean>} flow.install - Installs the archive and returns whether it succeeded.
+ * @returns {Promise<'success' | 'corrupt' | 'installFailed' | TFailure>} The result status.
+ */
+export async function runInstallFlow<TFailure extends string>(
+  win: BrowserWindow,
+  flow: {
+    resolveArchive: () => Promise<ArchiveResolution<TFailure>>;
+    integrity: string | undefined;
+    corruptLogUrl: string | undefined;
+    redownloadArchive: () => Promise<ArchiveResolution<TFailure>>;
+    install: (archivePath: string) => Promise<boolean>;
+  },
+): Promise<'success' | 'corrupt' | 'installFailed' | TFailure> {
+  const resolved = await flow.resolveArchive();
+  if ('failure' in resolved) return resolved.failure;
+  let archivePath = resolved.archivePath;
+
+  if (flow.integrity) {
+    while (!(await verifyFile(archivePath, flow.integrity))) {
+      const dialogResult = await dialog.showMessageBox(win, {
+        title: 'エラー',
+        message:
+          'ダウンロードされたファイルは破損しています。再ダウンロードしますか？',
+        type: 'warning',
+        buttons: ['はい', 'いいえ'],
+        cancelId: 1,
+      });
+
+      if (dialogResult.response !== 0) {
+        log.error(
+          `The downloaded archive file is corrupt. URL:${flow.corruptLogUrl}`,
+        );
+        return 'corrupt';
+      }
+
+      const redownloaded = await flow.redownloadArchive();
+      if ('failure' in redownloaded) return redownloaded.failure;
+      archivePath = redownloaded.archivePath;
+    }
+  }
+
+  try {
+    return (await flow.install(archivePath)) ? 'success' : 'installFailed';
+  } catch (e) {
+    log.error(e);
+    return 'installFailed';
+  }
+}

--- a/src/main/services/packageInstall.ts
+++ b/src/main/services/packageInstall.ts
@@ -1,4 +1,4 @@
-import { app, type BrowserWindow, dialog, shell } from 'electron';
+import { app, type BrowserWindow, shell } from 'electron';
 import log from 'electron-log/main';
 import { existsSync, readdir as fsReaddir, mkdir, rename } from 'fs-extra';
 import { execFileSync } from 'node:child_process';
@@ -6,13 +6,13 @@ import path from 'node:path';
 import { isParent } from '../../shared/apmPath';
 import { install, verifyFilesByCount } from '../../shared/install';
 import { buildInstallerArgs } from '../../shared/installerArgs';
-import { verifyFile } from '../../shared/integrity';
 import unzip from '../../shared/unzip';
 import { PackageState } from '../../types/packageState';
 import ApmJson from '../ApmJson';
 import type Config from '../Config';
 import { openBrowser } from './browser';
 import { downloadFile } from './download';
+import { runInstallFlow } from './installFlow';
 
 /**
  * Get the date today
@@ -145,65 +145,45 @@ export async function installPackageFlow(
   packageItem: Pick<PackageState, 'id' | 'info'>,
   { direct = false, archivePath }: { direct?: boolean; archivePath?: string },
 ): Promise<InstallPackageResult> {
-  let resolvedArchivePath = '';
-  if (archivePath) {
-    resolvedArchivePath = archivePath;
-  } else if (direct) {
-    resolvedArchivePath = await downloadFile(win, packageItem.info.directURL, {
-      loadCache: true,
-      subDir: 'package',
-    });
-
-    if (!resolvedArchivePath) {
-      log.error('Failed downloading a file.');
-      return 'downloadFailed';
-    }
-  } else {
-    const downloadResult = await openBrowser(
-      win,
-      packageItem.info.downloadURLs[0],
-      'package',
-    );
-
-    if (!downloadResult) {
-      log.info('The installation was canceled.');
-      return 'canceled';
-    }
-
-    resolvedArchivePath = downloadResult.savePath;
-  }
-
-  // integrity があるなら取得経路(直リンク・手動 DL・archivePath 渡し)に
-  // よらず検証する。無いパッケージ(公式データの約 1/4)を弾かないのは、
-  // 検証必須化すると既存パッケージのインストールが広く壊れるため
-  const integrityForArchive = packageItem.info.releases?.find(
-    (r) => r.version === packageItem.info.latestVersion,
-  )?.integrity?.archive;
-
-  if (integrityForArchive) {
-    while (!(await verifyFile(resolvedArchivePath, integrityForArchive))) {
-      const dialogResult =
-        (
-          await dialog.showMessageBox(win, {
-            title: 'エラー',
-            message:
-              'ダウンロードされたファイルは破損しています。再ダウンロードしますか？',
-            type: 'warning',
-            buttons: ['はい', 'いいえ'],
-            cancelId: 1,
-          })
-        ).response === 0;
-
-      if (!dialogResult) {
-        log.error(
-          `The downloaded archive file is corrupt. URL:${packageItem.info.directURL}`,
+  return await runInstallFlow<
+    'downloadFailed' | 'canceled' | 'redownloadFailed'
+  >(win, {
+    resolveArchive: async () => {
+      if (archivePath) return { archivePath };
+      if (direct) {
+        const resolvedArchivePath = await downloadFile(
+          win,
+          packageItem.info.directURL,
+          { loadCache: true, subDir: 'package' },
         );
-        return 'corrupt';
+        if (!resolvedArchivePath) {
+          log.error('Failed downloading a file.');
+          return { failure: 'downloadFailed' as const };
+        }
+        return { archivePath: resolvedArchivePath };
       }
-
+      const downloadResult = await openBrowser(
+        win,
+        packageItem.info.downloadURLs[0],
+        'package',
+      );
+      if (!downloadResult) {
+        log.info('The installation was canceled.');
+        return { failure: 'canceled' as const };
+      }
+      return { archivePath: downloadResult.savePath };
+    },
+    // integrity があるなら取得経路(直リンク・手動 DL・archivePath 渡し)に
+    // よらず検証する。無いパッケージ(公式データの約 1/4)を弾かないのは、
+    // 検証必須化すると既存パッケージのインストールが広く壊れるため
+    integrity: packageItem.info.releases?.find(
+      (r) => r.version === packageItem.info.latestVersion,
+    )?.integrity?.archive,
+    corruptLogUrl: packageItem.info.directURL,
+    redownloadArchive: async () => {
       if (direct) {
         // 再ダウンロード先が subDir 'core' なのは旧実装のままの挙動
-        resolvedArchivePath = await downloadFile(
+        const resolvedArchivePath = await downloadFile(
           win,
           packageItem.info.directURL,
           { subDir: 'core' },
@@ -212,30 +192,25 @@ export async function installPackageFlow(
           log.error(
             `Failed downloading the archive file. URL:${packageItem.info.directURL}`,
           );
-          return 'redownloadFailed';
+          return { failure: 'redownloadFailed' as const };
         }
-      } else {
-        // 手動 DL・archivePath 渡しの経路はブラウザ窓での再取得になる
-        const redownloadResult = await openBrowser(
-          win,
-          packageItem.info.downloadURLs[0],
-          'package',
-        );
-        if (!redownloadResult) {
-          log.info('The installation was canceled.');
-          return 'canceled';
-        }
-        resolvedArchivePath = redownloadResult.savePath;
+        return { archivePath: resolvedArchivePath };
       }
-    }
-  }
-
-  const installResult = await installPackageArchive(
-    instPath,
-    resolvedArchivePath,
-    packageItem,
-  );
-  return installResult ? 'success' : 'installFailed';
+      // 手動 DL・archivePath 渡しの経路はブラウザ窓での再取得になる
+      const redownloadResult = await openBrowser(
+        win,
+        packageItem.info.downloadURLs[0],
+        'package',
+      );
+      if (!redownloadResult) {
+        log.info('The installation was canceled.');
+        return { failure: 'canceled' as const };
+      }
+      return { archivePath: redownloadResult.savePath };
+    },
+    install: (resolvedArchivePath) =>
+      installPackageArchive(instPath, resolvedArchivePath, packageItem),
+  });
 }
 
 /**


### PR DESCRIPTION
## 概要

Phase 5(#2379)スライス④(#A2-④)。`installCoreProgram` と `installPackageFlow` に重複していた同型骨格(アーカイブ取得 → integrity 検証と再ダウンロードのループ → 配置)を `services/installFlow.ts` の `runInstallFlow` に一本化します。設計方針どおり、**唯一「圧縮」を伴うスライス**なので、挙動差は畳まずコールバック引数として呼び出し元に温存しています。

## 変更内容

### コミット 1: 特性化テスト追加(共通化に先立つ固定)

これまで未固定だった `installCoreProgram` の再ダウンロード分岐 2 経路を現行実装のまま固定:
- 再ダウンロード失敗 → `redownloadFailed`(subDir 'core' への呼び出しも検証)
- 再ダウンロード成功 → ssri の実ハッシュで検証ループを通過して `success`

### コミット 2: 共通化

`runInstallFlow<TFailure>` が持つのは両者で**完全に同一**だった部分のみ:
- 破損ダイアログ(文言・ボタン・cancelId まで同一)
- corrupt への丸め込みとログ(URL は `corruptLogUrl` 引数)
- 配置の try/catch → `installFailed`

**温存した挙動差**(コールバック側に残置):
- 取得経路: core は直 URL、package は archivePath 渡し / 直リンク / ブラウザ窓の 3 経路(`canceled` は package のみ)
- 再取得経路: package 直リンクの再ダウンロード先が subDir 'core' に落ちる旧実装の癖(コメント維持)
- 配置処理: core が `install()` の戻り値を検証しない点は旧実装のままの挙動としてコメントで明示

## 検証

- [x] `yarn lint` / `yarn lint:ts` / `yarn test`(251 件 = 249 + 新規 2)すべて緑
- [x] Node 22 で `yarn package` + `yarn test:e2e`(3 件、core インストールの E2E 含む)緑

## 関連

#2379(#A2-④)。マージ後はスライス⑤(Installation 導入 + ApmJson → Ledger 改名)に進みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)