### PR TITLE
refactor: 命名総点検 — 全識別子をユビキタス言語へ統一(Phase 5 #A2-⑥)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,13 +45,13 @@ PR 前に上記 3 つ(lint / lint:ts / test)がすべて緑であること。
 
 ### 却下した選択肢(再提案しない)
 
-| 選択肢                                 | 却下理由                                                                                                                                                                                                                                                                       |
-| -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| v4 全面リライト(#2169)                 | 機能喪失リスクが大きく、コンフリクトも解消不能に近い。Strangler Fig の段階移行で置き換えた                                                                                                                                                                                     |
-| AviUtl2(ExEdit2)対応(#2163)            | プラグインが完全新形式で v1 と非互換のため apm-data の資産(285 件)が流用できない。instPath 単一基準のパス解決がインストーラ版 AviUtl2(exe と ProgramData 分離・要管理者昇格)と構造的に不適合。専用マネージャの aviutl2-catalog が 1 年先行しており、後発参入の投資対効果がない |
-| dataURL の allowlist 化                | 自作パッケージ・サードパーティデータの検証というユースケースを壊す                                                                                                                                                                                                             |
-| semantic-release / changesets への移行 | release-it + conventional-changelog で十分。ツール入れ替えのコストに見合わない                                                                                                                                                                                                 |
-| React 移行と同時の i18n 導入           | 移行の変更量を最小に保つため分離                                                                                                                                                                                                                                               |
+| 選択肢                                 | 却下理由                                                                                                                                                                                                                                                                               |
+| -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| v4 全面リライト(#2169)                 | 機能喪失リスクが大きく、コンフリクトも解消不能に近い。Strangler Fig の段階移行で置き換えた                                                                                                                                                                                             |
+| AviUtl2(ExEdit2)対応(#2163)            | プラグインが完全新形式で v1 と非互換のため apm-data の資産(285 件)が流用できない。installationPath 単一基準のパス解決がインストーラ版 AviUtl2(exe と ProgramData 分離・要管理者昇格)と構造的に不適合。専用マネージャの aviutl2-catalog が 1 年先行しており、後発参入の投資対効果がない |
+| dataURL の allowlist 化                | 自作パッケージ・サードパーティデータの検証というユースケースを壊す                                                                                                                                                                                                                     |
+| semantic-release / changesets への移行 | release-it + conventional-changelog で十分。ツール入れ替えのコストに見合わない                                                                                                                                                                                                         |
+| React 移行と同時の i18n 導入           | 移行の変更量を最小に保つため分離                                                                                                                                                                                                                                                       |
 
 ## 既知の固定と理由(上げる前に必ず読む)
 
@@ -67,6 +67,26 @@ PR 前に上記 3 つ(lint / lint:ts / test)がすべて緑であること。
 - 分からないこと・方針が割れることは質問してから進める
 - テストは意味のあるものだけ。過剰な抽象化・スコープ拡大は避ける
 - 書き分けの原則: **コードには How、テストコードには What、コミットログには Why、コードコメントには Why not**。コードコメントは「なぜこう書かないか(採らなかった選択肢・制約)」を残す場所で、コードを読めば分かることは書かない
+
+## ユビキタス言語(Phase 5 の設計しなおしで確定)
+
+ドメイン概念とコード上の名前の対応。新しい識別子はこの表に合わせる。
+
+| 概念                     | コード上の名前                                                                                                                                                                                          |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| インストール先(集約)     | `Installation` / `openInstallation`(`src/main/installation.ts`)。引数・変数の慣用略は `inst`、パス文字列は `installationPath`(Config キー・DOM id `#installation-path` と一致。`instPath` とは略さない) |
+| 導入記録                 | `Ledger`(`src/main/Ledger.ts`)。ディスク上の実体は `{installationPath}/apm.json`                                                                                                                        |
+| 状態付きパッケージ       | `PackageState`(`src/types/packageState.d.ts`)。変数も `packageState`                                                                                                                                    |
+| パッケージ ID とその変換 | `src/shared/packageId.ts` に一本化                                                                                                                                                                      |
+| ローカルリポジトリ       | `Installation.localRepoPath`(`{installationPath}/packages.json`)                                                                                                                                        |
+| データ取得先             | 概念・ドキュメント・UI 表記は **dataURL**、コード識別子は camelCase の **dataUrl** 系(`config.dataUrl` 等)                                                                                              |
+
+改名してはいけないもの(互換のための例外):
+
+- ディスク形式のキー・ファイル名: `config.json` のキー(`dataURL.main` / `migration1to2.oldDataURL` 等)、`apm.json`(ファイル名と `convertMod` 等のキー)
+- apm-schema 由来のフィールド(`pageURL` / `downloadURLs` 等)
+- インストーラ引数のプレースホルダ `$instpath`(ユーザーデータに書かれる書式)
+- JSDoc・コメントの「旧 〜 と同一の挙動」に現れる旧実装の識別子(歴史的記述)
 
 ## 言語規約
 
@@ -85,7 +105,7 @@ PR 前に上記 3 つ(lint / lint:ts / test)がすべて緑であること。
 
 機械化できる制約は ESLint で強制し、背景説明は該当コードのコメントに置く(ここには lint・型で守れない判断基準だけを残す)。lint 化済み: monaco-editor の型のみインポート、renderer / lib での fs 直接 import 禁止(いずれも `eslint.config.mjs` の `no-restricted-imports`)。コード側に説明があるもの: `compareVersion` の NaN 返却(JSDoc)、起動フローの順序(`src/renderer/main/startup.ts` のコメント)。
 
-- main 窓は単一 React ルートだが、複数箇所から共有する実行状態(一覧再取得の phase・instPath・firstLaunch)は `packages/packagesListCheck.ts` のようにモジュールシングルトン + `useSyncExternalStore` で持つ(起動元と表示側が別タブにまたがるため)。コンポーネント間の再取得通知は DOM イベント(`apm-packages-changed` / `apm-core-changed` / `apm-check-packages-list` / `apm-install-package-by-id`)が残っている(queryClient への一本化は Phase 5 の設計しなおしで検討)
+- main 窓は単一 React ルートだが、複数箇所から共有する実行状態(一覧再取得の phase・installationPath・firstLaunch)は `packages/packagesListCheck.ts` のようにモジュールシングルトン + `useSyncExternalStore` で持つ(起動元と表示側が別タブにまたがるため)。コンポーネント間の再取得通知は DOM イベント(`apm-packages-changed` / `apm-core-changed` / `apm-check-packages-list` / `apm-install-package-by-id`)が残っている(queryClient への一本化は Phase 5 の設計しなおしで検討)
 - 1 窓に tRPC クライアントを複数作らない(main 窓は `TrpcProvider`、about 窓は `App` の 1 個ずつ)。複数作るとリクエスト ID が衝突し、**他方のリクエストへの応答で resolve される**。かつて preload 側クライアントと共存させるため `shared/trpcIdNamespace.ts` で ID 空間を偶奇分離していた — 再び複数が必要になったら git 履歴から復元する
 - メインワールドの React から import する shared モジュールは electron だけでなく **fs にも依存不可**(renderer の webpack ビルドに Node ポリフィルが無いため、fs-extra が混入するとビルドが落ちる)。直接 import は lint が検出するが、**shared モジュール経由の推移的な fs 依存は lint で検出できない**(webpack のビルド失敗が検出線)。表示用の定数・純関数は `src/shared/packageDisplay.ts` のように fs 非依存モジュールへ分離する
 - trpc-electron(electron-trpc の tRPC 11 対応フォーク。0.7.1 までの本家は tRPC 11 非互換)は falsy なトップレベル入力(`false` / `0` / `''`)を `undefined` に変換する(main ハンドラが `input: g ? deserialize(g) : void 0` と真偽値評価しているため)。tRPC procedure の入力にプリミティブの boolean / number を直接渡さず、必ずオブジェクトで包む(`{ update: boolean }` 等)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -39,7 +39,7 @@ src/main/
   ipcHandlers.ts  窓に依存しないレガシー IPC ハンドラの登録
   api/            tRPC ルーター(index = 集約、trpc = middleware、
                   ドメイン別ルーターの procedure から services/ を呼ぶ。
-                  instPath 入力は middleware が Installation に解決して渡す)
+                  installationPath 入力は middleware が Installation に解決して渡す)
   services/       ビジネスロジック(packageList / packageInstall /
                   packageUninstall / scriptInstall / packageShare / core /
                   download / modList / migration / appUpdate / settings /
@@ -47,7 +47,7 @@ src/main/
   Config.ts       electron-store による設定
   installation.ts インストール先の集約 Installation(path / ledger() /
                   localRepoPath)。ユースケース系 services が受け取る
-  Ledger.ts       導入記録 Ledger = {instPath}/apm.json の読み書き
+  Ledger.ts       導入記録 Ledger = {installationPath}/apm.json の読み書き
 ```
 
 ## データフロー(パッケージ管理の中核)
@@ -55,15 +55,15 @@ src/main/
 ```mermaid
 graph LR
   D[dataURL<br>既定: apm-data] -->|"download.ts"| T["一時ファイル<br>list.json / packages.json"]
-  L["{instPath}/packages.json<br>{instPath}/editorPackages.json"] --> M
+  L["{installationPath}/packages.json<br>{installationPath}/editorPackages.json"] --> M
   T --> M["パッケージ一覧<br>modList.ts + packageList.ts"]
   M --> I["インストール / 更新判定<br>installPackageFlow(packageInstall.ts)"]
-  I -->|"unzip + copy<br>(shared/install.ts)"| P["{instPath}/plugins, script 等"]
-  I -->|導入記録| A["{instPath}/apm.json<br>(Ledger)"]
+  I -->|"unzip + copy<br>(shared/install.ts)"| P["{installationPath}/plugins, script 等"]
+  I -->|導入記録| A["{installationPath}/apm.json<br>(Ledger)"]
 ```
 
 - dataURL は自由入力(allowlist しない)。防御は `src/shared/resolvePath.ts` の同一オリジン + 親ディレクトリ脱出禁止(確定方針)
-- `{instPath}` = ユーザーが選ぶ AviUtl インストールフォルダ。apm の状態はすべてここと electron-store(`Config.ts`)にある
+- `{installationPath}` = ユーザーが選ぶ AviUtl インストールフォルダ。apm の状態はすべてここと electron-store(`Config.ts`)にある
 - ファイルの整合性は apm-data 側の ssri ハッシュを `src/shared/integrity.ts` で検証
 
 ## このドキュメントの更新

--- a/e2e/core.spec.ts
+++ b/e2e/core.spec.ts
@@ -9,8 +9,8 @@ test('AviUtl 本体のインストールができる', async ({ cleanup, launchA
   const workDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-core-'));
   cleanup(() => rmSync(workDir, { recursive: true, force: true }));
   const fixturesDir = path.join(workDir, 'fixtures');
-  const instPath = path.join(workDir, 'aviutl');
-  mkdirSync(instPath, { recursive: true });
+  const installationPath = path.join(workDir, 'aviutl');
+  mkdirSync(installationPath, { recursive: true });
 
   const { baseUrl, close } = await serveFixtures(fixturesDir);
   cleanup(close);
@@ -33,15 +33,18 @@ test('AviUtl 本体のインストールができる', async ({ cleanup, launchA
   const app = await launchApp({
     config: {
       dataVersion: '3',
-      installationPath: instPath,
+      installationPath: installationPath,
       dataURL: { main: baseUrl, extra: '' },
     },
   });
   const window = await getMainWindow(app);
   // preload の初期化フロー完了を待つ(完了するとインストール先が入る)
-  await expect(window.locator('#installation-path')).toHaveValue(instPath, {
-    timeout: 120_000,
-  });
+  await expect(window.locator('#installation-path')).toHaveValue(
+    installationPath,
+    {
+      timeout: 120_000,
+    },
+  );
 
   // バージョン選択ドロップダウンから最新版(1.10)をインストールする
   await window.locator('#install-aviutl').click();
@@ -54,7 +57,7 @@ test('AviUtl 本体のインストールができる', async ({ cleanup, launchA
   );
 
   // 実ファイルが置かれ、インストール済みバージョンが表示される
-  expect(existsSync(path.join(instPath, 'aviutl.exe'))).toBe(true);
+  expect(existsSync(path.join(installationPath, 'aviutl.exe'))).toBe(true);
   await expect(window.locator('#aviutl-installed-version')).toContainText(
     'バージョン: 1.10',
   );

--- a/e2e/install.spec.ts
+++ b/e2e/install.spec.ts
@@ -48,9 +48,9 @@ test('dataURL の差し替えとパッケージのインストール・アンイ
   cleanup(() => rmSync(workDir, { recursive: true, force: true }));
   const fixturesDir = path.join(workDir, 'fixtures');
   const initialInstPath = path.join(workDir, 'aviutl-initial');
-  const instPath = path.join(workDir, 'aviutl');
+  const installationPath = path.join(workDir, 'aviutl');
   mkdirSync(initialInstPath, { recursive: true });
-  mkdirSync(instPath, { recursive: true });
+  mkdirSync(installationPath, { recursive: true });
 
   const { baseUrl, close } = await serveFixtures(fixturesDir);
   cleanup(close);
@@ -81,13 +81,16 @@ test('dataURL の差し替えとパッケージのインストール・アンイ
     }, dir);
 
   // インストール先をテスト用フォルダへ変更
-  await mockOpenDialog(instPath);
+  await mockOpenDialog(installationPath);
   await window
     .getByRole('button', { name: 'AviUtlインストールフォルダを選択' })
     .click();
-  await expect(window.locator('#installation-path')).toHaveValue(instPath, {
-    timeout: 120_000,
-  });
+  await expect(window.locator('#installation-path')).toHaveValue(
+    installationPath,
+    {
+      timeout: 120_000,
+    },
+  );
 
   // 差し替え前のデータにはダミープラグインが存在しない
   await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
@@ -119,7 +122,7 @@ test('dataURL の差し替えとパッケージのインストール・アンイ
   );
 
   // 実ファイルが置かれ、一覧の表示もインストール済みになる
-  expect(existsSync(path.join(instPath, 'dummy.auf'))).toBe(true);
+  expect(existsSync(path.join(installationPath, 'dummy.auf'))).toBe(true);
   await expect(row).toContainText('インストール済み');
 
   // アンインストールすると実ファイルが消え、一覧の表示も戻る
@@ -130,6 +133,6 @@ test('dataURL の差し替えとパッケージのインストール・アンイ
     'アンインストール完了',
     { timeout: 120_000 },
   );
-  expect(existsSync(path.join(instPath, 'dummy.auf'))).toBe(false);
+  expect(existsSync(path.join(installationPath, 'dummy.auf'))).toBe(false);
   await expect(row).not.toContainText('インストール済み');
 });

--- a/src/main/Config.test.ts
+++ b/src/main/Config.test.ts
@@ -32,12 +32,12 @@ describe('Config', () => {
       expect(config.hasInstallationPath()).toBe(false);
       expect(config.getInstallationPath()).toBe('');
 
-      expect(config.dataURL.hasMain()).toBe(false);
-      expect(config.dataURL.getMain()).toBe('');
-      expect(config.dataURL.hasExtra()).toBe(false);
-      expect(config.dataURL.getExtra()).toBe('');
-      expect(config.dataURL.hasPackages()).toBe(false);
-      expect(config.dataURL.getPackages()).toEqual([]);
+      expect(config.dataUrl.hasMain()).toBe(false);
+      expect(config.dataUrl.getMain()).toBe('');
+      expect(config.dataUrl.hasExtra()).toBe(false);
+      expect(config.dataUrl.getExtra()).toBe('');
+      expect(config.dataUrl.hasPackages()).toBe(false);
+      expect(config.dataUrl.getPackages()).toEqual([]);
 
       expect(config.modDate.hasCore()).toBe(false);
       expect(config.modDate.getCore()).toBe(0);
@@ -77,12 +77,12 @@ describe('Config', () => {
       config.setZoomFactor('125');
       expect(config.getZoomFactor()).toBe('125');
 
-      config.dataURL.setMain('https://example.com/data/');
-      config.dataURL.setExtra('https://example.com/extra/');
-      config.dataURL.setPackages(['https://example.com/packages.json']);
-      expect(config.dataURL.getMain()).toBe('https://example.com/data/');
-      expect(config.dataURL.getExtra()).toBe('https://example.com/extra/');
-      expect(config.dataURL.getPackages()).toEqual([
+      config.dataUrl.setMain('https://example.com/data/');
+      config.dataUrl.setExtra('https://example.com/extra/');
+      config.dataUrl.setPackages(['https://example.com/packages.json']);
+      expect(config.dataUrl.getMain()).toBe('https://example.com/data/');
+      expect(config.dataUrl.getExtra()).toBe('https://example.com/extra/');
+      expect(config.dataUrl.getPackages()).toEqual([
         'https://example.com/packages.json',
       ]);
 
@@ -105,7 +105,7 @@ describe('Config', () => {
       const cwd = await makeCwd();
       const config = new Config({ cwd });
 
-      config.dataURL.setMain('https://example.com/data/');
+      config.dataUrl.setMain('https://example.com/data/');
       config.modDate.setCore(123);
 
       // ドット区切りのキーはフラットな 'dataURL.main' ではなく入れ子で保存される

--- a/src/main/Config.ts
+++ b/src/main/Config.ts
@@ -1,5 +1,8 @@
 import Store from 'electron-store';
 
+// キー名はディスク上の config.json の形式そのもの。dataURL / oldDataURL /
+// newDataURL を識別子規約(dataUrl)に合わせて改名すると既存ユーザーの設定を
+// 読めなくなるため、ここでは大文字 URL のまま維持する
 type StoreType = {
   dataVersion: '1' | '2' | '3';
   installationPath: string;
@@ -65,7 +68,7 @@ export default class Config extends Store<StoreType> {
     this.set('installationPath', path);
   }
 
-  public dataURL = {
+  public dataUrl = {
     hasMain: () => this.has('dataURL.main'),
     getMain: () => this.get('dataURL.main', ''),
     setMain: (url: string) => this.set('dataURL.main', url),

--- a/src/main/Ledger.test.ts
+++ b/src/main/Ledger.test.ts
@@ -38,8 +38,8 @@ describe('Ledger', () => {
 
   describe('load', () => {
     it('apm.json が存在しないときは既定のオブジェクトで初期化される', async () => {
-      const instPath = await makeInstPath();
-      const ledger = await Ledger.load(instPath);
+      const installationPath = await makeInstPath();
+      const ledger = await Ledger.load(installationPath);
 
       expect(await ledger.get('dataVersion')).toBe('3');
       expect(await ledger.get('core')).toEqual({});
@@ -47,18 +47,18 @@ describe('Ledger', () => {
     });
 
     it('apm.json が存在しなくても load だけではファイルを作成しない', async () => {
-      const instPath = await makeInstPath();
-      await Ledger.load(instPath);
+      const installationPath = await makeInstPath();
+      await Ledger.load(installationPath);
 
-      expect(await pathExists(Ledger.getPath(instPath))).toBe(false);
+      expect(await pathExists(Ledger.getPath(installationPath))).toBe(false);
     });
 
     it('apm.json が壊れているときは既定値になり、ファイルは書き換えられない', async () => {
-      const instPath = await makeInstPath();
-      const jsonPath = Ledger.getPath(instPath);
+      const installationPath = await makeInstPath();
+      const jsonPath = Ledger.getPath(installationPath);
       await fsPromises.writeFile(jsonPath, 'not a json {{{');
 
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
 
       expect(await ledger.get('dataVersion')).toBe('3');
       // 次の set まで壊れたファイルはそのまま残る(現行仕様)
@@ -70,15 +70,15 @@ describe('Ledger', () => {
 
   describe('get / has', () => {
     it('ドット区切りのパスでネストした値を取得できる', async () => {
-      const instPath = await makeInstPath();
-      await writeJson(Ledger.getPath(instPath), {
+      const installationPath = await makeInstPath();
+      await writeJson(Ledger.getPath(installationPath), {
         dataVersion: '3',
         core: { aviutl: '1.10', exedit: '0.92' },
         packages: {
           'author/plugin': { id: 'author/plugin', version: 'v1.0.0' },
         },
       });
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
 
       expect(await ledger.get('core.aviutl')).toBe('1.10');
       expect(await ledger.get('packages')).toEqual({
@@ -89,8 +89,8 @@ describe('Ledger', () => {
     });
 
     it('存在しないキーは undefined、defaultValue 指定時はそれを返す', async () => {
-      const instPath = await makeInstPath();
-      const ledger = await Ledger.load(instPath);
+      const installationPath = await makeInstPath();
+      const ledger = await Ledger.load(installationPath);
 
       expect(await ledger.get('convertMod')).toBeUndefined();
       expect(await ledger.get('convertMod', 0)).toBe(0);
@@ -103,9 +103,9 @@ describe('Ledger', () => {
 
   describe('set / delete(即時書き込み)', () => {
     it('set は即座にファイルへ書き込む(ファイルが無ければ新規作成する)', async () => {
-      const instPath = await makeInstPath();
-      const jsonPath = Ledger.getPath(instPath);
-      const ledger = await Ledger.load(instPath);
+      const installationPath = await makeInstPath();
+      const jsonPath = Ledger.getPath(installationPath);
+      const ledger = await Ledger.load(installationPath);
 
       await ledger.set('core.aviutl', '1.10');
 
@@ -118,9 +118,9 @@ describe('Ledger', () => {
     });
 
     it('連続した set はそのたびに全体を書き込む', async () => {
-      const instPath = await makeInstPath();
-      const jsonPath = Ledger.getPath(instPath);
-      const ledger = await Ledger.load(instPath);
+      const installationPath = await makeInstPath();
+      const jsonPath = Ledger.getPath(installationPath);
+      const ledger = await Ledger.load(installationPath);
 
       await ledger.set('core.aviutl', '1.10');
       const afterFirst = await readJson(jsonPath);
@@ -132,9 +132,9 @@ describe('Ledger', () => {
     });
 
     it('delete はキーが無くてもファイルへ書き込み、親パスが辿れる限り true を返す', async () => {
-      const instPath = await makeInstPath();
-      const jsonPath = Ledger.getPath(instPath);
-      const ledger = await Ledger.load(instPath);
+      const installationPath = await makeInstPath();
+      const jsonPath = Ledger.getPath(installationPath);
+      const ledger = await Ledger.load(installationPath);
 
       // 存在しないキーの delete でも save が走り、ファイルが作成される(現行仕様)
       // 戻り値は「削除したかどうか」ではなく「親パスまで辿れたかどうか」(dot-prop 由来の現行仕様)
@@ -151,9 +151,9 @@ describe('Ledger', () => {
 
   describe('setCore / addPackage / removePackage', () => {
     it('setCore と addPackage は所定のキーに書き込み、removePackage で消える', async () => {
-      const instPath = await makeInstPath();
-      const jsonPath = Ledger.getPath(instPath);
-      const ledger = await Ledger.load(instPath);
+      const installationPath = await makeInstPath();
+      const jsonPath = Ledger.getPath(installationPath);
+      const ledger = await Ledger.load(installationPath);
 
       await ledger.setCore('aviutl', '1.10');
       await ledger.addPackage('author/plugin', 'v1.2.3');
@@ -171,8 +171,8 @@ describe('Ledger', () => {
     });
 
     it('ドットを含むパッケージ ID はネストしたキーとして解釈される(dot-prop 由来の現行仕様)', async () => {
-      const instPath = await makeInstPath();
-      const ledger = await Ledger.load(instPath);
+      const installationPath = await makeInstPath();
+      const ledger = await Ledger.load(installationPath);
 
       await ledger.addPackage('author/plugin.en', 'v1.0.0');
 
@@ -187,9 +187,9 @@ describe('Ledger', () => {
 
   describe('begin / commit(トランザクション)', () => {
     it('begin 中の set は書き込みを遅延し、commit で 1 回だけ書き込む', async () => {
-      const instPath = await makeInstPath();
-      const jsonPath = Ledger.getPath(instPath);
-      const ledger = await Ledger.load(instPath);
+      const installationPath = await makeInstPath();
+      const jsonPath = Ledger.getPath(installationPath);
+      const ledger = await Ledger.load(installationPath);
 
       ledger.begin();
       await ledger.set('core.aviutl', '1.10');
@@ -210,14 +210,14 @@ describe('Ledger', () => {
     });
 
     it('begin 中の delete も遅延され、戻り値の意味は変わらない', async () => {
-      const instPath = await makeInstPath();
-      const jsonPath = Ledger.getPath(instPath);
+      const installationPath = await makeInstPath();
+      const jsonPath = Ledger.getPath(installationPath);
       await writeJson(jsonPath, {
         dataVersion: '3',
         core: { aviutl: '1.10' },
         packages: {},
       });
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
 
       ledger.begin();
       // 戻り値は「親パスまで辿れたかどうか」(即時書き込み時と同じ)
@@ -230,21 +230,21 @@ describe('Ledger', () => {
     });
 
     it('変更がないまま commit してもファイルを書き込まない', async () => {
-      const instPath = await makeInstPath();
-      const ledger = await Ledger.load(instPath);
+      const installationPath = await makeInstPath();
+      const ledger = await Ledger.load(installationPath);
 
       ledger.begin();
       // 存在しないキーの delete はオブジェクトを変更しないため dirty にならない
       await ledger.delete('nonexistent.parent.key');
       await ledger.commit();
 
-      expect(await pathExists(Ledger.getPath(instPath))).toBe(false);
+      expect(await pathExists(Ledger.getPath(installationPath))).toBe(false);
     });
 
     it('commit 後の set は従来どおり即時書き込みに戻る', async () => {
-      const instPath = await makeInstPath();
-      const jsonPath = Ledger.getPath(instPath);
-      const ledger = await Ledger.load(instPath);
+      const installationPath = await makeInstPath();
+      const jsonPath = Ledger.getPath(installationPath);
+      const ledger = await Ledger.load(installationPath);
 
       ledger.begin();
       await ledger.set('core.aviutl', '1.10');
@@ -260,14 +260,14 @@ describe('Ledger', () => {
 
   describe('round-trip', () => {
     it('書き込んだ内容を別インスタンスで読み直しても同じ値になる', async () => {
-      const instPath = await makeInstPath();
+      const installationPath = await makeInstPath();
 
-      const writer = await Ledger.load(instPath);
+      const writer = await Ledger.load(installationPath);
       await writer.setCore('aviutl', '1.10');
       await writer.setCore('exedit', '0.92');
       await writer.addPackage('author/plugin', 'v1.2.3');
 
-      expect(await readJson(Ledger.getPath(instPath))).toEqual({
+      expect(await readJson(Ledger.getPath(installationPath))).toEqual({
         dataVersion: '3',
         core: { aviutl: '1.10', exedit: '0.92' },
         packages: {
@@ -275,7 +275,7 @@ describe('Ledger', () => {
         },
       });
 
-      const reader = await Ledger.load(instPath);
+      const reader = await Ledger.load(installationPath);
       expect(await reader.get('core.aviutl')).toBe('1.10');
       expect(await reader.get('core.exedit')).toBe('0.92');
       expect(await reader.get('packages.author/plugin')).toEqual({

--- a/src/main/Ledger.ts
+++ b/src/main/Ledger.ts
@@ -19,21 +19,21 @@ class Ledger {
 
   /**
    * Gets the path to `apm.json`.
-   * @param {string} [instPath] - The path to the installation directory.
+   * @param {string} [installationPath] - The path to the installation directory.
    * @returns {string} The path to `apm.json`.
    */
-  public static getPath(instPath: string): string {
-    return path.join(instPath, 'apm.json');
+  public static getPath(installationPath: string): string {
+    return path.join(installationPath, 'apm.json');
   }
 
   /**
    * Creates an instance of Ledger.
-   * @param {string} [instPath] - The path to the installation directory.
+   * @param {string} [installationPath] - The path to the installation directory.
    * @returns {Promise<Ledger>} A promise that resolves with the instance of Ledger.
    */
-  public static async load(instPath: string): Promise<Ledger> {
+  public static async load(installationPath: string): Promise<Ledger> {
     const ledger = new Ledger();
-    const jsonPath = this.getPath(instPath);
+    const jsonPath = this.getPath(installationPath);
     await ledger.load(jsonPath);
     return ledger;
   }

--- a/src/main/api/core.ts
+++ b/src/main/api/core.ts
@@ -20,15 +20,24 @@ import {
 
 const installProgramInput = (
   value: unknown,
-): { program: 'aviutl' | 'exedit'; version: string; instPath: string } => {
+): {
+  program: 'aviutl' | 'exedit';
+  version: string;
+  installationPath: string;
+} => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { program, version, instPath } = value as Record<string, unknown>;
+  const { program, version, installationPath } = value as Record<
+    string,
+    unknown
+  >;
   if (program !== 'aviutl' && program !== 'exedit')
     throw new TypeError('program is expected to be aviutl or exedit.');
-  if (typeof version !== 'string' || typeof instPath !== 'string')
-    throw new TypeError('version and instPath are expected to be strings.');
-  return { program, version, instPath };
+  if (typeof version !== 'string' || typeof installationPath !== 'string')
+    throw new TypeError(
+      'version and installationPath are expected to be strings.',
+    );
+  return { program, version, installationPath };
 };
 
 export const coreRouter = t.router({

--- a/src/main/api/core.ts
+++ b/src/main/api/core.ts
@@ -2,10 +2,10 @@ import {
   changeInstallationPath,
   checkCoreLatestVersion,
   ensureInstallationPath,
-  getApmJsonCoreVersions,
   getCoreDates,
   getCoreInfo,
   getInstalledVersionTexts,
+  getLedgerCoreVersions,
   hasExeditInPluginsFolder,
   installCoreProgram,
 } from '../services/core';
@@ -43,9 +43,9 @@ export const coreRouter = t.router({
   changeInstallationPath: winInstProcedure
     .input(stringInput)
     .mutation(async ({ ctx }) => await changeInstallationPath(ctx, ctx.inst)),
-  getApmJsonCoreVersions: instProcedure
+  getLedgerCoreVersions: instProcedure
     .input(stringInput)
-    .query(async ({ ctx }) => await getApmJsonCoreVersions(ctx.inst)),
+    .query(async ({ ctx }) => await getLedgerCoreVersions(ctx.inst)),
   getInstalledVersionTexts: winInstProcedure
     .input(stringInput)
     .query(async ({ ctx }) => await getInstalledVersionTexts(ctx, ctx.inst)),

--- a/src/main/api/packages.ts
+++ b/src/main/api/packages.ts
@@ -11,9 +11,9 @@ import {
   getLedgerInstalledIds,
   getPackages,
   getPackagesDates,
-  getPackagesExtra,
   getPackagesWithStatus,
   refreshPackagesList,
+  resolveInstallationStatus,
 } from '../services/packageList';
 import {
   buildShareString,
@@ -138,15 +138,18 @@ const installedIdsInput = (
 
 const packagesWithStatusInput = (
   value: unknown,
-): { instPath: string; fixIntegrity: boolean } => {
+): { instPath: string; adoptManuallyInstalled: boolean } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { instPath, fixIntegrity } = value as Record<string, unknown>;
-  if (typeof instPath !== 'string' || typeof fixIntegrity !== 'boolean')
+  const { instPath, adoptManuallyInstalled } = value as Record<string, unknown>;
+  if (
+    typeof instPath !== 'string' ||
+    typeof adoptManuallyInstalled !== 'boolean'
+  )
     throw new TypeError(
-      'instPath is expected to be a string and fixIntegrity a boolean.',
+      'instPath is expected to be a string and adoptManuallyInstalled a boolean.',
     );
-  return { instPath, fixIntegrity };
+  return { instPath, adoptManuallyInstalled };
 };
 
 const editorPackagesInput = (
@@ -172,9 +175,9 @@ export const packagesRouter = t.router({
   refreshList: winInstProcedure.input(stringInput).mutation(async ({ ctx }) => {
     await refreshPackagesList(ctx, ctx.inst);
   }),
-  getPackagesExtra: winInstProcedure
+  resolveInstallationStatus: winInstProcedure
     .input(stringInput)
-    .query(async ({ ctx }) => await getPackagesExtra(ctx, ctx.inst)),
+    .query(async ({ ctx }) => await resolveInstallationStatus(ctx, ctx.inst)),
   getLedgerInstalledIds: instProcedure
     .input(installedIdsInput)
     .query(
@@ -195,7 +198,11 @@ export const packagesRouter = t.router({
   getPackagesWithStatus: winInstProcedure
     .input(packagesWithStatusInput)
     .query(async ({ input, ctx }) => {
-      return await getPackagesWithStatus(ctx, ctx.inst, input.fixIntegrity);
+      return await getPackagesWithStatus(
+        ctx,
+        ctx.inst,
+        input.adoptManuallyInstalled,
+      );
     }),
   installPackage: winInstProcedure
     .input(installPackageInput)

--- a/src/main/api/packages.ts
+++ b/src/main/api/packages.ts
@@ -57,25 +57,23 @@ const packageItemInput = (
 const installPackageInput = (
   value: unknown,
 ): {
-  instPath: string;
+  installationPath: string;
   packageItem: { id: string; info: Record<string, unknown> };
   direct: boolean;
   archivePath?: string;
 } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { instPath, packageItem, direct, archivePath } = value as Record<
-    string,
-    unknown
-  >;
-  if (typeof instPath !== 'string')
-    throw new TypeError('instPath is expected to be a string.');
+  const { installationPath, packageItem, direct, archivePath } =
+    value as Record<string, unknown>;
+  if (typeof installationPath !== 'string')
+    throw new TypeError('installationPath is expected to be a string.');
   if (typeof direct !== 'boolean')
     throw new TypeError('direct is expected to be a boolean.');
   if (archivePath !== undefined && typeof archivePath !== 'string')
     throw new TypeError('archivePath is expected to be a string.');
   return {
-    instPath,
+    installationPath,
     packageItem: packageItemInput(packageItem),
     direct,
     archivePath: archivePath as string | undefined,
@@ -85,87 +83,90 @@ const installPackageInput = (
 const uninstallPackageInput = (
   value: unknown,
 ): {
-  instPath: string;
+  installationPath: string;
   packageItem: { id: string; info: Record<string, unknown> };
 } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { instPath, packageItem } = value as Record<string, unknown>;
-  if (typeof instPath !== 'string')
-    throw new TypeError('instPath is expected to be a string.');
-  return { instPath, packageItem: packageItemInput(packageItem) };
+  const { installationPath, packageItem } = value as Record<string, unknown>;
+  if (typeof installationPath !== 'string')
+    throw new TypeError('installationPath is expected to be a string.');
+  return { installationPath, packageItem: packageItemInput(packageItem) };
 };
 
 const installScriptFlowInput = (
   value: unknown,
-): { instPath: string; url: string } => {
+): { installationPath: string; url: string } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { instPath, url } = value as Record<string, unknown>;
-  if (typeof instPath !== 'string' || typeof url !== 'string')
-    throw new TypeError('instPath and url are expected to be strings.');
+  const { installationPath, url } = value as Record<string, unknown>;
+  if (typeof installationPath !== 'string' || typeof url !== 'string')
+    throw new TypeError('installationPath and url are expected to be strings.');
   // ブラウザ窓で開く URL なので http(s) 以外(file: 等)を通さない
   if (!isHttpUrl(url))
     throw new TypeError('url is expected to be a http(s) URL.');
-  return { instPath, url };
+  return { installationPath, url };
 };
 
 const convertIdsInput = (
   value: unknown,
-): { instPath: string; modTime: number } => {
+): { installationPath: string; modTime: number } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { instPath, modTime } = value as Record<string, unknown>;
-  if (typeof instPath !== 'string' || typeof modTime !== 'number')
+  const { installationPath, modTime } = value as Record<string, unknown>;
+  if (typeof installationPath !== 'string' || typeof modTime !== 'number')
     throw new TypeError(
-      'instPath is expected to be a string and modTime a number.',
+      'installationPath is expected to be a string and modTime a number.',
     );
-  return { instPath, modTime };
+  return { installationPath, modTime };
 };
 
 const installedIdsInput = (
   value: unknown,
-): { instPath: string; ids: string[] } => {
+): { installationPath: string; ids: string[] } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { instPath, ids } = value as Record<string, unknown>;
-  if (typeof instPath !== 'string')
-    throw new TypeError('instPath is expected to be a string.');
+  const { installationPath, ids } = value as Record<string, unknown>;
+  if (typeof installationPath !== 'string')
+    throw new TypeError('installationPath is expected to be a string.');
   if (!(Array.isArray(ids) && ids.every((id) => typeof id === 'string')))
     throw new TypeError('ids is expected to be an array of strings.');
-  return { instPath, ids: ids as string[] };
+  return { installationPath, ids: ids as string[] };
 };
 
 const packagesWithStatusInput = (
   value: unknown,
-): { instPath: string; adoptManuallyInstalled: boolean } => {
+): { installationPath: string; adoptManuallyInstalled: boolean } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { instPath, adoptManuallyInstalled } = value as Record<string, unknown>;
+  const { installationPath, adoptManuallyInstalled } = value as Record<
+    string,
+    unknown
+  >;
   if (
-    typeof instPath !== 'string' ||
+    typeof installationPath !== 'string' ||
     typeof adoptManuallyInstalled !== 'boolean'
   )
     throw new TypeError(
-      'instPath is expected to be a string and adoptManuallyInstalled a boolean.',
+      'installationPath is expected to be a string and adoptManuallyInstalled a boolean.',
     );
-  return { instPath, adoptManuallyInstalled };
+  return { installationPath, adoptManuallyInstalled };
 };
 
 const editorPackagesInput = (
   value: unknown,
-): { instPath: string; packages: Record<string, unknown>[] } => {
+): { installationPath: string; packages: Record<string, unknown>[] } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { instPath, packages } = value as Record<string, unknown>;
-  if (typeof instPath !== 'string')
-    throw new TypeError('instPath is expected to be a string.');
+  const { installationPath, packages } = value as Record<string, unknown>;
+  if (typeof installationPath !== 'string')
+    throw new TypeError('installationPath is expected to be a string.');
   if (!(
     Array.isArray(packages) &&
     packages.every((p) => typeof p === 'object' && p !== null)
   ))
     throw new TypeError('packages is expected to be an array of objects.');
-  return { instPath, packages: packages as Record<string, unknown>[] };
+  return { installationPath, packages: packages as Record<string, unknown>[] };
 };
 
 export const packagesRouter = t.router({

--- a/src/main/api/packages.ts
+++ b/src/main/api/packages.ts
@@ -42,7 +42,7 @@ const scriptsListInput = (value: unknown): { update: boolean } => {
   return { update };
 };
 
-const packageItemInput = (
+const packageStateInput = (
   value: unknown,
 ): { id: string; info: Record<string, unknown> } => {
   if (typeof value !== 'object' || value === null)
@@ -58,13 +58,13 @@ const installPackageInput = (
   value: unknown,
 ): {
   installationPath: string;
-  packageItem: { id: string; info: Record<string, unknown> };
+  packageState: { id: string; info: Record<string, unknown> };
   direct: boolean;
   archivePath?: string;
 } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { installationPath, packageItem, direct, archivePath } =
+  const { installationPath, packageState, direct, archivePath } =
     value as Record<string, unknown>;
   if (typeof installationPath !== 'string')
     throw new TypeError('installationPath is expected to be a string.');
@@ -74,7 +74,7 @@ const installPackageInput = (
     throw new TypeError('archivePath is expected to be a string.');
   return {
     installationPath,
-    packageItem: packageItemInput(packageItem),
+    packageState: packageStateInput(packageState),
     direct,
     archivePath: archivePath as string | undefined,
   };
@@ -84,14 +84,14 @@ const uninstallPackageInput = (
   value: unknown,
 ): {
   installationPath: string;
-  packageItem: { id: string; info: Record<string, unknown> };
+  packageState: { id: string; info: Record<string, unknown> };
 } => {
   if (typeof value !== 'object' || value === null)
     throw new TypeError('An object is expected.');
-  const { installationPath, packageItem } = value as Record<string, unknown>;
+  const { installationPath, packageState } = value as Record<string, unknown>;
   if (typeof installationPath !== 'string')
     throw new TypeError('installationPath is expected to be a string.');
-  return { installationPath, packageItem: packageItemInput(packageItem) };
+  return { installationPath, packageState: packageStateInput(packageState) };
 };
 
 const installScriptFlowInput = (
@@ -211,7 +211,7 @@ export const packagesRouter = t.router({
       return await installPackageFlow(
         ctx,
         ctx.inst,
-        input.packageItem as Parameters<typeof installPackageFlow>[2],
+        input.packageState as Parameters<typeof installPackageFlow>[2],
         { direct: input.direct, archivePath: input.archivePath },
       );
     }),
@@ -221,7 +221,7 @@ export const packagesRouter = t.router({
       return await uninstallPackageFiles(
         ctx,
         ctx.inst,
-        input.packageItem as Parameters<typeof uninstallPackageFiles>[2],
+        input.packageState as Parameters<typeof uninstallPackageFiles>[2],
       );
     }),
   installScript: winInstProcedure

--- a/src/main/api/packages.ts
+++ b/src/main/api/packages.ts
@@ -8,7 +8,7 @@ import {
 } from '../services/packageInstall';
 import {
   convertPackageIds,
-  getApmJsonInstalledIds,
+  getLedgerInstalledIds,
   getPackages,
   getPackagesDates,
   getPackagesExtra,
@@ -175,11 +175,11 @@ export const packagesRouter = t.router({
   getPackagesExtra: winInstProcedure
     .input(stringInput)
     .query(async ({ ctx }) => await getPackagesExtra(ctx, ctx.inst)),
-  getApmJsonInstalledIds: instProcedure
+  getLedgerInstalledIds: instProcedure
     .input(installedIdsInput)
     .query(
       async ({ input, ctx }) =>
-        await getApmJsonInstalledIds(ctx.inst, input.ids),
+        await getLedgerInstalledIds(ctx.inst, input.ids),
     ),
   convertIds: winInstProcedure
     .input(convertIdsInput)

--- a/src/main/api/settings.ts
+++ b/src/main/api/settings.ts
@@ -50,8 +50,8 @@ export const settingsRouter = t.router({
     }),
   getDataUrls: procedure.query(({ ctx }) => {
     return {
-      main: ctx.config.dataURL.getMain(),
-      extra: ctx.config.dataURL.getExtra(),
+      main: ctx.config.dataUrl.getMain(),
+      extra: ctx.config.dataUrl.getExtra(),
     };
   }),
   getAutoUpdate: procedure.query(({ ctx }) => ctx.config.getAutoUpdate()),

--- a/src/main/api/trpc.ts
+++ b/src/main/api/trpc.ts
@@ -33,21 +33,21 @@ export const winProcedure = procedure.use(({ ctx, next }) => {
   return next({ ctx: { win } });
 });
 
-// 入力(instPath 文字列そのもの、または instPath フィールドを持つ
-// オブジェクト)から Installation を解決して ctx に載せる。instPath の
+// 入力(installationPath 文字列そのもの、または installationPath フィールドを持つ
+// オブジェクト)から Installation を解決して ctx に載せる。installationPath の
 // 文字列貫通を tRPC 境界で止め、procedure には Installation を渡す
 const installationMiddleware = t.middleware(async ({ getRawInput, next }) => {
   const raw = await getRawInput();
-  const instPath =
+  const installationPath =
     typeof raw === 'string'
       ? raw
-      : typeof (raw as { instPath?: unknown } | null | undefined)?.instPath ===
-          'string'
-        ? (raw as { instPath: string }).instPath
+      : typeof (raw as { installationPath?: unknown } | null | undefined)
+            ?.installationPath === 'string'
+        ? (raw as { installationPath: string }).installationPath
         : null;
-  if (instPath === null)
-    throw new TypeError('instPath is expected to be a string.');
-  return next({ ctx: { inst: openInstallation(instPath) } });
+  if (installationPath === null)
+    throw new TypeError('installationPath is expected to be a string.');
+  return next({ ctx: { inst: openInstallation(installationPath) } });
 });
 
 export const instProcedure = procedure.use(installationMiddleware);

--- a/src/main/installation.ts
+++ b/src/main/installation.ts
@@ -3,7 +3,7 @@ import Ledger from './Ledger';
 
 /**
  * インストール先フォルダの集約(ユビキタス言語の Installation)。
- * services を貫通していた instPath 文字列を置き換える plain object。
+ * services を貫通していた installationPath 文字列を置き換える plain object。
  * クラスにしないのは、全面的に関数スタイルの現行コードと vi.mock による
  * モジュール差し替えのテスト戦略を保つため。存在チェック等の不変条件も
  * 強制しない(現行挙動の維持を優先し、賢さは後から足せる)。
@@ -19,13 +19,13 @@ export type Installation = {
 
 /**
  * Creates the Installation of the given installation directory.
- * @param {string} instPath - The path to the installation directory.
+ * @param {string} installationPath - The path to the installation directory.
  * @returns {Installation} The installation.
  */
-export function openInstallation(instPath: string): Installation {
+export function openInstallation(installationPath: string): Installation {
   return {
-    path: instPath,
-    ledger: () => Ledger.load(instPath),
-    localRepoPath: path.join(instPath, 'packages.json'),
+    path: installationPath,
+    ledger: () => Ledger.load(installationPath),
+    localRepoPath: path.join(installationPath, 'packages.json'),
   };
 }

--- a/src/main/services/core.test.ts
+++ b/src/main/services/core.test.ts
@@ -20,10 +20,10 @@ import Ledger from '../Ledger';
 import {
   changeInstallationPath,
   ensureInstallationPath,
-  getApmJsonCoreVersions,
   getCoreDates,
   getCoreInfo,
   getInstalledVersionTexts,
+  getLedgerCoreVersions,
   hasExeditInPluginsFolder,
   installCoreProgram,
 } from './core';
@@ -140,9 +140,9 @@ describe('core service', () => {
     });
   });
 
-  describe('getApmJsonCoreVersions', () => {
+  describe('getLedgerCoreVersions', () => {
     it('未記録なら undefined を返す', async () => {
-      expect(await getApmJsonCoreVersions(inst)).toEqual({
+      expect(await getLedgerCoreVersions(inst)).toEqual({
         aviutl: undefined,
         exedit: undefined,
       });
@@ -151,7 +151,7 @@ describe('core service', () => {
     it('記録済みのバージョンを返す', async () => {
       const ledger = await Ledger.load(instPath);
       await ledger.setCore('aviutl', '1.10');
-      expect(await getApmJsonCoreVersions(inst)).toEqual({
+      expect(await getLedgerCoreVersions(inst)).toEqual({
         aviutl: '1.10',
         exedit: undefined,
       });

--- a/src/main/services/core.test.ts
+++ b/src/main/services/core.test.ts
@@ -92,7 +92,7 @@ const win = {} as BrowserWindow;
 describe('core service', () => {
   const tempDirs: string[] = [];
   let config: Config;
-  let instPath: string;
+  let installationPath: string;
   let ctx: { win: BrowserWindow; config: Config };
   let inst: Installation;
 
@@ -118,10 +118,10 @@ describe('core service', () => {
     vi.clearAllMocks();
     mocks.userDataDir.value = await makeTempDir('apm-userdata-');
     mocks.homeDir.value = await makeTempDir('apm-home-');
-    instPath = await makeTempDir('apm-inst-');
+    installationPath = await makeTempDir('apm-inst-');
     config = new Config({ cwd: await makeTempDir('apm-config-') });
     ctx = { win, config };
-    inst = openInstallation(instPath);
+    inst = openInstallation(installationPath);
   });
 
   afterEach(async () => {
@@ -149,7 +149,7 @@ describe('core service', () => {
     });
 
     it('記録済みのバージョンを返す', async () => {
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
       await ledger.setCore('aviutl', '1.10');
       expect(await getLedgerCoreVersions(inst)).toEqual({
         aviutl: '1.10',
@@ -161,8 +161,8 @@ describe('core service', () => {
   describe('hasExeditInPluginsFolder', () => {
     it('plugins/exedit.auf があるときだけ true', async () => {
       expect(hasExeditInPluginsFolder(inst)).toBe(false);
-      await ensureDir(path.join(instPath, 'plugins'));
-      await writeFile(path.join(instPath, 'plugins/exedit.auf'), 'x');
+      await ensureDir(path.join(installationPath, 'plugins'));
+      await writeFile(path.join(installationPath, 'plugins/exedit.auf'), 'x');
       expect(hasExeditInPluginsFolder(inst)).toBe(true);
     });
   });
@@ -252,8 +252,10 @@ describe('core service', () => {
       const result = await installCoreProgram(ctx, inst, 'aviutl', '1.10');
 
       expect(result).toBe('success');
-      expect(await pathExists(path.join(instPath, 'aviutl.exe'))).toBe(true);
-      const ledger = await Ledger.load(instPath);
+      expect(await pathExists(path.join(installationPath, 'aviutl.exe'))).toBe(
+        true,
+      );
+      const ledger = await Ledger.load(installationPath);
       expect(await ledger.get('core.aviutl')).toBe('1.10');
     });
 
@@ -310,8 +312,10 @@ describe('core service', () => {
       expect(await installCoreProgram(ctx, inst, 'aviutl', '1.10')).toBe(
         'success',
       );
-      expect(await pathExists(path.join(instPath, 'aviutl.exe'))).toBe(true);
-      const ledger = await Ledger.load(instPath);
+      expect(await pathExists(path.join(installationPath, 'aviutl.exe'))).toBe(
+        true,
+      );
+      const ledger = await Ledger.load(installationPath);
       expect(await ledger.get('core.aviutl')).toBe('1.10');
     });
   });
@@ -341,7 +345,7 @@ describe('core service', () => {
 
       await changeInstallationPath(ctx, inst);
 
-      expect(config.getInstallationPath()).toBe(instPath);
+      expect(config.getInstallationPath()).toBe(installationPath);
       expect(mocks.migrationByFolder).toHaveBeenCalledOnce();
       expect(mocks.getScriptsList).toHaveBeenCalledWith(ctx, true);
       // core の再取得は checkCoreLatestVersion 経由の downloadFile で観測する
@@ -372,7 +376,7 @@ describe('core service', () => {
       expect(mocks.refreshPackagesList).not.toHaveBeenCalled();
     });
 
-    it('instPath が存在しなければ migration も変換も行わない', async () => {
+    it('installationPath が存在しなければ migration も変換も行わない', async () => {
       mocks.getInfo.mockResolvedValue(
         modInfo({
           scripts: '2026-01-01',
@@ -386,7 +390,7 @@ describe('core service', () => {
 
       await changeInstallationPath(
         ctx,
-        openInstallation(path.join(instPath, 'not-exist')),
+        openInstallation(path.join(installationPath, 'not-exist')),
       );
 
       expect(mocks.migrationByFolder).not.toHaveBeenCalled();
@@ -406,7 +410,7 @@ describe('core service', () => {
       config.modDate.setCore(new Date('2026-01-02').getTime());
       config.modDate.setPackages(new Date('2026-01-02').getTime());
       // apm.json が存在し convertMod が古い
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
       await ledger.set('convertMod', new Date('2026-01-01').getTime());
 
       await changeInstallationPath(ctx, inst);

--- a/src/main/services/core.ts
+++ b/src/main/services/core.ts
@@ -65,7 +65,7 @@ export async function checkCoreLatestVersion(ctx: ServiceContext) {
  * @param {Installation} inst - The target installation.
  * @returns {Promise<{ aviutl?: string; exedit?: string }>} The recorded versions.
  */
-export async function getApmJsonCoreVersions(
+export async function getLedgerCoreVersions(
   inst: Installation,
 ): Promise<{ aviutl?: string; exedit?: string }> {
   const ledger = await inst.ledger();

--- a/src/main/services/migration.test.ts
+++ b/src/main/services/migration.test.ts
@@ -51,7 +51,7 @@ const win = {} as BrowserWindow;
 describe('migration service', () => {
   const tempDirs: string[] = [];
   let config: Config;
-  let instPath: string;
+  let installationPath: string;
   let ctx: { win: BrowserWindow; config: Config };
   let inst: Installation;
 
@@ -64,10 +64,10 @@ describe('migration service', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mocks.userDataDir.value = await makeTempDir('apm-userdata-');
-    instPath = await makeTempDir('apm-inst-');
+    installationPath = await makeTempDir('apm-inst-');
     config = new Config({ cwd: await makeTempDir('apm-config-') });
     ctx = { win, config };
-    inst = openInstallation(instPath);
+    inst = openInstallation(installationPath);
     // v1 のキャッシュ掃除が readdir する Data/package を用意しておく
     await ensureDir(path.join(mocks.userDataDir.value, 'Data/package'));
   });
@@ -138,11 +138,13 @@ describe('migration service', () => {
   describe('migrationByFolder', () => {
     it('apm.json が無ければ何もしない', async () => {
       await migrationByFolder(ctx, inst);
-      expect(await pathExists(path.join(instPath, 'apm.json'))).toBe(false);
+      expect(await pathExists(path.join(installationPath, 'apm.json'))).toBe(
+        false,
+      );
     });
 
     it('v1 の apm.json は repository の書き換えを経て v3(repository 削除)まで進む', async () => {
-      await writeJson(path.join(instPath, 'apm.json'), {
+      await writeJson(path.join(installationPath, 'apm.json'), {
         core: {},
         packages: {
           'author/pkg': {
@@ -156,7 +158,7 @@ describe('migration service', () => {
 
       await migrationByFolder(ctx, inst);
 
-      const ledger = await readJson(path.join(instPath, 'apm.json'));
+      const ledger = await readJson(path.join(installationPath, 'apm.json'));
       expect(ledger.dataVersion).toBe('3');
       expect(ledger.packages['author/pkg'].repository).toBeUndefined();
       expect(ledger.packages['author/pkg'].version).toBe('1.0');
@@ -165,7 +167,7 @@ describe('migration service', () => {
     });
 
     it('v2 の apm.json + packages.xml は packages.json へ変換される', async () => {
-      await writeJson(path.join(instPath, 'apm.json'), {
+      await writeJson(path.join(installationPath, 'apm.json'), {
         dataVersion: '2',
         core: {},
         packages: {
@@ -173,7 +175,7 @@ describe('migration service', () => {
         },
       });
       await writeFile(
-        path.join(instPath, 'packages.xml'),
+        path.join(installationPath, 'packages.xml'),
         `<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package>
@@ -191,16 +193,18 @@ describe('migration service', () => {
 
       await migrationByFolder(ctx, inst);
 
-      const ledger = await readJson(path.join(instPath, 'apm.json'));
+      const ledger = await readJson(path.join(installationPath, 'apm.json'));
       expect(ledger.dataVersion).toBe('3');
       expect(ledger.packages.script_old.repository).toBeUndefined();
-      const converted = await readJson(path.join(instPath, 'packages.json'));
+      const converted = await readJson(
+        path.join(installationPath, 'packages.json'),
+      );
       expect(converted.packages).toHaveLength(1);
       expect(converted.packages[0].id).toBe('script_old');
     });
 
     it('v3 済みの apm.json には触れない', async () => {
-      await writeJson(path.join(instPath, 'apm.json'), {
+      await writeJson(path.join(installationPath, 'apm.json'), {
         dataVersion: '3',
         core: {},
         packages: {},

--- a/src/main/services/migration.test.ts
+++ b/src/main/services/migration.test.ts
@@ -86,18 +86,18 @@ describe('migration service', () => {
     });
 
     it('dataVersion 3 済みなら何もしない', async () => {
-      config.dataURL.setMain('https://example.com/v3/');
+      config.dataUrl.setMain('https://example.com/v3/');
       config.setDataVersion('3');
 
       const result = await migrationGlobal(ctx);
 
       expect(result).toBe(true);
-      expect(config.dataURL.getMain()).toBe('https://example.com/v3/');
+      expect(config.dataUrl.getMain()).toBe('https://example.com/v3/');
       expect(mocks.showMessageBox).not.toHaveBeenCalled();
     });
 
     it('v2 からは dataURL・更新日時をリセットして 3 にし、案内ダイアログを出す', async () => {
-      config.dataURL.setMain('https://example.com/custom/');
+      config.dataUrl.setMain('https://example.com/custom/');
       config.setDataVersion('2');
       config.modDate.setCore(1000);
 
@@ -105,7 +105,7 @@ describe('migration service', () => {
 
       expect(result).toBe(true);
       expect(config.getDataVersion()).toBe('3');
-      expect(config.dataURL.hasMain()).toBe(false);
+      expect(config.dataUrl.hasMain()).toBe(false);
       expect(config.modDate.hasCore()).toBe(false);
       expect(mocks.showMessageBox).toHaveBeenCalledOnce();
     });
@@ -113,19 +113,19 @@ describe('migration service', () => {
     it('v1(旧デフォルト URL)からは確認なしで v2 を経由して 3 まで進む', async () => {
       // かつて setMain(undefined) が conf に拒否されクラッシュしていた経路
       // (#2397)。デフォルト利用者は dataURL.main が未設定へ戻る
-      config.dataURL.setMain(OLD_DEFAULT_DATA_URL);
+      config.dataUrl.setMain(OLD_DEFAULT_DATA_URL);
 
       const result = await migrationGlobal(ctx);
 
       expect(result).toBe(true);
       expect(config.getDataVersion()).toBe('3');
-      expect(config.dataURL.hasMain()).toBe(false);
+      expect(config.dataUrl.hasMain()).toBe(false);
       // v2→3 の案内ダイアログの 1 回だけ(v1→2 の確認は旧デフォルトなら出ない)
       expect(mocks.showMessageBox).toHaveBeenCalledOnce();
     });
 
     it('v1(カスタム URL)でキャンセルを選ぶと false(起動中止)', async () => {
-      config.dataURL.setMain('https://example.com/custom-v1/');
+      config.dataUrl.setMain('https://example.com/custom-v1/');
       mocks.showMessageBox.mockResolvedValueOnce({ response: 0 });
 
       const result = await migrationGlobal(ctx);

--- a/src/main/services/migration.ts
+++ b/src/main/services/migration.ts
@@ -40,9 +40,9 @@ async function migration1to2Global(ctx: ServiceContext): Promise<boolean> {
   if (!isVerOne) return true;
 
   // Show the dialogs for those using custom dataURL.main
-  let useDefaultDataURL = true;
+  let useDefaultDataUrl = true;
   if (
-    config.dataURL.getMain() !==
+    config.dataUrl.getMain() !==
     'https://cdn.jsdelivr.net/gh/team-apm/apm-data@main/data/'
   ) {
     for (;;) {
@@ -69,7 +69,7 @@ async function migration1to2Global(ctx: ServiceContext): Promise<boolean> {
       }
       // else (response === 1) // use new dataURL.main
 
-      const newDataURL = await prompt(
+      const newDataUrl = await prompt(
         {
           title: '新しいデータ取得先の入力',
           label: '新しいデータ取得先のURL（例: https://example.com/data/）',
@@ -79,30 +79,30 @@ async function migration1to2Global(ctx: ServiceContext): Promise<boolean> {
         },
         win,
       );
-      if (!newDataURL) {
+      if (!newDataUrl) {
         continue;
-      } else if (!newDataURL.startsWith('http') && !fs.existsSync(newDataURL)) {
+      } else if (!newDataUrl.startsWith('http') && !fs.existsSync(newDataUrl)) {
         await showErrorDialog(
           'エラー',
           '有効なURLまたは場所を入力してください。',
         );
         continue;
-      } else if (path.extname(newDataURL) === '.xml') {
+      } else if (path.extname(newDataUrl) === '.xml') {
         await showErrorDialog('エラー', 'フォルダのURLを入力してください。');
         continue;
       } else {
-        const oldDataURL = config.dataURL.getMain();
-        const urls = config.dataURL
+        const oldDataUrl = config.dataUrl.getMain();
+        const urls = config.dataUrl
           .getPackages()
-          .filter((url) => !url.includes(oldDataURL));
-        urls.push(joinUrlOrPath(newDataURL, 'packages.xml'));
-        config.dataURL.setMain(newDataURL);
-        config.dataURL.setPackages(urls);
+          .filter((url) => !url.includes(oldDataUrl));
+        urls.push(joinUrlOrPath(newDataUrl, 'packages.xml'));
+        config.dataUrl.setMain(newDataUrl);
+        config.dataUrl.setPackages(urls);
         config.set('migration1to2', {
-          oldDataURL: oldDataURL,
-          newDataURL: newDataURL,
+          oldDataURL: oldDataUrl,
+          newDataURL: newDataUrl,
         });
-        useDefaultDataURL = false;
+        useDefaultDataUrl = false;
         break;
       }
     }
@@ -139,7 +139,7 @@ async function migration1to2Global(ctx: ServiceContext): Promise<boolean> {
   // 3. Triggers initialization
   // 旧実装の setMain(undefined) は conf が TypeError で拒否し、この移行が
   // 必ずクラッシュしていた(#2397)
-  if (useDefaultDataURL) config.dataURL.deleteMain();
+  if (useDefaultDataUrl) config.dataUrl.deleteMain();
 
   // Finalize
   config.setDataVersion('2');
@@ -206,10 +206,10 @@ async function migration1to2ByFolder(ctx: ServiceContext, inst: Installation) {
       path.join(inst.path, 'packages.xml'),
     );
     if (config.has('migration1to2')) {
-      const dataURLs = config.get('migration1to2');
+      const dataUrls = config.get('migration1to2');
       text = text.replaceAll(
-        joinUrlOrPath(dataURLs.oldDataURL, 'packages_list.xml'),
-        joinUrlOrPath(dataURLs.newDataURL, 'packages.xml'),
+        joinUrlOrPath(dataUrls.oldDataURL, 'packages_list.xml'),
+        joinUrlOrPath(dataUrls.newDataURL, 'packages.xml'),
       );
     }
     packages[id].repository = text;
@@ -230,7 +230,7 @@ async function migration1to2ByFolder(ctx: ServiceContext, inst: Installation) {
  */
 export async function migrationGlobal(ctx: ServiceContext): Promise<boolean> {
   const { config } = ctx;
-  const firstLaunch = !config.dataURL.hasMain();
+  const firstLaunch = !config.dataUrl.hasMain();
   if (firstLaunch) {
     config.setDataVersion('3');
     return true;

--- a/src/main/services/modList.ts
+++ b/src/main/services/modList.ts
@@ -31,8 +31,8 @@ export async function updateInfo(win: BrowserWindow, config: Config) {
     .split(os.EOL)
     .filter((url) => url !== '');
   const packages = ([] as string[]).concat(
-    info.packages.map((packageItem) =>
-      resolvePath(config.dataUrl.getMain(), packageItem.path),
+    info.packages.map((packagesFile) =>
+      resolvePath(config.dataUrl.getMain(), packagesFile.path),
     ),
     URLs,
   );

--- a/src/main/services/modList.ts
+++ b/src/main/services/modList.ts
@@ -19,24 +19,24 @@ export async function updateInfo(win: BrowserWindow, config: Config) {
   // クエリがここへ到達しうる。空のまま進めると 'list.json' がローカルパス
   // 扱いになり紛らわしい ENOENT で落ちるため、明示的に失敗させて
   // 呼び出し側(react-query)のリトライに任せる
-  if (config.dataURL.getMain() === '') {
+  if (config.dataUrl.getMain() === '') {
     throw new Error('The main data URL is not set yet.');
   }
-  await downloadFile(win, joinUrlOrPath(config.dataURL.getMain(), 'list.json'));
+  await downloadFile(win, joinUrlOrPath(config.dataUrl.getMain(), 'list.json'));
 
   const modFile = existsTempFile('list.json');
   const info = (await readJson(modFile.path)) as List;
-  const URLs = config.dataURL
+  const URLs = config.dataUrl
     .getExtra()
     .split(os.EOL)
     .filter((url) => url !== '');
   const packages = ([] as string[]).concat(
     info.packages.map((packageItem) =>
-      resolvePath(config.dataURL.getMain(), packageItem.path),
+      resolvePath(config.dataUrl.getMain(), packageItem.path),
     ),
     URLs,
   );
-  config.dataURL.setPackages(packages);
+  config.dataUrl.setPackages(packages);
 }
 
 /**
@@ -70,7 +70,7 @@ export async function getInfo(
  */
 export async function getCoreDataUrl(win: BrowserWindow, config: Config) {
   const info = await getInfo(win, config);
-  return resolvePath(config.dataURL.getMain(), info.core.path);
+  return resolvePath(config.dataUrl.getMain(), info.core.path);
 }
 
 /**
@@ -82,7 +82,7 @@ export async function getCoreDataUrl(win: BrowserWindow, config: Config) {
  */
 export async function getConvertDataUrl(win: BrowserWindow, config: Config) {
   const info = await getInfo(win, config);
-  return resolvePath(config.dataURL.getMain(), info.convert.path);
+  return resolvePath(config.dataUrl.getMain(), info.convert.path);
 }
 
 /**
@@ -95,6 +95,6 @@ export async function getConvertDataUrl(win: BrowserWindow, config: Config) {
 export async function getScriptsDataUrl(win: BrowserWindow, config: Config) {
   const info = await getInfo(win, config);
   return info.scripts.map((script) =>
-    resolvePath(config.dataURL.getMain(), script.path),
+    resolvePath(config.dataUrl.getMain(), script.path),
   );
 }

--- a/src/main/services/packageInstall.ts
+++ b/src/main/services/packageInstall.ts
@@ -34,23 +34,23 @@ export function getDate() {
  * (展開 → インストーラ実行または配置 → 検証 → 導入記録への記帳)と同一の挙動。
  * @param {Installation} inst - The target installation.
  * @param {string} archivePath - Path to the downloaded archive.
- * @param {object} packageItem - A package to install.
+ * @param {object} packageState - A package to install.
  * @returns {Promise<boolean>} Whether the installation succeeded.
  */
 export async function installPackageArchive(
   inst: Installation,
   archivePath: string,
-  packageItem: Pick<PackageState, 'id' | 'info'>,
+  packageState: Pick<PackageState, 'id' | 'info'>,
 ): Promise<boolean> {
   let installResult = false;
 
   try {
     const getUnzippedPath = async () => {
       if (['.zip', '.lzh', '.7z', '.rar'].includes(path.extname(archivePath))) {
-        return await unzip(archivePath, packageItem.id);
+        return await unzip(archivePath, packageState.id);
       } else {
         // In this line, path.dirname(archivePath) always refers to the 'Data/package' folder.
-        const newFolder = path.join(path.dirname(archivePath), packageItem.id);
+        const newFolder = path.join(path.dirname(archivePath), packageState.id);
         await mkdir(newFolder, { recursive: true });
         await rename(
           archivePath,
@@ -62,7 +62,7 @@ export async function installPackageArchive(
 
     const unzippedPath = await getUnzippedPath();
 
-    if (packageItem.info.installer) {
+    if (packageState.info.installer) {
       const searchFiles = async (dirName: string) => {
         let result: string[][] = [];
         const dirents = await fsReaddir(dirName, {
@@ -75,7 +75,7 @@ export async function installPackageArchive(
             );
             result = result.concat(childResult);
           } else {
-            if (dirent.name === packageItem.info.installer) {
+            if (dirent.name === packageState.info.installer) {
               result.push([path.join(dirName, dirent.name)]);
               break;
             }
@@ -88,15 +88,15 @@ export async function installPackageArchive(
       // シェルを介さないため installArg のメタ文字がコマンドとして解釈されない
       execFileSync(
         exePath[0][0],
-        buildInstallerArgs(packageItem.info.installArg, inst.path),
+        buildInstallerArgs(packageState.info.installArg, inst.path),
       );
 
-      installResult = verifyFilesByCount(inst.path, packageItem.info.files);
+      installResult = verifyFilesByCount(inst.path, packageState.info.files);
     } else {
       installResult = await install(
         unzippedPath,
         inst.path,
-        packageItem.info.files,
+        packageState.info.files,
       );
     }
   } catch (e) {
@@ -106,11 +106,11 @@ export async function installPackageArchive(
 
   if (installResult) {
     // isContinuous のパッケージはインストール日をバージョンとして記録する
-    const latestVersion = packageItem.info.isContinuous
+    const latestVersion = packageState.info.isContinuous
       ? getDate()
-      : packageItem.info.latestVersion;
+      : packageState.info.latestVersion;
     const ledger = await inst.ledger();
-    await ledger.addPackage(packageItem.id, latestVersion);
+    await ledger.addPackage(packageState.id, latestVersion);
   }
 
   return installResult;
@@ -131,7 +131,7 @@ export type InstallPackageResult =
  * 同一の挙動。UI(ボタン遷移・メッセージ表示)は renderer 側に残る。
  * @param {ServiceContext} ctx - The service context.
  * @param {Installation} inst - The target installation.
- * @param {Pick<PackageState, 'id' | 'info'>} packageItem - The package to install.
+ * @param {Pick<PackageState, 'id' | 'info'>} packageState - The package to install.
  * @param {object} [options] - Options.
  * @param {boolean} [options.direct] - Install from the direct link to the zip.
  * @param {string} [options.archivePath] - Path to the already-downloaded archive.
@@ -140,7 +140,7 @@ export type InstallPackageResult =
 export async function installPackageFlow(
   ctx: ServiceContext,
   inst: Installation,
-  packageItem: Pick<PackageState, 'id' | 'info'>,
+  packageState: Pick<PackageState, 'id' | 'info'>,
   { direct = false, archivePath }: { direct?: boolean; archivePath?: string },
 ): Promise<InstallPackageResult> {
   const { win } = ctx;
@@ -152,7 +152,7 @@ export async function installPackageFlow(
       if (direct) {
         const resolvedArchivePath = await downloadFile(
           win,
-          packageItem.info.directURL,
+          packageState.info.directURL,
           { loadCache: true, subDir: 'package' },
         );
         if (!resolvedArchivePath) {
@@ -163,7 +163,7 @@ export async function installPackageFlow(
       }
       const downloadResult = await openBrowser(
         win,
-        packageItem.info.downloadURLs[0],
+        packageState.info.downloadURLs[0],
         'package',
       );
       if (!downloadResult) {
@@ -175,21 +175,21 @@ export async function installPackageFlow(
     // integrity があるなら取得経路(直リンク・手動 DL・archivePath 渡し)に
     // よらず検証する。無いパッケージ(公式データの約 1/4)を弾かないのは、
     // 検証必須化すると既存パッケージのインストールが広く壊れるため
-    integrity: packageItem.info.releases?.find(
-      (r) => r.version === packageItem.info.latestVersion,
+    integrity: packageState.info.releases?.find(
+      (r) => r.version === packageState.info.latestVersion,
     )?.integrity?.archive,
-    corruptLogUrl: packageItem.info.directURL,
+    corruptLogUrl: packageState.info.directURL,
     redownloadArchive: async () => {
       if (direct) {
         // 再ダウンロード先が subDir 'core' なのは旧実装のままの挙動
         const resolvedArchivePath = await downloadFile(
           win,
-          packageItem.info.directURL,
+          packageState.info.directURL,
           { subDir: 'core' },
         );
         if (!resolvedArchivePath) {
           log.error(
-            `Failed downloading the archive file. URL:${packageItem.info.directURL}`,
+            `Failed downloading the archive file. URL:${packageState.info.directURL}`,
           );
           return { failure: 'redownloadFailed' as const };
         }
@@ -198,7 +198,7 @@ export async function installPackageFlow(
       // 手動 DL・archivePath 渡しの経路はブラウザ窓での再取得になる
       const redownloadResult = await openBrowser(
         win,
-        packageItem.info.downloadURLs[0],
+        packageState.info.downloadURLs[0],
         'package',
       );
       if (!redownloadResult) {
@@ -208,7 +208,7 @@ export async function installPackageFlow(
       return { archivePath: redownloadResult.savePath };
     },
     install: (resolvedArchivePath) =>
-      installPackageArchive(inst, resolvedArchivePath, packageItem),
+      installPackageArchive(inst, resolvedArchivePath, packageState),
   });
 }
 

--- a/src/main/services/packageList.ts
+++ b/src/main/services/packageList.ts
@@ -193,40 +193,40 @@ async function getInstalledFiles(instPath: string) {
 }
 
 /**
- * Updates the installedVersion of the packages and returns a list of
- * manually installed files.
+ * Resolves the installation status (installationStatus / version) of each
+ * package and returns them with a list of manually installed files.
  * 旧 src/renderer/main/packageUtil.ts の getPackagesExtra と同一の挙動
  * (パッケージ一覧は main 側の getPackages から取得する)。
  * @param {ServiceContext} ctx - The service context.
  * @param {Installation} inst - The target installation.
  * @returns {Promise<object>} List of manually installed files and packages.
  */
-export async function getPackagesExtra(
+export async function resolveInstallationStatus(
   ctx: ServiceContext,
   inst: Installation,
 ): Promise<{ manuallyInstalledFiles: string[]; packages: PackageState[] }> {
   const packages = await getPackages(ctx, inst);
   const ledger = await inst.ledger();
-  const tmpInstalledPackages = (await ledger.get(
+  const ledgerPackages = (await ledger.get(
     'packages',
   )) as LedgerObject['packages'];
-  const tmpInstalledFiles = await getInstalledFiles(inst.path);
-  const tmpManuallyInstalledFiles = getManuallyInstalledFiles(
-    tmpInstalledFiles,
-    tmpInstalledPackages,
+  const installedFiles = await getInstalledFiles(inst.path);
+  const manuallyInstalledFiles = getManuallyInstalledFiles(
+    installedFiles,
+    ledgerPackages,
     packages,
   );
   packages.forEach((p) => {
     [p.installationStatus, p.version] = getInstalledVersionOfPackage(
       p,
-      tmpInstalledFiles,
-      tmpManuallyInstalledFiles,
-      tmpInstalledPackages,
+      installedFiles,
+      manuallyInstalledFiles,
+      ledgerPackages,
       inst.path,
     );
   });
   return {
-    manuallyInstalledFiles: tmpManuallyInstalledFiles,
+    manuallyInstalledFiles: manuallyInstalledFiles,
     packages: packages,
   };
 }
@@ -263,28 +263,31 @@ export async function adoptManuallyInstalledPackages(
 /**
  * Returns the packages with their status (doNotInstall / detached) computed.
  * 旧 src/renderer/main/package.ts の setPackagesList 前半
- * (getPackages → getPackagesExtra → 整合性による導入記録の補正 →
- * getPackagesStatus)と同一の挙動。fixIntegrity = false の場合は
+ * (getPackages → resolveInstallationStatus → 整合性による導入記録の補正 →
+ * getPackagesStatus)と同一の挙動。adoptManuallyInstalled = false の場合は
  * 補正を行わない(旧 installScript の redirect 解決と同一)。
  * @param {ServiceContext} ctx - The service context.
  * @param {Installation} inst - The target installation.
- * @param {boolean} fixIntegrity - Whether to guess installed packages from integrity.
+ * @param {boolean} adoptManuallyInstalled - Whether to guess installed packages from integrity.
  * @returns {Promise<object>} List of manually installed files and packages.
  */
 export async function getPackagesWithStatus(
   ctx: ServiceContext,
   inst: Installation,
-  fixIntegrity: boolean,
+  adoptManuallyInstalled: boolean,
 ): Promise<{ manuallyInstalledFiles: string[]; packages: PackageState[] }> {
-  let { manuallyInstalledFiles, packages } = await getPackagesExtra(ctx, inst);
+  let { manuallyInstalledFiles, packages } = await resolveInstallationStatus(
+    ctx,
+    inst,
+  );
 
-  if (fixIntegrity) {
+  if (adoptManuallyInstalled) {
     // guess which packages are installed from integrity
     const modified = await adoptManuallyInstalledPackages(inst, packages);
     if (modified) {
-      const packagesExtraMod = await getPackagesExtra(ctx, inst);
-      manuallyInstalledFiles = packagesExtraMod.manuallyInstalledFiles;
-      packages = packagesExtraMod.packages;
+      const resolved = await resolveInstallationStatus(ctx, inst);
+      manuallyInstalledFiles = resolved.manuallyInstalledFiles;
+      packages = resolved.packages;
     }
   }
 
@@ -308,7 +311,7 @@ export async function getPackagesWithStatus(
  * @param {ServiceContext} ctx - The service context.
  * @param {Installation} inst - The target installation.
  */
-export async function downloadRepository(
+export async function downloadPackagesData(
   ctx: ServiceContext,
   inst: Installation,
 ) {
@@ -335,7 +338,7 @@ export async function refreshPackagesList(
 ) {
   const { win, config } = ctx;
   await updateInfo(win, config);
-  await downloadRepository(ctx, inst);
+  await downloadPackagesData(ctx, inst);
   config.checkDate.setPackages(Date.now());
   const modInfo = await getInfo(win, config);
   config.modDate.setPackages(

--- a/src/main/services/packageList.ts
+++ b/src/main/services/packageList.ts
@@ -161,10 +161,10 @@ export async function getPackages(
 /**
  * Returns a list of installed files.
  * 旧 src/renderer/main/packageUtil.ts の getInstalledFiles と同一の挙動。
- * @param {string} instPath - An installation path
+ * @param {string} installationPath - An installation path
  * @returns {Promise<string[]>} List of installed files
  */
-async function getInstalledFiles(instPath: string) {
+async function getInstalledFiles(installationPath: string) {
   const regex = /^(?!exedit).*\.(auf|aui|auo|auc|aul|anm|obj|cam|tra|scn|lua)$/;
   const safeReaddir = async (path: string) => {
     try {
@@ -179,15 +179,19 @@ async function getInstalledFiles(instPath: string) {
     (await safeReaddir(dir))
       .filter((i) => i.isFile() && regex.test(i.name))
       .map((i) => i.name);
-  return (await readdir(instPath)).concat(
-    (await readdir(path.join(instPath, 'plugins'))).map((i) => 'plugins/' + i),
-    (await readdir(path.join(instPath, 'script'))).map((i) => 'script/' + i),
+  return (await readdir(installationPath)).concat(
+    (await readdir(path.join(installationPath, 'plugins'))).map(
+      (i) => 'plugins/' + i,
+    ),
+    (await readdir(path.join(installationPath, 'script'))).map(
+      (i) => 'script/' + i,
+    ),
     await asyncFlatMap(
-      (await safeReaddir(path.join(instPath, 'script')))
+      (await safeReaddir(path.join(installationPath, 'script')))
         .filter((i) => i.isDirectory())
         .map((i) => 'script/' + i.name),
       async (i) =>
-        (await readdir(path.join(instPath, i))).map((j) => i + '/' + j),
+        (await readdir(path.join(installationPath, i))).map((j) => i + '/' + j),
     ),
   );
 }

--- a/src/main/services/packageList.ts
+++ b/src/main/services/packageList.ts
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { asyncFlatMap } from '../../shared/asyncFlatMap';
 import { checkIntegrity } from '../../shared/integrity';
 import {
-  convertV1ApmJsonPackages,
+  convertV1LedgerPackages,
   convertV1PackageIds,
 } from '../../shared/packageId';
 import {
@@ -97,7 +97,7 @@ export async function convertPackageIds(
   };
 
   const convDict = await getIdDict(ctx, true);
-  convertV1ApmJsonPackages(packages, convDict);
+  convertV1LedgerPackages(packages, convDict);
 
   await ledger.set('packages', packages);
   await ledger.set('convertMod', modTime);
@@ -368,10 +368,7 @@ export function getPackagesDates(
  * @param {string[]} ids - Package ids to check.
  * @returns {Promise<string[]>} The ids recorded in the ledger.
  */
-export async function getApmJsonInstalledIds(
-  inst: Installation,
-  ids: string[],
-) {
+export async function getLedgerInstalledIds(inst: Installation, ids: string[]) {
   const ledger = await inst.ledger();
   const result: string[] = [];
   for (const id of ids) {

--- a/src/main/services/packageList.ts
+++ b/src/main/services/packageList.ts
@@ -80,7 +80,7 @@ export async function getIdDict(
 /**
  * Converts the package ids in the ledger using the conversion dictionary.
  * 旧 src/lib/convertId.ts の convertId と同一の挙動(新 ID の解決に
- * packageItem.id を引く点も含めて維持)。
+ * ledgerEntry.id を引く点も含めて維持)。
  * @param {ServiceContext} ctx - The service context.
  * @param {Installation} inst - The target installation.
  * @param {number} modTime - A mod time.

--- a/src/main/services/packageList.ts
+++ b/src/main/services/packageList.ts
@@ -34,7 +34,7 @@ import { existsTempFile } from './tempFile';
  * @returns {string[]} Package data files URLs.
  */
 export function getPackagesDataUrl(config: Config, inst: Installation) {
-  return config.dataURL
+  return config.dataUrl
     .getPackages()
     .concat(
       inst.path && inst.path.length > 0

--- a/src/main/services/packageShare.ts
+++ b/src/main/services/packageShare.ts
@@ -7,7 +7,7 @@ import { states } from '../../shared/packageUtil';
 import { programs } from '../../shared/programs';
 import { shareStringVersion } from '../../shared/shareString';
 import type { Installation } from '../installation';
-import { getIdDict, getPackagesExtra } from './packageList';
+import { getIdDict, resolveInstallationStatus } from './packageList';
 import type { ServiceContext } from './serviceContext';
 
 /**
@@ -36,7 +36,7 @@ export async function buildShareString(
     const currentVersion = (await ledger.get('core.' + program)) as string;
     ver[program] = currentVersion;
   }
-  ver.packages = (await getPackagesExtra(ctx, inst)).packages
+  ver.packages = (await resolveInstallationStatus(ctx, inst)).packages
     .filter(
       (p) =>
         p.installationStatus === states.installed ||

--- a/src/main/services/packageUninstall.ts
+++ b/src/main/services/packageUninstall.ts
@@ -18,16 +18,16 @@ export type UninstallPackageResult = 'success' | 'removeFailed' | 'filesRemain';
  * (削除失敗時のメッセージ表示は renderer 側の責務)。
  * @param {ServiceContext} ctx - The service context.
  * @param {Installation} inst - The target installation.
- * @param {object} packageItem - A package to uninstall.
+ * @param {object} packageState - A package to uninstall.
  * @returns {Promise<UninstallPackageResult>} The result of the uninstallation.
  */
 export async function uninstallPackageFiles(
   ctx: ServiceContext,
   inst: Installation,
-  packageItem: Pick<PackageState, 'id' | 'info'>,
+  packageState: Pick<PackageState, 'id' | 'info'>,
 ): Promise<UninstallPackageResult> {
   const filesToRemove = [];
-  for (const file of packageItem.info.files) {
+  for (const file of packageState.info.files) {
     if (!file.isInstallOnly)
       filesToRemove.push(path.join(inst.path, file.filename));
   }
@@ -43,7 +43,7 @@ export async function uninstallPackageFiles(
 
   let filesCount = 0;
   let notExistCount = 0;
-  for (const file of packageItem.info.files) {
+  for (const file of packageState.info.files) {
     if (!file.isInstallOnly) {
       filesCount++;
       if (!existsSync(path.join(inst.path, file.filename))) {
@@ -53,14 +53,14 @@ export async function uninstallPackageFiles(
   }
 
   const ledger = await inst.ledger();
-  await ledger.removePackage(packageItem.id);
+  await ledger.removePackage(packageState.id);
 
   const result: UninstallPackageResult =
     filesCount === notExistCount ? 'success' : 'filesRemain';
   // スクリプト由来のパッケージはローカル packages.json からも削除する
   // (旧 renderer 側 parseJson.removePackage の呼び出しと同一の挙動)
-  if (result === 'success' && packageItem.id.startsWith('script_')) {
-    await removeScriptPackage(ctx, inst, packageItem.id);
+  if (result === 'success' && packageState.id.startsWith('script_')) {
+    await removeScriptPackage(ctx, inst, packageState.id);
   }
   return result;
 }

--- a/src/main/services/packages.test.ts
+++ b/src/main/services/packages.test.ts
@@ -136,7 +136,7 @@ describe('packages service', () => {
 
   describe('getPackagesDataUrl', () => {
     it('設定の取得先に、installationPath 直下の存在するローカル一覧だけを足す', async () => {
-      config.dataURL.setPackages(['https://example.com/packages.json']);
+      config.dataUrl.setPackages(['https://example.com/packages.json']);
       await writeJson(path.join(installationPath, 'packages.json'), {});
 
       expect(getPackagesDataUrl(config, inst)).toEqual([
@@ -146,7 +146,7 @@ describe('packages service', () => {
     });
 
     it('installationPath が空文字列なら設定の取得先のみを返す', () => {
-      config.dataURL.setPackages(['https://example.com/packages.json']);
+      config.dataUrl.setPackages(['https://example.com/packages.json']);
       expect(getPackagesDataUrl(config, openInstallation(''))).toEqual([
         'https://example.com/packages.json',
       ]);
@@ -156,7 +156,7 @@ describe('packages service', () => {
   describe('getPackages', () => {
     it('キャッシュ済みの一覧を読み、変換辞書で ID を差し替える', async () => {
       const repo = 'https://example.com/packages.json';
-      config.dataURL.setPackages([repo]);
+      config.dataUrl.setPackages([repo]);
       await writeCachedRepo(repo, {
         version: 3,
         packages: [
@@ -178,7 +178,7 @@ describe('packages service', () => {
 
     it('壊れた一覧はダイアログを出してスキップする', async () => {
       const repo = 'https://example.com/broken.json';
-      config.dataURL.setPackages([repo]);
+      config.dataUrl.setPackages([repo]);
       const file = path.join(
         mocks.userDataDir.value,
         'Data/package',
@@ -193,7 +193,7 @@ describe('packages service', () => {
     });
 
     it('キャッシュが無い取得先は黙ってスキップする', async () => {
-      config.dataURL.setPackages(['https://example.com/nocache.json']);
+      config.dataUrl.setPackages(['https://example.com/nocache.json']);
       expect(await getPackages(ctx, inst)).toEqual([]);
       expect(mocks.showMessageBox).not.toHaveBeenCalled();
     });
@@ -208,7 +208,7 @@ describe('packages service', () => {
     };
 
     beforeEach(async () => {
-      config.dataURL.setPackages([repo]);
+      config.dataUrl.setPackages([repo]);
       await writeCachedRepo(repo, { version: 3, packages: [packageInfo] });
     });
 
@@ -661,7 +661,7 @@ describe('packages service', () => {
   describe('buildShareString', () => {
     it('スラッシュ入り ID のインストール済みパッケージを整列して共有文字列にする', async () => {
       const repo = 'https://example.com/packages.json';
-      config.dataURL.setPackages([repo]);
+      config.dataUrl.setPackages([repo]);
       await writeCachedRepo(repo, {
         version: 3,
         packages: [

--- a/src/main/services/packages.test.ts
+++ b/src/main/services/packages.test.ts
@@ -25,7 +25,7 @@ import {
   getLedgerInstalledIds,
   getPackages,
   getPackagesDataUrl,
-  getPackagesExtra,
+  resolveInstallationStatus,
 } from './packageList';
 import { buildShareString } from './packageShare';
 import { uninstallPackageFiles } from './packageUninstall';
@@ -199,7 +199,7 @@ describe('packages service', () => {
     });
   });
 
-  describe('getPackagesExtra', () => {
+  describe('resolveInstallationStatus', () => {
     const repo = 'https://example.com/packages.json';
     const packageInfo = {
       id: 'author/plugin',
@@ -218,10 +218,8 @@ describe('packages service', () => {
       const ledger = await Ledger.load(instPath);
       await ledger.addPackage('author/plugin', '1.0');
 
-      const { packages, manuallyInstalledFiles } = await getPackagesExtra(
-        ctx,
-        inst,
-      );
+      const { packages, manuallyInstalledFiles } =
+        await resolveInstallationStatus(ctx, inst);
 
       expect(packages[0].installationStatus).toBe(states.installed);
       expect(packages[0].version).toBe('1.0');
@@ -232,7 +230,7 @@ describe('packages service', () => {
       await ensureDir(path.join(instPath, 'plugins'));
       await writeFile(path.join(instPath, 'plugins/test.auf'), 'x');
 
-      const { packages } = await getPackagesExtra(ctx, inst);
+      const { packages } = await resolveInstallationStatus(ctx, inst);
 
       expect(packages[0].installationStatus).toBe(states.manuallyInstalled);
     });
@@ -241,10 +239,8 @@ describe('packages service', () => {
       await ensureDir(path.join(instPath, 'plugins'));
       await writeFile(path.join(instPath, 'plugins/unknown.auf'), 'x');
 
-      const { packages, manuallyInstalledFiles } = await getPackagesExtra(
-        ctx,
-        inst,
-      );
+      const { packages, manuallyInstalledFiles } =
+        await resolveInstallationStatus(ctx, inst);
 
       expect(manuallyInstalledFiles).toEqual(['plugins/unknown.auf']);
       expect(packages[0].installationStatus).toBe(states.notInstalled);

--- a/src/main/services/packages.test.ts
+++ b/src/main/services/packages.test.ts
@@ -22,7 +22,7 @@ import {
   openPackageFolder,
 } from './packageInstall';
 import {
-  getApmJsonInstalledIds,
+  getLedgerInstalledIds,
   getPackages,
   getPackagesDataUrl,
   getPackagesExtra,
@@ -490,8 +490,8 @@ describe('packages service', () => {
       expect(await pathExists(path.join(instPath, 'plugins/target.auf'))).toBe(
         false,
       );
-      const apmJson2 = await Ledger.load(instPath);
-      expect(await apmJson2.has('packages.a/b')).toBe(false);
+      const ledger2 = await Ledger.load(instPath);
+      expect(await ledger2.has('packages.a/b')).toBe(false);
     });
 
     it('isInstallOnly のファイルは削除しない', async () => {
@@ -527,8 +527,8 @@ describe('packages service', () => {
 
       expect(result).toBe('removeFailed');
       // 失敗時は apm.json に残る(削除処理まで到達しない)
-      const apmJson2 = await Ledger.load(instPath);
-      expect(await apmJson2.has('packages.a/evil')).toBe(true);
+      const ledger2 = await Ledger.load(instPath);
+      expect(await ledger2.has('packages.a/evil')).toBe(true);
     });
 
     it('script_ パッケージはローカル packages.json からも取り除く', async () => {
@@ -687,12 +687,12 @@ describe('packages service', () => {
     });
   });
 
-  describe('getApmJsonInstalledIds', () => {
+  describe('getLedgerInstalledIds', () => {
     it('apm.json に記録済みの ID だけを返す', async () => {
       const ledger = await Ledger.load(instPath);
       await ledger.addPackage('a/b', '1.0');
 
-      expect(await getApmJsonInstalledIds(inst, ['a/b', 'c/d'])).toEqual([
+      expect(await getLedgerInstalledIds(inst, ['a/b', 'c/d'])).toEqual([
         'a/b',
       ]);
     });

--- a/src/main/services/packages.test.ts
+++ b/src/main/services/packages.test.ts
@@ -84,7 +84,7 @@ const win = {} as BrowserWindow;
 describe('packages service', () => {
   const tempDirs: string[] = [];
   let config: Config;
-  let instPath: string;
+  let installationPath: string;
   let ctx: { win: BrowserWindow; config: Config };
   let inst: Installation;
 
@@ -122,10 +122,10 @@ describe('packages service', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mocks.userDataDir.value = await makeTempDir('apm-userdata-');
-    instPath = await makeTempDir('apm-inst-');
+    installationPath = await makeTempDir('apm-inst-');
     config = new Config({ cwd: await makeTempDir('apm-config-') });
     ctx = { win, config };
-    inst = openInstallation(instPath);
+    inst = openInstallation(installationPath);
     await ensureDir(path.join(mocks.userDataDir.value, 'Data/package'));
     await writeConvertDict();
   });
@@ -135,17 +135,17 @@ describe('packages service', () => {
   });
 
   describe('getPackagesDataUrl', () => {
-    it('設定の取得先に、instPath 直下の存在するローカル一覧だけを足す', async () => {
+    it('設定の取得先に、installationPath 直下の存在するローカル一覧だけを足す', async () => {
       config.dataURL.setPackages(['https://example.com/packages.json']);
-      await writeJson(path.join(instPath, 'packages.json'), {});
+      await writeJson(path.join(installationPath, 'packages.json'), {});
 
       expect(getPackagesDataUrl(config, inst)).toEqual([
         'https://example.com/packages.json',
-        path.join(instPath, 'packages.json'),
+        path.join(installationPath, 'packages.json'),
       ]);
     });
 
-    it('instPath が空文字列なら設定の取得先のみを返す', () => {
+    it('installationPath が空文字列なら設定の取得先のみを返す', () => {
       config.dataURL.setPackages(['https://example.com/packages.json']);
       expect(getPackagesDataUrl(config, openInstallation(''))).toEqual([
         'https://example.com/packages.json',
@@ -213,9 +213,9 @@ describe('packages service', () => {
     });
 
     it('apm.json に記録済みでファイルもあるパッケージはインストール済みになる', async () => {
-      await ensureDir(path.join(instPath, 'plugins'));
-      await writeFile(path.join(instPath, 'plugins/test.auf'), 'x');
-      const ledger = await Ledger.load(instPath);
+      await ensureDir(path.join(installationPath, 'plugins'));
+      await writeFile(path.join(installationPath, 'plugins/test.auf'), 'x');
+      const ledger = await Ledger.load(installationPath);
       await ledger.addPackage('author/plugin', '1.0');
 
       const { packages, manuallyInstalledFiles } =
@@ -227,8 +227,8 @@ describe('packages service', () => {
     });
 
     it('未記録でファイルだけあるパッケージは手動インストール済みになる', async () => {
-      await ensureDir(path.join(instPath, 'plugins'));
-      await writeFile(path.join(instPath, 'plugins/test.auf'), 'x');
+      await ensureDir(path.join(installationPath, 'plugins'));
+      await writeFile(path.join(installationPath, 'plugins/test.auf'), 'x');
 
       const { packages } = await resolveInstallationStatus(ctx, inst);
 
@@ -236,8 +236,8 @@ describe('packages service', () => {
     });
 
     it('どのパッケージにも属さないプラグインファイルは手動導入ファイル一覧に載る', async () => {
-      await ensureDir(path.join(instPath, 'plugins'));
-      await writeFile(path.join(instPath, 'plugins/unknown.auf'), 'x');
+      await ensureDir(path.join(installationPath, 'plugins'));
+      await writeFile(path.join(installationPath, 'plugins/unknown.auf'), 'x');
 
       const { packages, manuallyInstalledFiles } =
         await resolveInstallationStatus(ctx, inst);
@@ -274,8 +274,10 @@ describe('packages service', () => {
       );
 
       expect(result).toBe(true);
-      expect(await pathExists(path.join(instPath, 'test.auf'))).toBe(true);
-      const ledger = await Ledger.load(instPath);
+      expect(await pathExists(path.join(installationPath, 'test.auf'))).toBe(
+        true,
+      );
+      const ledger = await Ledger.load(installationPath);
       expect(await ledger.get('packages.author/plugin.version')).toBe('1.2');
     });
 
@@ -293,7 +295,7 @@ describe('packages service', () => {
 
       await installPackageArchive(inst, archivePath, packageItem);
 
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
       const version = (await ledger.get(
         'packages.author/continuous.version',
       )) as string;
@@ -318,7 +320,7 @@ describe('packages service', () => {
       );
 
       expect(result).toBe(false);
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
       expect(await ledger.has('packages.author/missing')).toBe(false);
     });
   });
@@ -462,15 +464,17 @@ describe('packages service', () => {
       );
 
       expect(result).toBe('success');
-      expect(await pathExists(path.join(instPath, 'direct.auf'))).toBe(true);
+      expect(await pathExists(path.join(installationPath, 'direct.auf'))).toBe(
+        true,
+      );
     });
   });
 
   describe('uninstallPackageFiles', () => {
     it('ファイルを削除して apm.json からも取り除く', async () => {
-      await ensureDir(path.join(instPath, 'plugins'));
-      await writeFile(path.join(instPath, 'plugins/target.auf'), 'x');
-      const ledger = await Ledger.load(instPath);
+      await ensureDir(path.join(installationPath, 'plugins'));
+      await writeFile(path.join(installationPath, 'plugins/target.auf'), 'x');
+      const ledger = await Ledger.load(installationPath);
       await ledger.addPackage('a/b', '1.0');
 
       const result = await uninstallPackageFiles(ctx, inst, {
@@ -483,16 +487,16 @@ describe('packages service', () => {
       } as unknown as Parameters<typeof uninstallPackageFiles>[2]);
 
       expect(result).toBe('success');
-      expect(await pathExists(path.join(instPath, 'plugins/target.auf'))).toBe(
-        false,
-      );
-      const ledger2 = await Ledger.load(instPath);
+      expect(
+        await pathExists(path.join(installationPath, 'plugins/target.auf')),
+      ).toBe(false);
+      const ledger2 = await Ledger.load(installationPath);
       expect(await ledger2.has('packages.a/b')).toBe(false);
     });
 
     it('isInstallOnly のファイルは削除しない', async () => {
-      await writeFile(path.join(instPath, 'keep.txt'), 'x');
-      const ledger = await Ledger.load(instPath);
+      await writeFile(path.join(installationPath, 'keep.txt'), 'x');
+      const ledger = await Ledger.load(installationPath);
       await ledger.addPackage('a/keep', '1.0');
 
       const result = await uninstallPackageFiles(ctx, inst, {
@@ -505,11 +509,13 @@ describe('packages service', () => {
       } as unknown as Parameters<typeof uninstallPackageFiles>[2]);
 
       expect(result).toBe('success');
-      expect(await pathExists(path.join(instPath, 'keep.txt'))).toBe(true);
+      expect(await pathExists(path.join(installationPath, 'keep.txt'))).toBe(
+        true,
+      );
     });
 
     it('インストール先の外を指す filename は削除に失敗し removeFailed', async () => {
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
       await ledger.addPackage('a/evil', '1.0');
 
       const result = await uninstallPackageFiles(ctx, inst, {
@@ -523,21 +529,21 @@ describe('packages service', () => {
 
       expect(result).toBe('removeFailed');
       // 失敗時は apm.json に残る(削除処理まで到達しない)
-      const ledger2 = await Ledger.load(instPath);
+      const ledger2 = await Ledger.load(installationPath);
       expect(await ledger2.has('packages.a/evil')).toBe(true);
     });
 
     it('script_ パッケージはローカル packages.json からも取り除く', async () => {
-      await ensureDir(path.join(instPath, 'script'));
-      await writeFile(path.join(instPath, 'script/s.anm'), 'x');
-      await writeJson(path.join(instPath, 'packages.json'), {
+      await ensureDir(path.join(installationPath, 'script'));
+      await writeFile(path.join(installationPath, 'script/s.anm'), 'x');
+      await writeJson(path.join(installationPath, 'packages.json'), {
         version: 3,
         packages: [
           { id: 'script_abc', name: 's', files: [] },
           { id: 'other/pkg', name: 'o', files: [] },
         ],
       });
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
       await ledger.addPackage('script_abc', '2026/01/01');
 
       const result = await uninstallPackageFiles(ctx, inst, {
@@ -550,7 +556,9 @@ describe('packages service', () => {
       } as unknown as Parameters<typeof uninstallPackageFiles>[2]);
 
       expect(result).toBe('success');
-      const local = await readJson(path.join(instPath, 'packages.json'));
+      const local = await readJson(
+        path.join(installationPath, 'packages.json'),
+      );
       expect(local.packages.map((p: { id: string }) => p.id)).toEqual([
         'other/pkg',
       ]);
@@ -578,13 +586,15 @@ describe('packages service', () => {
 
       expect(result).toBe('success');
       expect(
-        await pathExists(path.join(instPath, 'script/cool/cool.anm')),
+        await pathExists(path.join(installationPath, 'script/cool/cool.anm')),
       ).toBe(true);
-      const local = await readJson(path.join(instPath, 'packages.json'));
+      const local = await readJson(
+        path.join(installationPath, 'packages.json'),
+      );
       expect(local.packages).toHaveLength(1);
       expect(local.packages[0].id).toMatch(/^script_/);
       expect(local.packages[0].developer).toBe('dev');
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
       expect(await ledger.has('packages.' + local.packages[0].id)).toBe(true);
     });
 
@@ -627,7 +637,7 @@ describe('packages service', () => {
     });
 
     it('インストール先の外を指す folder は installFailed に落ちる', async () => {
-      // '../evil' は script/../evil = instPath 内に収まるため成功する
+      // '../evil' は script/../evil = installationPath 内に収まるため成功する
       // (現行挙動)。外へ出るのは '../../evil' から
       const archivePath = await makeScriptArchive('evil.anm');
 
@@ -641,7 +651,9 @@ describe('packages service', () => {
 
       expect(result).toBe('installFailed');
       expect(
-        await pathExists(path.resolve(instPath, 'script', '../../evil')),
+        await pathExists(
+          path.resolve(installationPath, 'script', '../../evil'),
+        ),
       ).toBe(false);
     });
   });
@@ -662,12 +674,12 @@ describe('packages service', () => {
           },
         ],
       });
-      await ensureDir(path.join(instPath, 'plugins'));
-      await ensureDir(path.join(instPath, 'script'));
+      await ensureDir(path.join(installationPath, 'plugins'));
+      await ensureDir(path.join(installationPath, 'script'));
       for (const f of ['plugins/bx.auf', 'plugins/ay.auf', 'script/z.anm']) {
-        await writeFile(path.join(instPath, f), 'x');
+        await writeFile(path.join(installationPath, f), 'x');
       }
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
       await ledger.setCore('aviutl', '1.10');
       await ledger.setCore('exedit', '0.92');
       await ledger.addPackage('b/x', '1.0');
@@ -685,7 +697,7 @@ describe('packages service', () => {
 
   describe('getLedgerInstalledIds', () => {
     it('apm.json に記録済みの ID だけを返す', async () => {
-      const ledger = await Ledger.load(instPath);
+      const ledger = await Ledger.load(installationPath);
       await ledger.addPackage('a/b', '1.0');
 
       expect(await getLedgerInstalledIds(inst, ['a/b', 'c/d'])).toEqual([

--- a/src/main/services/packages.test.ts
+++ b/src/main/services/packages.test.ts
@@ -258,7 +258,7 @@ describe('packages service', () => {
 
     it('非アーカイブのファイルを配置して apm.json に記録する', async () => {
       const archivePath = await makeArchive('test.auf');
-      const packageItem = {
+      const packageState = {
         id: 'author/plugin',
         info: {
           name: 'プラグイン',
@@ -270,7 +270,7 @@ describe('packages service', () => {
       const result = await installPackageArchive(
         inst,
         archivePath,
-        packageItem,
+        packageState,
       );
 
       expect(result).toBe(true);
@@ -283,7 +283,7 @@ describe('packages service', () => {
 
     it('isContinuous のパッケージはインストール日をバージョンとして記録する', async () => {
       const archivePath = await makeArchive('test2.auf');
-      const packageItem = {
+      const packageState = {
         id: 'author/continuous',
         info: {
           name: '継続',
@@ -293,7 +293,7 @@ describe('packages service', () => {
         },
       } as unknown as Parameters<typeof installPackageArchive>[2];
 
-      await installPackageArchive(inst, archivePath, packageItem);
+      await installPackageArchive(inst, archivePath, packageState);
 
       const ledger = await Ledger.load(installationPath);
       const version = (await ledger.get(
@@ -304,7 +304,7 @@ describe('packages service', () => {
 
     it('必要なファイルが配置できなければ false を返し apm.json に記録しない', async () => {
       const archivePath = await makeArchive('test3.auf');
-      const packageItem = {
+      const packageState = {
         id: 'author/missing',
         info: {
           name: '欠損',
@@ -316,7 +316,7 @@ describe('packages service', () => {
       const result = await installPackageArchive(
         inst,
         archivePath,
-        packageItem,
+        packageState,
       );
 
       expect(result).toBe(false);

--- a/src/main/services/scriptInstall.ts
+++ b/src/main/services/scriptInstall.ts
@@ -220,7 +220,7 @@ export async function installScriptArchive(
     await rename(unzippedPath, newPath);
 
     // Save package information
-    const packageItem = {
+    const newPackage = {
       id: id,
       name: name,
       overview: 'スクリプト',
@@ -242,14 +242,14 @@ export async function installScriptArchive(
       : [];
     convertV1PackageIds(localPackages, await getIdDict(ctx));
     const newLocalPackages = localPackages.filter((p) => p.id !== id);
-    newLocalPackages.push(packageItem as Packages['packages'][number]);
+    newLocalPackages.push(newPackage as Packages['packages'][number]);
     await writeJson(localPackagesPath, {
       version: 3,
       packages: newLocalPackages,
     });
 
     const ledger = await inst.ledger();
-    await ledger.addPackage(packageItem.id, packageItem.latestVersion);
+    await ledger.addPackage(newPackage.id, newPackage.latestVersion);
     return 'success';
   } catch (e) {
     log.error(e);

--- a/src/main/services/settings.test.ts
+++ b/src/main/services/settings.test.ts
@@ -30,14 +30,14 @@ describe('settings service', () => {
 
       const result = ensureExtraDataUrl(config);
 
-      expect(config.dataURL.hasExtra()).toBe(true);
+      expect(config.dataUrl.hasExtra()).toBe(true);
       expect(result).toEqual({ hasMain: false, extra: '' });
     });
 
     it('設定済みの値は変更せず、メイン URL の有無を返す', async () => {
       const config = await makeConfig();
-      config.dataURL.setMain('https://example.com/data/');
-      config.dataURL.setExtra('https://example.com/x.json');
+      config.dataUrl.setMain('https://example.com/data/');
+      config.dataUrl.setExtra('https://example.com/x.json');
 
       const result = ensureExtraDataUrl(config);
 
@@ -62,8 +62,8 @@ describe('settings service', () => {
       );
 
       expect(result.errors).toEqual([]);
-      expect(config.dataURL.getMain()).toBe('https://example.com/data/');
-      expect(config.dataURL.getExtra()).toBe(
+      expect(config.dataUrl.getMain()).toBe('https://example.com/data/');
+      expect(config.dataUrl.getExtra()).toBe(
         ['https://a.example/x.json', 'https://b.example/y.json'].join(os.EOL),
       );
     });
@@ -75,14 +75,14 @@ describe('settings service', () => {
       const result = await setDataUrls(config, '', '', confirm);
 
       expect(result.mainUrl).toBe(DEFAULT_DATA_URL);
-      expect(config.dataURL.getMain()).toBe(DEFAULT_DATA_URL);
+      expect(config.dataUrl.getMain()).toBe(DEFAULT_DATA_URL);
       expect(confirm).not.toHaveBeenCalled();
     });
 
     it('検証エラー時は config を変更しない', async () => {
       const config = await makeConfig();
-      config.dataURL.setMain('https://example.com/data/');
-      config.dataURL.setExtra('https://example.com/x.json');
+      config.dataUrl.setMain('https://example.com/data/');
+      config.dataUrl.setExtra('https://example.com/x.json');
 
       const result = await setDataUrls(
         config,
@@ -92,8 +92,8 @@ describe('settings service', () => {
       );
 
       expect(result.errors.length).toBeGreaterThan(0);
-      expect(config.dataURL.getMain()).toBe('https://example.com/data/');
-      expect(config.dataURL.getExtra()).toBe('https://example.com/x.json');
+      expect(config.dataUrl.getMain()).toBe('https://example.com/data/');
+      expect(config.dataUrl.getExtra()).toBe('https://example.com/x.json');
     });
 
     it('未知オリジンは承認するとオリジンが記録され、次回は確認されない', async () => {
@@ -102,7 +102,7 @@ describe('settings service', () => {
 
       await setDataUrls(config, 'https://example.com/data/', '', confirm);
       expect(confirm).toHaveBeenCalledTimes(1);
-      expect(config.dataURL.getApprovedOrigins()).toEqual([
+      expect(config.dataUrl.getApprovedOrigins()).toEqual([
         'https://example.com',
       ]);
 
@@ -121,8 +121,8 @@ describe('settings service', () => {
       );
 
       expect(result.canceled).toBe(true);
-      expect(config.dataURL.hasMain()).toBe(false);
-      expect(config.dataURL.getApprovedOrigins()).toEqual([]);
+      expect(config.dataUrl.hasMain()).toBe(false);
+      expect(config.dataUrl.getApprovedOrigins()).toEqual([]);
     });
 
     it('平文 http は確認メッセージに警告として含まれる', async () => {
@@ -156,7 +156,7 @@ describe('settings service', () => {
 
       expect(result.canceled).toBe(false);
       expect(confirm).not.toHaveBeenCalled();
-      expect(config.dataURL.getMain()).toBe('http://localhost:3000/data/');
+      expect(config.dataUrl.getMain()).toBe('http://localhost:3000/data/');
     });
   });
 });

--- a/src/main/services/settings.ts
+++ b/src/main/services/settings.ts
@@ -17,10 +17,10 @@ export function ensureExtraDataUrl(config: Config): {
   hasMain: boolean;
   extra: string;
 } {
-  if (!config.dataURL.hasExtra()) config.dataURL.setExtra('');
+  if (!config.dataUrl.hasExtra()) config.dataUrl.setExtra('');
   return {
-    hasMain: config.dataURL.hasMain(),
-    extra: config.dataURL.getExtra(),
+    hasMain: config.dataUrl.hasMain(),
+    extra: config.dataUrl.getExtra(),
   };
 }
 
@@ -72,7 +72,7 @@ export async function setDataUrls(
 
   const approvedOrigins = [
     new URL(DEFAULT_DATA_URL).origin,
-    ...config.dataURL.getApprovedOrigins(),
+    ...config.dataUrl.getApprovedOrigins(),
   ];
   const cautions = collectDataUrlCautions(
     [result.mainUrl, ...result.extraUrls],
@@ -81,15 +81,15 @@ export async function setDataUrls(
   if (cautions.unknownOrigins.length > 0 || cautions.insecureUrls.length > 0) {
     if (!(await confirm(buildCautionMessage(cautions))))
       return { ...result, canceled: true };
-    config.dataURL.setApprovedOrigins([
+    config.dataUrl.setApprovedOrigins([
       ...new Set([
-        ...config.dataURL.getApprovedOrigins(),
+        ...config.dataUrl.getApprovedOrigins(),
         ...cautions.unknownOrigins,
       ]),
     ]);
   }
 
-  config.dataURL.setMain(result.mainUrl);
-  config.dataURL.setExtra(result.extraUrls.join(os.EOL));
+  config.dataUrl.setMain(result.mainUrl);
+  config.dataUrl.setExtra(result.extraUrls.join(os.EOL));
   return { ...result, canceled: false };
 }

--- a/src/renderer/main/App.tsx
+++ b/src/renderer/main/App.tsx
@@ -18,7 +18,7 @@ function Startup(): null {
   const started = useRef(false);
   useEffect(() => {
     // React のマウントより後に開始すれば十分で、完了は待たない
-    // (各コンポーネントは instPath ストアと apm-* イベントで追従する)
+    // (各コンポーネントは installationPath ストアと apm-* イベントで追従する)
     if (started.current) return;
     started.current = true;
     void runStartupFlow(utils.client);

--- a/src/renderer/main/aviutl/AviutlTab.tsx
+++ b/src/renderer/main/aviutl/AviutlTab.tsx
@@ -1,5 +1,8 @@
 import React, { type JSX, useSyncExternalStore } from 'react';
-import { getInstallationPath, subscribeInstallationPath } from '../instPath';
+import {
+  getInstallationPath,
+  subscribeInstallationPath,
+} from '../installationPath';
 import BatchInstallButton from './BatchInstallButton';
 import BatchInstallList from './BatchInstallList';
 import ProgramRow from './ProgramRow';
@@ -8,12 +11,12 @@ import TutorialAlert from './TutorialAlert';
 
 /**
  * The whole pane of the AviUtl tab (旧 index.html の section#aviutl の中身).
- * インストール先の表示は instPath ストアの購読で更新する(旧実装は
+ * インストール先の表示は installationPath ストアの購読で更新する(旧実装は
  * preload が #installation-path の value を直接書いていた)。
  * @returns {JSX.Element} The rendered component.
  */
 function AviutlTab(): JSX.Element {
-  const instPath = useSyncExternalStore(
+  const installationPath = useSyncExternalStore(
     subscribeInstallationPath,
     getInstallationPath,
   );
@@ -49,7 +52,7 @@ function AviutlTab(): JSX.Element {
                 placeholder="AviUtlフォルダ"
                 aria-label="Installation path"
                 readOnly
-                value={instPath}
+                value={installationPath}
               />
             </div>
             <div className="d-flex">

--- a/src/renderer/main/aviutl/BatchInstallButton.tsx
+++ b/src/renderer/main/aviutl/BatchInstallButton.tsx
@@ -4,7 +4,7 @@ import { states } from '../../../shared/packageDisplay';
 import { programs } from '../../../shared/programs';
 import type { PackageState } from '../../../types/packageState';
 import { TRPCReact } from '../../trpc';
-import { getInstallationPath } from '../instPath';
+import { getInstallationPath } from '../installationPath';
 
 type ButtonPhase =
   | { kind: 'idle' }
@@ -42,8 +42,8 @@ function BatchInstallButton(): JSX.Element {
     clearTimeout(timer.current);
     setPhase({ kind: 'loading' });
 
-    const instPath = getInstallationPath();
-    if (!instPath) {
+    const installationPath = getInstallationPath();
+    if (!installationPath) {
       finish('インストール先フォルダを指定してください。', 'danger');
       return;
     }
@@ -56,7 +56,7 @@ function BatchInstallButton(): JSX.Element {
         const result = await installProgramMutation.mutateAsync({
           program,
           version: progInfo.latestVersion,
-          instPath,
+          installationPath,
         });
         // 旧 installProgram の btn なしルート: ダウンロード失敗のみ全体を
         // エラーにし、他の失敗は黙って次へ進む
@@ -71,7 +71,7 @@ function BatchInstallButton(): JSX.Element {
       }
 
       const allPackages = (
-        await utils.packages.resolveInstallationStatus.fetch(instPath)
+        await utils.packages.resolveInstallationStatus.fetch(installationPath)
       ).packages as PackageState[];
       const packagesToInstall = allPackages.filter(
         (p) =>
@@ -82,7 +82,7 @@ function BatchInstallButton(): JSX.Element {
       );
       for (const packageItem of packagesToInstall) {
         const result = await installPackageMutation.mutateAsync({
-          instPath,
+          installationPath,
           packageItem: { id: packageItem.id, info: packageItem.info },
           direct: true,
         });

--- a/src/renderer/main/aviutl/BatchInstallButton.tsx
+++ b/src/renderer/main/aviutl/BatchInstallButton.tsx
@@ -80,10 +80,10 @@ function BatchInstallButton(): JSX.Element {
             (status) => status === p.installationStatus,
           ),
       );
-      for (const packageItem of packagesToInstall) {
+      for (const packageState of packagesToInstall) {
         const result = await installPackageMutation.mutateAsync({
           installationPath,
-          packageItem: { id: packageItem.id, info: packageItem.info },
+          packageState: { id: packageState.id, info: packageState.info },
           direct: true,
         });
         // 旧 installPackage の direct ルート: 破損・ダウンロード失敗は throw

--- a/src/renderer/main/aviutl/BatchInstallButton.tsx
+++ b/src/renderer/main/aviutl/BatchInstallButton.tsx
@@ -71,7 +71,7 @@ function BatchInstallButton(): JSX.Element {
       }
 
       const allPackages = (
-        await utils.packages.getPackagesExtra.fetch(instPath)
+        await utils.packages.resolveInstallationStatus.fetch(instPath)
       ).packages as PackageState[];
       const packagesToInstall = allPackages.filter(
         (p) =>

--- a/src/renderer/main/aviutl/BatchInstallList.tsx
+++ b/src/renderer/main/aviutl/BatchInstallList.tsx
@@ -9,7 +9,7 @@ import { getInstallationPath } from '../instPath';
  * AviutlTab の ul(#batch-install-packages)内に li 群として描画する
  * (pane の React 化前は portal で静的 HTML の ul へ差し込んでいた)。
  * 旧 package.ts の updateBatchInstallList と同一の表示。
- * クエリは PackagesTab と同じキー(fixIntegrity: true)でキャッシュを共有する
+ * クエリは PackagesTab と同じキー(adoptManuallyInstalled: true)でキャッシュを共有する
  * (apm.json の整合性補正は冪等のため表示結果は旧実装と変わらない)。
  * レガシー側からの再描画通知(apm-packages-changed イベント)で自動更新する。
  * @returns {JSX.Element} The rendered component.
@@ -19,7 +19,7 @@ function BatchInstallList(): JSX.Element {
 
   const utils = TRPCReact.useUtils();
   const packagesQuery = TRPCReact.packages.getPackagesWithStatus.useQuery(
-    { instPath, fixIntegrity: true },
+    { instPath, adoptManuallyInstalled: true },
     { refetchOnWindowFocus: false },
   );
 

--- a/src/renderer/main/aviutl/BatchInstallList.tsx
+++ b/src/renderer/main/aviutl/BatchInstallList.tsx
@@ -1,7 +1,7 @@
 import React, { type JSX, useEffect, useState } from 'react';
 import type { PackageState } from '../../../types/packageState';
 import { TRPCReact } from '../../trpc';
-import { getInstallationPath } from '../instPath';
+import { getInstallationPath } from '../installationPath';
 
 /**
  * The list of the recommended plugins (directURL packages) shown in the
@@ -15,18 +15,20 @@ import { getInstallationPath } from '../instPath';
  * @returns {JSX.Element} The rendered component.
  */
 function BatchInstallList(): JSX.Element {
-  const [instPath, setInstPath] = useState(() => getInstallationPath());
+  const [installationPath, setInstallationPath] = useState(() =>
+    getInstallationPath(),
+  );
 
   const utils = TRPCReact.useUtils();
   const packagesQuery = TRPCReact.packages.getPackagesWithStatus.useQuery(
-    { instPath, adoptManuallyInstalled: true },
+    { installationPath, adoptManuallyInstalled: true },
     { refetchOnWindowFocus: false },
   );
 
   // レガシー側(preload の package.ts)からの再描画通知を受けて最新化する
   useEffect(() => {
     const listener = () => {
-      setInstPath(getInstallationPath());
+      setInstallationPath(getInstallationPath());
       void utils.packages.getPackagesWithStatus.invalidate();
     };
     window.addEventListener('apm-packages-changed', listener);

--- a/src/renderer/main/aviutl/ProgramRow.tsx
+++ b/src/renderer/main/aviutl/ProgramRow.tsx
@@ -3,7 +3,7 @@ import React, { type JSX, useEffect, useRef, useState } from 'react';
 import { Dropdown } from 'react-bootstrap';
 import { releaseLabel } from '../../../shared/coreVersionText';
 import { TRPCReact } from '../../trpc';
-import { getInstallationPath } from '../instPath';
+import { getInstallationPath } from '../installationPath';
 
 type ButtonPhase = 'idle' | 'loading' | 'success' | 'danger';
 
@@ -29,7 +29,9 @@ function ProgramRow({
   iconClass,
   buttonRoundedClass,
 }: ProgramRowProps) {
-  const [instPath, setInstPath] = useState(() => getInstallationPath());
+  const [installationPath, setInstallationPath] = useState(() =>
+    getInstallationPath(),
+  );
   const [phase, setPhase] = useState<ButtonPhase>('idle');
   const [buttonMessage, setButtonMessage] = useState('');
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -38,13 +40,13 @@ function ProgramRow({
   const utils = TRPCReact.useUtils();
   const coreInfoQuery = TRPCReact.core.getCoreInfo.useQuery();
   const installedTextsQuery =
-    TRPCReact.core.getInstalledVersionTexts.useQuery(instPath);
+    TRPCReact.core.getInstalledVersionTexts.useQuery(installationPath);
   const installProgram = TRPCReact.core.installProgram.useMutation();
 
   // レガシー側(preload の core.ts)からの再描画通知を受けて最新化する
   useEffect(() => {
     const listener = () => {
-      setInstPath(getInstallationPath());
+      setInstallationPath(getInstallationPath());
       void utils.core.getCoreInfo.invalidate();
       void utils.core.getInstalledVersionTexts.invalidate();
     };
@@ -71,7 +73,7 @@ function ProgramRow({
     clearTimeout(timer.current);
     setPhase('loading');
 
-    if (!instPath) {
+    if (!installationPath) {
       showError('インストール先フォルダを指定してください。');
       return;
     }
@@ -81,7 +83,7 @@ function ProgramRow({
       result = await installProgram.mutateAsync({
         program,
         version,
-        instPath,
+        installationPath,
       });
     } catch {
       showError('エラーが発生しました。');

--- a/src/renderer/main/aviutl/SelectInstallationPathButton.tsx
+++ b/src/renderer/main/aviutl/SelectInstallationPathButton.tsx
@@ -1,13 +1,13 @@
 import React, { type JSX } from 'react';
 import { TRPCReact } from '../../trpc';
-import { getInstallationPath, setInstallationPath } from '../instPath';
+import { getInstallationPath, setInstallationPath } from '../installationPath';
 
 /**
  * The button to select the installation path of the AviUtl tab.
  * 旧 core.ts の selectInstallationPath・changeInstallationPath のフローに
  * 相当する。判定・更新は main プロセス側(services/core.ts)が行い、ここは
  * ダイアログの表示と再描画通知のみを行う。
- * インストール先の値は instPath ストアが保持する。
+ * インストール先の値は installationPath ストアが保持する。
  * @returns {JSX.Element} The rendered component.
  */
 function SelectInstallationPathButton(): JSX.Element {
@@ -35,15 +35,15 @@ function SelectInstallationPathButton(): JSX.Element {
         return;
       }
 
-      const instPath = selectedPath[0];
+      const installationPath = selectedPath[0];
       // mod 情報の更新・migration・変換辞書の適用と、必要なデータの再取得は
       // main プロセス側(services/core.ts の changeInstallationPath)が行う
-      await changeInstallationPathMutation.mutateAsync(instPath);
+      await changeInstallationPathMutation.mutateAsync(installationPath);
       // 再描画通知(旧 changeInstallationPath と同一)
       window.dispatchEvent(new Event('apm-core-changed'));
       window.dispatchEvent(new Event('apm-packages-changed'));
 
-      setInstallationPath(instPath);
+      setInstallationPath(installationPath);
       // インストール先の確定を React(ProgramRow)へ通知する
       // (旧 selectInstallationPath と同一。ストア反映後にもう一度通知する)
       window.dispatchEvent(new Event('apm-core-changed'));

--- a/src/renderer/main/installationPath.ts
+++ b/src/renderer/main/installationPath.ts
@@ -3,7 +3,7 @@
 // 初期化フロー移設に伴い DOM から独立させた。React からは
 // useSyncExternalStore(subscribeInstallationPath, getInstallationPath) で購読する。
 
-let instPath = '';
+let installationPath = '';
 const listeners = new Set<() => void>();
 
 /**
@@ -11,7 +11,7 @@ const listeners = new Set<() => void>();
  * @returns {string} The installation path (empty string if not set).
  */
 export function getInstallationPath(): string {
-  return instPath;
+  return installationPath;
 }
 
 /**
@@ -19,7 +19,7 @@ export function getInstallationPath(): string {
  * @param {string} next - The new installation path.
  */
 export function setInstallationPath(next: string): void {
-  instPath = next;
+  installationPath = next;
   listeners.forEach((listener) => listener());
 }
 

--- a/src/renderer/main/monacoEditorRenderer.tsx
+++ b/src/renderer/main/monacoEditorRenderer.tsx
@@ -14,7 +14,7 @@ import schema from 'apm-schema/v3/schema/packages.json';
 import type { editor } from 'monaco-editor';
 import React, { useRef } from 'react';
 import { TRPCReact } from '../trpc';
-import { getInstallationPath } from './instPath';
+import { getInstallationPath } from './installationPath';
 import { usePhase } from './usePhase';
 
 const placeholderStr = `
@@ -188,7 +188,7 @@ export const MonacoEditorRenderer: React.FC = () => {
       // editorPackages.json の読み書きは main プロセス側
       // (src/main/services/packages.ts)
       await setEditorPackagesMutation.mutateAsync({
-        instPath: getInstallationPath(),
+        installationPath: getInstallationPath(),
         packages: json as Packages['packages'],
       });
       // 一覧データの再取得(旧 checkPackagesList)は ManualUpdateTable が
@@ -224,19 +224,19 @@ export const MonacoEditorRenderer: React.FC = () => {
       editor,
       monaco.editor.ContentWidgetPositionPreference.EXACT,
     );
-    // インストール先は起動フロー(startup.ts)が instPath ストアに設定して
+    // インストール先は起動フロー(startup.ts)が installationPath ストアに設定して
     // apm-core-changed を発火するため、未確定なら確定を待って一度だけ読み込む
     // (旧 EditorContextBridge の setOnload / setInstPath の両者待ち合わせ相当。
     // 読み込み失敗を無視するのも旧実装と同じ)
     let loaded = false;
     const loadEditorPackages = async () => {
       if (loaded) return;
-      const instPath = getInstallationPath();
-      if (!instPath) return;
+      const installationPath = getInstallationPath();
+      if (!installationPath) return;
       loaded = true;
       try {
         const packages = (await utils.client.packages.getEditorPackages.query(
-          instPath,
+          installationPath,
         )) as Packages['packages'];
         if (packages.length === 0) return;
         editor.setValue(JSON.stringify(packages));

--- a/src/renderer/main/nicommons/NicommonsTab.tsx
+++ b/src/renderer/main/nicommons/NicommonsTab.tsx
@@ -2,7 +2,7 @@ import React, { type JSX, useEffect, useMemo, useState } from 'react';
 import { parsePackageType } from '../../../shared/packageDisplay';
 import type { PackageState } from '../../../types/packageState';
 import { TRPCReact } from '../../trpc';
-import { getInstallationPath } from '../instPath';
+import { getInstallationPath } from '../installationPath';
 
 type NicommonsItem = {
   name: string;
@@ -97,7 +97,9 @@ function NicommonsRow({
  * @returns {JSX.Element} The rendered component.
  */
 function NicommonsTab(): JSX.Element {
-  const [instPath, setInstPath] = useState(() => getInstallationPath());
+  const [installationPath, setInstallationPath] = useState(() =>
+    getInstallationPath(),
+  );
   // 除外したもの(チェックを外したもの)だけを持つ。一覧の再取得時に全部
   // チェック済みへ戻る旧挙動と同じにするため、checked の集合は持たない
   const [uncheckedIds, setUncheckedIds] = useState<ReadonlySet<string>>(
@@ -106,9 +108,12 @@ function NicommonsTab(): JSX.Element {
 
   const utils = TRPCReact.useUtils();
   const writeClipboardMutation = TRPCReact.writeClipboardText.useMutation();
-  const packagesQuery = TRPCReact.packages.getPackages.useQuery(instPath, {
-    refetchOnWindowFocus: false,
-  });
+  const packagesQuery = TRPCReact.packages.getPackages.useQuery(
+    installationPath,
+    {
+      refetchOnWindowFocus: false,
+    },
+  );
   const packages = useMemo(
     () => (packagesQuery.data ?? []) as PackageState[],
     [packagesQuery.data],
@@ -119,13 +124,13 @@ function NicommonsTab(): JSX.Element {
     [packages],
   );
   const installedIdsQuery = TRPCReact.packages.getLedgerInstalledIds.useQuery(
-    { instPath, ids: candidateIds },
+    { installationPath, ids: candidateIds },
     { refetchOnWindowFocus: false, enabled: packagesQuery.isSuccess },
   );
 
   useEffect(() => {
     const onCoreChanged = () => {
-      setInstPath(getInstallationPath());
+      setInstallationPath(getInstallationPath());
     };
     const onPackagesChanged = () => {
       void utils.packages.getPackages.invalidate();

--- a/src/renderer/main/nicommons/NicommonsTab.tsx
+++ b/src/renderer/main/nicommons/NicommonsTab.tsx
@@ -118,7 +118,7 @@ function NicommonsTab(): JSX.Element {
     () => packages.filter((p) => p.info.nicommons).map((p) => p.id),
     [packages],
   );
-  const installedIdsQuery = TRPCReact.packages.getApmJsonInstalledIds.useQuery(
+  const installedIdsQuery = TRPCReact.packages.getLedgerInstalledIds.useQuery(
     { instPath, ids: candidateIds },
     { refetchOnWindowFocus: false, enabled: packagesQuery.isSuccess },
   );
@@ -129,7 +129,7 @@ function NicommonsTab(): JSX.Element {
     };
     const onPackagesChanged = () => {
       void utils.packages.getPackages.invalidate();
-      void utils.packages.getApmJsonInstalledIds.invalidate();
+      void utils.packages.getLedgerInstalledIds.invalidate();
       // 旧実装は再描画のたびに全チェック済みへ戻していた
       setUncheckedIds(new Set());
     };

--- a/src/renderer/main/packages/PackageActions.tsx
+++ b/src/renderer/main/packages/PackageActions.tsx
@@ -61,7 +61,7 @@ function ActionButton({
 }
 
 export type PackageActionsProps = {
-  instPath: string;
+  installationPath: string;
   selectedEntry: SelectedEntry;
   packages: PackageState[];
 };
@@ -79,7 +79,7 @@ export type PackageActionsProps = {
  * @returns {JSX.Element} The rendered component.
  */
 function PackageActions({
-  instPath,
+  installationPath,
   selectedEntry,
   packages,
 }: PackageActionsProps): JSX.Element {
@@ -107,13 +107,15 @@ function PackageActions({
   // 一覧データの再取得(旧 checkPackagesList 相当)。設定タブの更新ボタンと
   // 実行状態を共有する
   const checkPackagesList = async () => {
-    await runPackagesListCheck(() => refreshListMutation.mutateAsync(instPath));
+    await runPackagesListCheck(() =>
+      refreshListMutation.mutateAsync(installationPath),
+    );
   };
 
   const installScript = async (url: string) => {
     install.start();
 
-    if (!instPath) {
+    if (!installationPath) {
       install.finish('インストール先フォルダを指定してください。', 'danger');
       return;
     }
@@ -122,7 +124,10 @@ function PackageActions({
       ReturnType<typeof installScriptMutation.mutateAsync>
     > | null;
     try {
-      result = await installScriptMutation.mutateAsync({ instPath, url });
+      result = await installScriptMutation.mutateAsync({
+        installationPath,
+        url,
+      });
     } catch {
       result = null; // installFailed 相当
     }
@@ -170,7 +175,7 @@ function PackageActions({
 
     install.start();
 
-    if (!instPath) {
+    if (!installationPath) {
       install.finish('インストール先フォルダを指定してください。', 'danger');
       return;
     }
@@ -199,7 +204,7 @@ function PackageActions({
     let result: Awaited<ReturnType<typeof installPackageMutation.mutateAsync>>;
     try {
       result = await installPackageMutation.mutateAsync({
-        instPath,
+        installationPath,
         packageItem: { id: installedPackage.id, info: installedPackage.info },
         direct: false,
       });
@@ -248,7 +253,7 @@ function PackageActions({
       return;
     }
 
-    if (!instPath) {
+    if (!installationPath) {
       uninstall.finish('インストール先フォルダを指定してください。', 'danger');
       return;
     }
@@ -260,7 +265,7 @@ function PackageActions({
     >;
     try {
       result = await uninstallPackageMutation.mutateAsync({
-        instPath,
+        installationPath,
         packageItem: {
           id: uninstalledPackage.id,
           info: uninstalledPackage.info,
@@ -305,7 +310,7 @@ function PackageActions({
     if (share.phase.kind === 'loading') return;
     share.start();
 
-    const text = await utils.packages.getShareString.fetch(instPath);
+    const text = await utils.packages.getShareString.fetch(installationPath);
     await writeClipboardMutation.mutateAsync({ text });
     share.finish('コピーしました', 'info');
   };

--- a/src/renderer/main/packages/PackageActions.tsx
+++ b/src/renderer/main/packages/PackageActions.tsx
@@ -205,7 +205,7 @@ function PackageActions({
     try {
       result = await installPackageMutation.mutateAsync({
         installationPath,
-        packageItem: { id: installedPackage.id, info: installedPackage.info },
+        packageState: { id: installedPackage.id, info: installedPackage.info },
         direct: false,
       });
     } catch {
@@ -266,7 +266,7 @@ function PackageActions({
     try {
       result = await uninstallPackageMutation.mutateAsync({
         installationPath,
-        packageItem: {
+        packageState: {
           id: uninstalledPackage.id,
           info: uninstalledPackage.info,
         },

--- a/src/renderer/main/packages/PackagesTab.tsx
+++ b/src/renderer/main/packages/PackagesTab.tsx
@@ -167,7 +167,7 @@ function PackagesTab(): JSX.Element {
     { update: false },
     { refetchOnWindowFocus: false },
   );
-  const coreVersionsQuery = TRPCReact.core.getApmJsonCoreVersions.useQuery(
+  const coreVersionsQuery = TRPCReact.core.getLedgerCoreVersions.useQuery(
     instPath,
     { refetchOnWindowFocus: false },
   );
@@ -180,7 +180,7 @@ function PackagesTab(): JSX.Element {
     const onPackagesChanged = () => {
       void utils.packages.getPackagesWithStatus.invalidate();
       void utils.packages.getScriptsList.invalidate();
-      void utils.core.getApmJsonCoreVersions.invalidate();
+      void utils.core.getLedgerCoreVersions.invalidate();
     };
     window.addEventListener('apm-core-changed', onCoreChanged);
     window.addEventListener('apm-packages-changed', onPackagesChanged);

--- a/src/renderer/main/packages/PackagesTab.tsx
+++ b/src/renderer/main/packages/PackagesTab.tsx
@@ -160,7 +160,7 @@ function PackagesTab(): JSX.Element {
 
   const utils = TRPCReact.useUtils();
   const packagesQuery = TRPCReact.packages.getPackagesWithStatus.useQuery(
-    { instPath, fixIntegrity: true },
+    { instPath, adoptManuallyInstalled: true },
     { refetchOnWindowFocus: false },
   );
   const scriptsQuery = TRPCReact.packages.getScriptsList.useQuery(

--- a/src/renderer/main/packages/PackagesTab.tsx
+++ b/src/renderer/main/packages/PackagesTab.tsx
@@ -15,7 +15,7 @@ import {
 } from '../../../shared/shareString';
 import type { PackageState } from '../../../types/packageState';
 import { TRPCReact } from '../../trpc';
-import { getInstallationPath } from '../instPath';
+import { getInstallationPath } from '../installationPath';
 import PackageActions, { type SelectedEntry } from './PackageActions';
 import { getPhase, subscribePhase } from './packagesListCheck';
 
@@ -148,7 +148,9 @@ const naturalCompare = (a: string, b: string) => {
  * @returns {JSX.Element} The rendered component.
  */
 function PackagesTab(): JSX.Element {
-  const [instPath, setInstPath] = useState(() => getInstallationPath());
+  const [installationPath, setInstallationPath] = useState(() =>
+    getInstallationPath(),
+  );
   const [searchString, setSearchString] = useState('');
   const [alertDismissed, setAlertDismissed] = useState(false);
   const [sort, setSort] = useState<SortState>({
@@ -160,7 +162,7 @@ function PackagesTab(): JSX.Element {
 
   const utils = TRPCReact.useUtils();
   const packagesQuery = TRPCReact.packages.getPackagesWithStatus.useQuery(
-    { instPath, adoptManuallyInstalled: true },
+    { installationPath, adoptManuallyInstalled: true },
     { refetchOnWindowFocus: false },
   );
   const scriptsQuery = TRPCReact.packages.getScriptsList.useQuery(
@@ -168,14 +170,14 @@ function PackagesTab(): JSX.Element {
     { refetchOnWindowFocus: false },
   );
   const coreVersionsQuery = TRPCReact.core.getLedgerCoreVersions.useQuery(
-    instPath,
+    installationPath,
     { refetchOnWindowFocus: false },
   );
 
   // レガシー側からの通知: インストール先変更と一覧の再取得要求
   useEffect(() => {
     const onCoreChanged = () => {
-      setInstPath(getInstallationPath());
+      setInstallationPath(getInstallationPath());
     };
     const onPackagesChanged = () => {
       void utils.packages.getPackagesWithStatus.invalidate();
@@ -370,7 +372,7 @@ function PackagesTab(): JSX.Element {
                 </div>
                 <div className="d-flex">
                   <PackageActions
-                    instPath={instPath}
+                    installationPath={installationPath}
                     selectedEntry={selectedEntry}
                     packages={packages}
                   />

--- a/src/renderer/main/packages/packagesListCheck.ts
+++ b/src/renderer/main/packages/packagesListCheck.ts
@@ -6,7 +6,7 @@ import type { ActionPhase } from '../usePhase';
 // からのイベント)の 3 経路から起動され、どこから呼んでもボタン表示と
 // オーバーレイが連動する。実行状態は起動元と表示側(別タブ)にまたがるため、
 // Context ではなくモジュールシングルトン + useSyncExternalStore で共有する
-// (instPath / startup の firstLaunch も同じパターン)。
+// (installationPath / startup の firstLaunch も同じパターン)。
 
 let phase: ActionPhase = { kind: 'idle' };
 let timer: ReturnType<typeof setTimeout> | null = null;

--- a/src/renderer/main/settings/ManualUpdateTable.tsx
+++ b/src/renderer/main/settings/ManualUpdateTable.tsx
@@ -1,6 +1,6 @@
 import React, { type JSX, useEffect, useSyncExternalStore } from 'react';
 import { TRPCReact } from '../../trpc';
-import { getInstallationPath } from '../instPath';
+import { getInstallationPath } from '../installationPath';
 import {
   getPhase,
   runPackagesListCheck,
@@ -91,8 +91,10 @@ function ManualUpdateTable(): JSX.Element {
 
   const checkPackagesList = async () => {
     // 旧実装どおり呼び出し時点の入力値を使う
-    const instPath = getInstallationPath();
-    await runPackagesListCheck(() => refreshListMutation.mutateAsync(instPath));
+    const installationPath = getInstallationPath();
+    await runPackagesListCheck(() =>
+      refreshListMutation.mutateAsync(installationPath),
+    );
   };
 
   // レガシー・他コンポーネントからの再描画通知と、データエディタ保存後の

--- a/src/renderer/main/startup.ts
+++ b/src/renderer/main/startup.ts
@@ -1,6 +1,6 @@
 import log from 'electron-log/renderer';
 import type { TRPCReact } from '../trpc';
-import { setInstallationPath } from './instPath';
+import { setInstallationPath } from './installationPath';
 
 // 初回起動かどうかのモジュールストア(TutorialAlert が購読する)。
 // 値は起動フローが一度だけ false → true に変えうるのみ
@@ -65,7 +65,7 @@ async function initSettings(client: TrpcClient): Promise<boolean> {
  * 以下の順序は仕様
  * (migration → initSettings → ensureInstallationPath → changeInstallationPath)。
  * 並べ替え・並列化はしない。React のマウントとは並行に走り、確定した値は
- * instPath ストアと firstLaunch ストア + apm-* イベントで各コンポーネントへ
+ * installationPath ストアと firstLaunch ストア + apm-* イベントで各コンポーネントへ
  * 伝える(イベント購読は旧実装からの継続。ストアへの一本化は別スライス)。
  * @param {TrpcClient} client - The tRPC client.
  */
@@ -84,8 +84,8 @@ export async function runStartupFlow(client: TrpcClient): Promise<void> {
     // *local*
     // インストール先の既定値書き込みと取得・mod 情報の更新・migration・
     // 変換辞書の適用は main プロセス側(services/core.ts)
-    const instPath = await client.core.ensureInstallationPath.mutate();
-    await client.core.changeInstallationPath.mutate(instPath);
+    const installationPath = await client.core.ensureInstallationPath.mutate();
+    await client.core.changeInstallationPath.mutate(installationPath);
     window.dispatchEvent(new Event('apm-core-changed'));
     window.dispatchEvent(new Event('apm-packages-changed'));
 
@@ -94,7 +94,7 @@ export async function runStartupFlow(client: TrpcClient): Promise<void> {
       firstLaunch = true;
       listeners.forEach((listener) => listener());
     }
-    setInstallationPath(instPath);
+    setInstallationPath(installationPath);
     // インストール先確定後に ProgramRow・データエディタへ再描画を通知する
     // (旧 preload と同じく、確定前にも一度発火している)
     window.dispatchEvent(new Event('apm-core-changed'));

--- a/src/shared/apmPath.test.ts
+++ b/src/shared/apmPath.test.ts
@@ -37,43 +37,45 @@ describe('pathRelated', () => {
 });
 
 describe('resolveInside', () => {
-  const instPath = path.resolve('/data', 'aviutl');
+  const installationPath = path.resolve('/data', 'aviutl');
 
   it('インストール先の中のパスをそのまま解決する', () => {
-    expect(resolveInside(instPath, 'plugins/foo.auf')).toBe(
-      path.join(instPath, 'plugins', 'foo.auf'),
+    expect(resolveInside(installationPath, 'plugins/foo.auf')).toBe(
+      path.join(installationPath, 'plugins', 'foo.auf'),
     );
   });
 
   it('複数のセグメントを結合できる', () => {
-    expect(resolveInside(instPath, 'script', 'developer', 'a.anm')).toBe(
-      path.join(instPath, 'script', 'developer', 'a.anm'),
-    );
+    expect(
+      resolveInside(installationPath, 'script', 'developer', 'a.anm'),
+    ).toBe(path.join(installationPath, 'script', 'developer', 'a.anm'));
   });
 
   it('親ディレクトリへ脱出するパスを拒否する', () => {
-    expect(() => resolveInside(instPath, '../evil.exe')).toThrow();
-    expect(() => resolveInside(instPath, 'plugins/../../evil.exe')).toThrow();
-    expect(() => resolveInside(instPath, 'script', '../../..', 'evil')).toThrow(
-      /invalid path/,
-    );
+    expect(() => resolveInside(installationPath, '../evil.exe')).toThrow();
+    expect(() =>
+      resolveInside(installationPath, 'plugins/../../evil.exe'),
+    ).toThrow();
+    expect(() =>
+      resolveInside(installationPath, 'script', '../../..', 'evil'),
+    ).toThrow(/invalid path/);
   });
 
   it('絶対パス指定を拒否する', () => {
     expect(() =>
-      resolveInside(instPath, path.resolve('/etc/passwd')),
+      resolveInside(installationPath, path.resolve('/etc/passwd')),
     ).toThrow();
   });
 
   it('インストール先そのものを指すパスを拒否する', () => {
-    // copy 先が instPath 自体になる指定は書き込み対象として不正
-    expect(() => resolveInside(instPath, '.')).toThrow();
-    expect(() => resolveInside(instPath, '')).toThrow();
+    // copy 先が installationPath 自体になる指定は書き込み対象として不正
+    expect(() => resolveInside(installationPath, '.')).toThrow();
+    expect(() => resolveInside(installationPath, '')).toThrow();
   });
 
   it('途中に .. があっても中に留まるなら許可する', () => {
-    expect(resolveInside(instPath, 'plugins/../script/a.anm')).toBe(
-      path.join(instPath, 'script', 'a.anm'),
+    expect(resolveInside(installationPath, 'plugins/../script/a.anm')).toBe(
+      path.join(installationPath, 'script', 'a.anm'),
     );
   });
 });

--- a/src/shared/install.test.ts
+++ b/src/shared/install.test.ts
@@ -165,7 +165,7 @@ describe('install', () => {
   it('展開ディレクトリの外を指す archivePath をコピー元にできない', async () => {
     const src = await makeTempDir('apm-install-src-');
     const inst = await makeTempDir('apm-install-dst-');
-    // 展開ディレクトリの外にあるファイル(instPath 内へ持ち出される標的)
+    // 展開ディレクトリの外にあるファイル(installationPath 内へ持ち出される標的)
     await writeFile(path.join(src, '..', 'apm-install-secret.txt'), 'secret');
 
     await expect(

--- a/src/shared/install.ts
+++ b/src/shared/install.ts
@@ -12,17 +12,17 @@ export type Files = {
 
 /**
  * Verifys files by count.
- * @param {string} instPath - An installation path.
+ * @param {string} installationPath - An installation path.
  * @param {object[]} files - An array of the files to be installed.
  * @returns {boolean} Whether all files exist.
  */
-export function verifyFilesByCount(instPath: string, files: Files) {
+export function verifyFilesByCount(installationPath: string, files: Files) {
   let filesCount = 0;
   let existCount = 0;
   for (const file of files) {
     if (!file.isUninstallOnly && !file.isObsolete) {
       filesCount++;
-      if (existsSync(path.join(instPath, file.filename))) {
+      if (existsSync(path.join(installationPath, file.filename))) {
         existCount++;
       }
     }
@@ -34,24 +34,30 @@ export function verifyFilesByCount(instPath: string, files: Files) {
  * Install some package.
  * エラーは発生元の例外をそのまま投げる(ログは呼び出し側の責務)。
  * @param {string} unzippedPath - A path of the unzipped directory.
- * @param {string} instPath - An installation path.
+ * @param {string} installationPath - An installation path.
  * @param {object[]} files - An array of the files to be installed.
  * @param {boolean} isProgram - Whether it is a program.
  * @returns {Promise<boolean>} Whether the installation was successful.
  */
 export async function install(
   unzippedPath: string,
-  instPath: string,
+  installationPath: string,
   files: Files,
   isProgram = false,
 ) {
   if (isProgram) {
-    await copy(unzippedPath, instPath);
+    await copy(unzippedPath, installationPath);
   } else {
     // Delete obsolete files
     for (const file of files) {
-      if (file.isObsolete && existsSync(path.join(instPath, file.filename))) {
-        await safeRemove(path.join(instPath, file.filename), instPath);
+      if (
+        file.isObsolete &&
+        existsSync(path.join(installationPath, file.filename))
+      ) {
+        await safeRemove(
+          path.join(installationPath, file.filename),
+          installationPath,
+        );
       }
     }
 
@@ -71,7 +77,7 @@ export async function install(
           : path.join(unzippedPath, path.basename(file.filename)),
         // filename はリモート由来。削除側(safeRemove)と同じくインストール先の
         // 外を指していないか確かめてから書き込む
-        resolveInside(instPath, file.filename),
+        resolveInside(installationPath, file.filename),
       ];
       if (file.isUninstallOnly) {
         if (existsSync(filePath[0]) && !existsSync(filePath[1]))
@@ -84,7 +90,7 @@ export async function install(
     );
   }
 
-  if (verifyFilesByCount(instPath, files)) {
+  if (verifyFilesByCount(installationPath, files)) {
     return true;
   } else {
     throw new Error('Could not verify that the files was installed.');

--- a/src/shared/installerArgs.ts
+++ b/src/shared/installerArgs.ts
@@ -5,7 +5,7 @@ const INSTALL_PATH_PLACEHOLDER = '$instpath';
  * Splits an `installArg` string into an argument array.
  *
  * 引用符はシェルと同じく引数の区切りを打ち消す用途にのみ使い、トークンからは
- * 取り除く(`/DIR="$instpath"` → `/DIR=<instPath>`)。シェルを介さず
+ * 取り除く(`/DIR="$instpath"` → `/DIR=<installationPath>`)。シェルを介さず
  * execFileSync へ渡すため、メタ文字(`&` `|` `;` など)は展開されず
  * ただの文字として実行ファイルに届く。
  * @param {string} installArg - The raw `installArg` from the package data.
@@ -51,15 +51,15 @@ function tokenize(installArg: string): string[] {
  * `$instpath` はトークン化した後に置換するため、インストール先のパスに空白や
  * シェルメタ文字が含まれていても引数の境界は動かない。
  * @param {string | undefined} installArg - The raw `installArg` from the package data.
- * @param {string} instPath - An installation path.
+ * @param {string} installationPath - An installation path.
  * @returns {string[]} The arguments for the installer.
  */
 export function buildInstallerArgs(
   installArg: string | undefined,
-  instPath: string,
+  installationPath: string,
 ): string[] {
   if (!installArg) return [];
   return tokenize(installArg).map((arg) =>
-    arg.replaceAll(INSTALL_PATH_PLACEHOLDER, instPath),
+    arg.replaceAll(INSTALL_PATH_PLACEHOLDER, installationPath),
   );
 }

--- a/src/shared/integrity.ts
+++ b/src/shared/integrity.ts
@@ -4,12 +4,12 @@ import { checkStream } from 'ssri';
 
 /**
  * Check for integrity.
- * @param {string} instPath - An installation path.
+ * @param {string} installationPath - An installation path.
  * @param {object[]} integrities - List of integrity objects.
  * @returns {Promise<boolean>} Integrities match or don't match.
  */
 export async function checkIntegrity(
-  instPath: string,
+  installationPath: string,
   integrities: { target: string; hash: string }[],
 ) {
   if (integrities.length === 0) return false;
@@ -18,7 +18,10 @@ export async function checkIntegrity(
   for (const integrity of integrities) {
     match =
       match &&
-      (await verifyFile(path.join(instPath, integrity.target), integrity.hash));
+      (await verifyFile(
+        path.join(installationPath, integrity.target),
+        integrity.hash,
+      ));
   }
 
   return match;

--- a/src/shared/packageId.test.ts
+++ b/src/shared/packageId.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { convertV1ApmJsonPackages, convertV1PackageIds } from './packageId';
+import { convertV1LedgerPackages, convertV1PackageIds } from './packageId';
 
 // services/packages.ts に重複していた ID 変換ループの特性化テスト。
 // ID 例は実在の変換辞書の形式(v1 の連結形 → v2 以降の developer/name 形)。
@@ -27,13 +27,13 @@ describe('convertV1PackageIds', () => {
   });
 });
 
-describe('convertV1ApmJsonPackages', () => {
+describe('convertV1LedgerPackages', () => {
   it('キーと id の両方を現行 ID へ書き換える(in place)', () => {
     const packages: { [key: string]: { id: string; version: string } } = {
       MrOjii_LSMASHWorks: { id: 'MrOjii_LSMASHWorks', version: 'v1' },
       'rigaya/NVEnc': { id: 'rigaya/NVEnc', version: 'v2' },
     };
-    convertV1ApmJsonPackages(packages, {
+    convertV1LedgerPackages(packages, {
       MrOjii_LSMASHWorks: 'MrOjii/LSMASHWorks',
     });
     expect(packages).toEqual({
@@ -46,7 +46,7 @@ describe('convertV1ApmJsonPackages', () => {
     // キーと id が食い違うデータでは id 側の変換結果が採用され、
     // id が辞書に無ければ undefined キーになる(旧 convertId と同一)
     const packages = { oldKey: { id: 'unknownId' } };
-    convertV1ApmJsonPackages(packages, { oldKey: 'new/key' });
+    convertV1LedgerPackages(packages, { oldKey: 'new/key' });
     expect(packages).toEqual({ undefined: { id: undefined } });
   });
 });

--- a/src/shared/packageId.test.ts
+++ b/src/shared/packageId.test.ts
@@ -42,7 +42,7 @@ describe('convertV1LedgerPackages', () => {
     });
   });
 
-  it('変換判定はキーで行い、新 ID の解決は packageItem.id を辞書に引く(既存挙動の保存)', () => {
+  it('変換判定はキーで行い、新 ID の解決は ledgerEntry.id を辞書に引く(既存挙動の保存)', () => {
     // キーと id が食い違うデータでは id 側の変換結果が採用され、
     // id が辞書に無ければ undefined キーになる(旧 convertId と同一)
     const packages = { oldKey: { id: 'unknownId' } };

--- a/src/shared/packageId.ts
+++ b/src/shared/packageId.ts
@@ -29,7 +29,7 @@ export function convertV1PackageIds(
  * @param {{ [key: string]: { id: string } }} packages - The apm.json packages object.
  * @param {PackageIdDict} convDict - Dictionary of id relationships.
  */
-export function convertV1ApmJsonPackages(
+export function convertV1LedgerPackages(
   packages: { [key: string]: { id: string } },
   convDict: PackageIdDict,
 ) {

--- a/src/shared/packageId.ts
+++ b/src/shared/packageId.ts
@@ -24,7 +24,7 @@ export function convertV1PackageIds(
 /**
  * Converts the keys and ids of the apm.json packages object in place.
  * 旧 convertId と同一の挙動 — 変換対象かどうかは旧キー(oldId)で判定するが、
- * 新 ID の解決は packageItem.id を辞書に引く(キーと id が食い違うデータでは
+ * 新 ID の解決は ledgerEntry.id を辞書に引く(キーと id が食い違うデータでは
  * 結果も食い違う。これは既存挙動の保存であり、意図的な仕様ではない)。
  * @param {{ [key: string]: { id: string } }} packages - The apm.json packages object.
  * @param {PackageIdDict} convDict - Dictionary of id relationships.
@@ -33,9 +33,9 @@ export function convertV1LedgerPackages(
   packages: { [key: string]: { id: string } },
   convDict: PackageIdDict,
 ) {
-  for (const [oldId, packageItem] of Object.entries(packages)) {
+  for (const [oldId, ledgerEntry] of Object.entries(packages)) {
     if (Object.prototype.hasOwnProperty.call(convDict, oldId)) {
-      const newId = convDict[packageItem.id];
+      const newId = convDict[ledgerEntry.id];
       packages[newId] = packages[oldId];
       delete packages[oldId];
       packages[newId].id = newId;

--- a/src/shared/packageInfoValidation.ts
+++ b/src/shared/packageInfoValidation.ts
@@ -1,4 +1,4 @@
-// tRPC 境界(renderer は非信頼)で packageItem.info のセキュリティ不変条件を
+// tRPC 境界(renderer は非信頼)で packageState.info のセキュリティ不変条件を
 // 検証する。apm-schema の JSON Schema 全体を強制しないのは、name の文字数上限の
 // ような表示用制約まで強制するとサードパーティ dataURL の緩いデータが
 // インストールできなくなるため(dataURL 自由入力の確定方針と衝突する)。

--- a/src/shared/packageUtil.ts
+++ b/src/shared/packageUtil.ts
@@ -134,7 +134,7 @@ export function getInstalledVersionOfPackage(
  * Computes doNotInstall / detached of the packages from the dependency and
  * conflict information.
  * 旧 getPackagesStatus の計算部分(apm.json の読み出しを除く)と同一の挙動。
- * @param {object[]} _packages - A list of object parsed from packages.json and getPackagesExtra()
+ * @param {object[]} _packages - A list of object parsed from packages.json and resolveInstallationStatus()
  * @param {string} aviUtlVer - An installed version of AviUtl.
  * @param {string} exeditVer - An installed version of 拡張編集.
  * @returns {object[]} - packages

--- a/src/shared/packageUtil.ts
+++ b/src/shared/packageUtil.ts
@@ -81,7 +81,7 @@ export function getManuallyInstalledFiles(
  * @param {string[]} installedFiles - List of installed files
  * @param {string[]} manuallyInstalledFiles - List of manually installed files
  * @param {object[]} installedPackages - A list of object from ledger
- * @param {string} instPath - An installation path
+ * @param {string} installationPath - An installation path
  * @returns {object} Installed version or installation status of the package
  */
 export function getInstalledVersionOfPackage(
@@ -89,7 +89,7 @@ export function getInstalledVersionOfPackage(
   installedFiles: string[],
   manuallyInstalledFiles: string[],
   installedPackages: LedgerObject['packages'],
-  instPath: string,
+  installationPath: string,
 ) {
   let installationStatus;
   let version;
@@ -117,7 +117,7 @@ export function getInstalledVersionOfPackage(
         version = installedPackage.version;
       } else {
         // Determine if the package has been installed properly.
-        if (verifyFilesByCount(instPath, packageItem.info.files)) {
+        if (verifyFilesByCount(installationPath, packageItem.info.files)) {
           installationStatus = states.installed;
           version = installedPackage.version;
         } else {

--- a/src/shared/packageUtil.ts
+++ b/src/shared/packageUtil.ts
@@ -59,10 +59,10 @@ export function getManuallyInstalledFiles(
   packages: PackageState[],
 ) {
   let retFiles = [...files];
-  for (const packageItem of packages) {
+  for (const packageState of packages) {
     for (const installedId of Object.keys(installedPackages)) {
-      if (installedId === packageItem.id) {
-        for (const file of packageItem.info.files) {
+      if (installedId === packageState.id) {
+        for (const file of packageState.info.files) {
           if (!file.isDirectory) {
             retFiles = retFiles.filter((ef) => ef !== file.filename);
           } else {
@@ -77,7 +77,7 @@ export function getManuallyInstalledFiles(
 
 /**
  * Returns the installed version or installation status of the package.
- * @param {object} packageItem - A Package
+ * @param {object} packageState - A Package
  * @param {string[]} installedFiles - List of installed files
  * @param {string[]} manuallyInstalledFiles - List of manually installed files
  * @param {object[]} installedPackages - A list of object from ledger
@@ -85,7 +85,7 @@ export function getManuallyInstalledFiles(
  * @returns {object} Installed version or installation status of the package
  */
 export function getInstalledVersionOfPackage(
-  packageItem: PackageState,
+  packageState: PackageState,
   installedFiles: string[],
   manuallyInstalledFiles: string[],
   installedPackages: LedgerObject['packages'],
@@ -95,7 +95,7 @@ export function getInstalledVersionOfPackage(
   let version;
   let isInstalledPackage = false;
   let isManuallyInstalledPackage = false;
-  for (const file of packageItem.info.files) {
+  for (const file of packageState.info.files) {
     if (file.isInstallOnly) continue; // isInstallOnly is not used to determine installation status because the file is often shared by multiple packages.
     if (installedFiles.includes(file.filename)) isInstalledPackage = true;
     if (manuallyInstalledFiles.includes(file.filename))
@@ -110,14 +110,14 @@ export function getInstalledVersionOfPackage(
   for (const [installedId, installedPackage] of Object.entries(
     installedPackages,
   )) {
-    if (installedId === packageItem.id) {
-      if (packageItem.info.files.some((file) => file.isObsolete)) {
+    if (installedId === packageState.id) {
+      if (packageState.info.files.some((file) => file.isObsolete)) {
         // There is no way to determine if a package that contains obsolete files is corrupt.
         installationStatus = states.installed;
         version = installedPackage.version;
       } else {
         // Determine if the package has been installed properly.
-        if (verifyFilesByCount(installationPath, packageItem.info.files)) {
+        if (verifyFilesByCount(installationPath, packageState.info.files)) {
           installationStatus = states.installed;
           version = installedPackage.version;
         } else {

--- a/src/shared/parsePackagesXml.ts
+++ b/src/shared/parsePackagesXml.ts
@@ -133,7 +133,7 @@ export interface ReleaseInfo {
 function parseFiles(parsedData: RawPackage): XmlFile[] {
   const files: XmlFile[] = [];
   for (const file of parsedData.files[0].file) {
-    const tmpFile: XmlFile = {
+    const xmlFile: XmlFile = {
       filename: null,
       isOptional: false,
       isInstallOnly: false,
@@ -142,20 +142,20 @@ function parseFiles(parsedData: RawPackage): XmlFile[] {
       archivePath: null,
     };
     if (typeof file === 'string') {
-      tmpFile.filename = file;
+      xmlFile.filename = file;
     } else if (typeof file === 'object') {
-      tmpFile.filename = file._;
-      if (file.$optional) tmpFile.isOptional = Boolean(file.$optional[0]);
+      xmlFile.filename = file._;
+      if (file.$optional) xmlFile.isOptional = Boolean(file.$optional[0]);
       if (file.$installOnly)
-        tmpFile.isInstallOnly = Boolean(file.$installOnly[0]);
-      if (file.$directory) tmpFile.isDirectory = Boolean(file.$directory[0]);
-      if (file.$obsolete) tmpFile.isObsolete = Boolean(file.$obsolete[0]);
-      if (file.$archivePath) tmpFile.archivePath = file.$archivePath[0];
+        xmlFile.isInstallOnly = Boolean(file.$installOnly[0]);
+      if (file.$directory) xmlFile.isDirectory = Boolean(file.$directory[0]);
+      if (file.$obsolete) xmlFile.isObsolete = Boolean(file.$obsolete[0]);
+      if (file.$archivePath) xmlFile.archivePath = file.$archivePath[0];
     } else {
       continue;
     }
-    Object.freeze(tmpFile);
-    files.push(tmpFile);
+    Object.freeze(xmlFile);
+    files.push(xmlFile);
   }
   return files;
 }
@@ -197,13 +197,13 @@ export class PackageInfo {
         if (key === 'files') {
           this.files = parseFiles(parsedPackage);
         } else if (key === 'latestVersion') {
-          const tmpObj = parsedPackage[key][0];
-          if (typeof tmpObj === 'string') {
-            this[key] = tmpObj;
-          } else if (typeof tmpObj === 'object') {
-            this[key] = tmpObj._;
-            if (tmpObj.$continuous)
-              this.isContinuous = Boolean(tmpObj.$continuous[0]);
+          const parsedValue = parsedPackage[key][0];
+          if (typeof parsedValue === 'string') {
+            this[key] = parsedValue;
+          } else if (typeof parsedValue === 'object') {
+            this[key] = parsedValue._;
+            if (parsedValue.$continuous)
+              this.isContinuous = Boolean(parsedValue.$continuous[0]);
           }
         } else if (key === 'releases') {
           // version はリモート由来のままキーになる。__proto__ のような名前で

--- a/src/shared/parsePackagesXml.ts
+++ b/src/shared/parsePackagesXml.ts
@@ -248,8 +248,8 @@ export function parsePackagesXml(xmlData: string): PackagesList {
 
   // id はリモート由来のままキーになるため、releases と同じく継承なしにする
   const packages: PackagesList = Object.create(null) as PackagesList;
-  for (const packageItem of packagesInfo.packages[0].package) {
-    packages[packageItem.id[0]] = new PackageInfo(packageItem);
+  for (const parsedPackage of packagesInfo.packages[0].package) {
+    packages[parsedPackage.id[0]] = new PackageInfo(parsedPackage);
   }
   return packages;
 }

--- a/src/types/packageState.d.ts
+++ b/src/types/packageState.d.ts
@@ -3,7 +3,7 @@ import { Packages } from 'apm-schema';
 /**
  * パッケージの定義(info)と、あるインストール先での現在の状態を束ねた型。
  * 旧 PackageItem。version 以降が optional なのは、getPackages(定義 + type
- * のみ)→ getPackagesExtra(installationStatus / version)→
+ * のみ)→ resolveInstallationStatus(installationStatus / version)→
  * getPackagesWithStatus(doNotInstall / detached)の順に段階的に埋まるため。
  */
 export type PackageState = {


### PR DESCRIPTION
## 概要

Phase 5(#2379)スライス⑥(#A2-⑥)。全識別子を棚卸しし、意味の見えない名前・ユビキタス言語と食い違う名前を統一します。Phase 5 の締めとして、確定したユビキタス言語対応表を AGENTS.md に記録します。

**挙動は完全に同一**です(識別子とドキュメントのみの変更。特性化テスト 251 件は名前の追随以外変更なし)。

## コミット構成(論理単位で 6 分割)

### 1. 導入記録系の識別子を Ledger 語彙へ統一

#2409 で procedure 名に露出するため温存していた残り: `getApmJsonCoreVersions` → `getLedgerCoreVersions` / `getApmJsonInstalledIds` → `getLedgerInstalledIds` / `convertV1ApmJsonPackages` → `convertV1LedgerPackages`(procedure 名も改名、renderer 追随)。

### 2. 役割の見えない名前をユビキタス言語で言い直す

- `getPackagesExtra` → `resolveInstallationStatus`(実態は PackageState の installationStatus / version の解決 + 手動導入ファイルの検出)
- `fixIntegrity` 引数 → `adoptManuallyInstalled`(切り出し済みの `adoptManuallyInstalledPackages` と語彙を統一。ワイヤの入力フィールド名も変更)
- `downloadRepository` → `downloadPackagesData`
- `tmp` 接頭辞のローカル変数を実体で命名(`ledgerPackages` / `installedFiles` / `manuallyInstalledFiles` / `xmlFile` / `parsedValue`)

### 3. instPath → installationPath 統一(32 ファイル・290 箇所)

Config キー・DOM id・renderer ストア関数は既に installationPath 系で、略した `instPath` が境界(tRPC 入力フィールド・関数引数)にだけ残っていた。`src/renderer/main/instPath.ts` → `installationPath.ts`(git mv)も含む。

### 4. dataURL / dataUrl の識別子揺れを dataUrl へ統一

識別子は camelCase の `dataUrl` 系(既存関数名の多数派 + TS 慣例)。`config.dataURL` → `config.dataUrl` 等。**ディスク上 config.json のキー(`'dataURL.main'` 等)・コメントやドキュメントの概念表記「dataURL」・apm-schema 由来フィールドは不変**(StoreType に理由コメントを追加)。

### 5. packageItem を実体ごとの名前へ分離

`PackageState` 型改名(#2407)後も残っていた変数 `packageItem` は文脈により指す実体が違ったため分離: PackageState 値 → `packageState`(ワイヤフィールド含む)/ list.json エントリ → `packagesFile` / XML パース済み要素 → `parsedPackage` / ledger 記録エントリ → `ledgerEntry` / scriptInstall で生成する定義 → `newPackage`。

### 6. ユビキタス言語対応表を AGENTS.md へ記録

概念とコードの対応表 + **改名してはいけないもの**(ディスク形式のキー・apm-schema フィールド・`$instpath` プレースホルダ・JSDoc の旧実装名言及)を明文化。ARCHITECTURE.md の `{instPath}` 表記も追随。

## 挙動同一の担保

- tRPC の procedure 名・入力フィールド名の変更は main / renderer を同一コミットで変更(同時にビルドされるため互換問題なし)。renderer と main の間のワイヤ形式は各コミット内で一貫
- ディスク互換に触れない: `apm.json`(ファイル名・`convertMod` 等のキー)、`config.json` のキー、`$instpath` 書式はすべて不変
- JSDoc の「旧 〜 と同一の挙動」に現れる旧実装の識別子は歴史的記述のため温存

## 検証

- [x] `yarn lint` / `yarn lint:ts` / `yarn test`(251 件)
- [x] Node 22 で `yarn package` + `yarn test:e2e`(3 件)— 改名後のワイヤ形式(installationPath / adoptManuallyInstalled / packageState フィールド)を実 IPC で通過

これで Phase 5 の #A2 系スライスは完了です。マージ後は #A1(レガシー IPC の tRPC 集約)へ進みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
