### PR TITLE
refactor: レガシー IPC を preload 専用の 1 チャンネルへ縮小(Phase 5 #A1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,12 @@ AviUtl Package Manager (apm) — AviUtl のプラグイン・スクリプトを�
 
 | パス                 | 役割                                                                                                                                                 |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/main/`          | メインプロセス。`index.ts` = エントリ、`api.ts` = tRPC ルーター、`services/` = ビジネスロジック                                                      |
+| `src/main/`          | メインプロセス。`index.ts` = エントリ、`api/` = tRPC ルーター、`services/` = ビジネスロジック                                                        |
 | `src/renderer/`      | 窓ごと(`main` / `about` / `splash`)。forge.config.ts の entryPoints と 1:1 対応                                                                      |
 | `src/renderer/main/` | main 窓。単一 React ルート(`App.tsx`)+ タブごとのディレクトリ(`aviutl` / `packages` / `nicommons` / `settings` / `others`)+ 起動フロー(`startup.ts`) |
-| `src/lib/`           | renderer から使う electron 依存モジュール(`ipcWrapper.ts`)                                                                                           |
+| `src/lib/`           | renderer から使う electron 依存モジュール(`ipcWrapper.ts` = preload 専用)                                                                            |
 | `src/shared/`        | electron 非依存の純粋モジュール。ユニットテストの主対象                                                                                              |
-| `src/common/ipc.ts`  | レガシー IPC のチャンネル名定義                                                                                                                      |
+| `src/common/ipc.ts`  | preload 専用 IPC のチャンネル名定義(他はすべて tRPC。理由はファイル内コメント)                                                                       |
 
 プロセス構成・main プロセスの内訳・データフローの詳細は ARCHITECTURE.md を参照。
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ Electron の 3 窓 + main プロセス。窓はすべて `sandbox: true`。
 
 - ビジネスロジックは main プロセス(`src/main/services/`)。renderer からは tRPC(trpc-electron)で呼ぶ
 - このほか `services/browser.ts` がダウンロード用のモーダルブラウザ窓を動的に生成する(forge の entryPoint ではない)
-- IPC は 2 系統が併存: tRPC(主)と、レガシー `ipcMain.handle`(`src/common/ipc.ts` のチャンネル定義 + `src/lib/ipcWrapper.ts`。ダイアログ・app 情報取得など少数のチャンネルが残る)
+- IPC は tRPC に集約済み。例外は preload のエラーハンドラ用ダイアログの 1 チャンネルのみ(`src/common/ipc.ts` + `src/lib/ipcWrapper.ts`。preload に tRPC クライアントを置けない理由は `src/common/ipc.ts` のコメントを参照)
 
 ## ディレクトリと責務
 
@@ -22,8 +22,8 @@ Electron の 3 窓 + main プロセス。窓はすべて `sandbox: true`。
 src/
   shared/     electron 完全非依存の純粋モジュール(main / renderer 両方から import 可)。
               ユニットテストの主対象。fs 依存の可否は AGENTS.md 落とし穴を参照
-  lib/        renderer から使う electron 依存モジュール(ipcWrapper)
-  common/     レガシー IPC のチャンネル名定義(ipc.ts)
+  lib/        renderer から使う electron 依存モジュール(ipcWrapper = preload 専用)
+  common/     preload 専用 IPC のチャンネル名定義(ipc.ts)
   main/       main プロセス(下記)
   renderer/   窓ごとの UI(上の表を参照)。main/ 配下はタブ単位
               (aviutl / packages / nicommons / settings / others)
@@ -35,8 +35,8 @@ main プロセスの内訳:
 ```
 src/main/
   index.ts        エントリ(ログ・config 初期化、app イベント、ハンドラ登録)
-  windows.ts      窓生成(splash / main / about)+ 窓依存のレガシー IPC ハンドラ
-  ipcHandlers.ts  窓に依存しないレガシー IPC ハンドラの登録
+  windows.ts      窓生成(splash / main / about)+ tRPC ハンドラの張り付け
+  ipcHandlers.ts  preload 専用 IPC ハンドラの登録(エラーダイアログのみ)
   api/            tRPC ルーター(index = 集約、trpc = middleware、
                   ドメイン別ルーターの procedure から services/ を呼ぶ。
                   installationPath 入力は middleware が Installation に解決して渡す)

--- a/src/common/ipc.ts
+++ b/src/common/ipc.ts
@@ -1,10 +1,7 @@
+// レガシー IPC は preload 専用の 1 チャンネルのみ(他はすべて tRPC へ集約済み)。
+// preload にも tRPC クライアントを置けば揃えられるが、1 窓に複数クライアントを
+// 作るとリクエスト ID が衝突する(AGENTS.md 落とし穴)ため、エラーダイアログは
+// レガシー IPC のまま維持する
 export const IPC_CHANNELS = {
-  GET_APP_NAME: 'get-app-name',
-  GET_APP_VERSION: 'get-app-version',
-  APP_GET_PATH: 'app-get-path',
-  APP_QUIT: 'app-quit',
-  OPEN_PATH: 'open-path',
   OPEN_DIALOG: 'open-dialog',
-  OPEN_YES_NO_DIALOG: 'open-yes-no-dialog',
-  CLIPBOARD_WRITE_TEXT: 'clipboard-write-text',
 };

--- a/src/lib/ipcWrapper.ts
+++ b/src/lib/ipcWrapper.ts
@@ -1,81 +1,9 @@
 import { ipcRenderer } from 'electron';
 import { IPC_CHANNELS } from '../common/ipc';
 
-export const app = {
-  /**
-   * Gets the app's name.
-   * @returns {Promise<string>} The app's name.
-   */
-  getName: async function () {
-    return (await ipcRenderer.invoke(IPC_CHANNELS.GET_APP_NAME)) as string;
-  },
-
-  /**
-   * Gets the app's version.
-   * @returns {Promise<string>} The app's version.
-   */
-  getVersion: async function () {
-    return (await ipcRenderer.invoke(IPC_CHANNELS.GET_APP_VERSION)) as string;
-  },
-
-  /**
-   * Gets a path to a special directory or file associated with `name`.
-   * @param {string} name - A name associated with a special directory or file you get.
-   * @returns {Promise<string>} The path to the special directory or file.
-   */
-  getPath: async function (
-    name:
-      | 'home'
-      | 'appData'
-      | 'userData'
-      | 'cache'
-      | 'temp'
-      | 'exe'
-      | 'module'
-      | 'desktop'
-      | 'documents'
-      | 'downloads'
-      | 'music'
-      | 'pictures'
-      | 'videos'
-      | 'recent'
-      | 'logs'
-      | 'crashDumps',
-  ) {
-    return (await ipcRenderer.invoke(
-      IPC_CHANNELS.APP_GET_PATH,
-      name,
-    )) as string;
-  },
-
-  /**
-   * Quits the app.
-   */
-  quit: async function () {
-    await ipcRenderer.invoke(IPC_CHANNELS.APP_QUIT);
-  },
-};
-
 /**
- * Opens a file explorer and returns whether the directory exists.
- * @param {string} relativePath - A relative path from the data directory.
- * @returns {Promise<boolean>} Whether the directory exists.
- */
-export async function openPath(relativePath: string) {
-  return (await ipcRenderer.invoke(
-    IPC_CHANNELS.OPEN_PATH,
-    relativePath,
-  )) as boolean;
-}
-
-/**
- * Opens a directory dialog and returns the path selected by a user.
- * @param {string} title - A title of the dialog.
- * @param {string} defaultPath - A path of the initial directory.
- * @returns {Promise<string[]>} The path selected by the user.
- */
-/**
- * Opens a error dialog.
+ * Opens an error dialog.
+ * preload のエラーハンドラ専用(メインワールドは tRPC の openDialog を使う)
  * @param {string} title - A title of the dialog.
  * @param {string} message - A message showed in the dialog.
  * @param {'none' | 'info' | 'error' | 'question' | 'warning'} [type] - A type of the dialog.
@@ -86,26 +14,4 @@ export async function openDialog(
   type?: 'none' | 'info' | 'error' | 'question' | 'warning',
 ) {
   await ipcRenderer.invoke(IPC_CHANNELS.OPEN_DIALOG, title, message, type);
-}
-
-/**
- * Opens a yes-no dialog and returns a response.
- * @param {string} title - A title of the dialog.
- * @param {string} message - A message showed in the dialog.
- * @returns {Promise<boolean>} The user's response.
- */
-export async function openYesNoDialog(title: string, message: string) {
-  return (await ipcRenderer.invoke(
-    IPC_CHANNELS.OPEN_YES_NO_DIALOG,
-    title,
-    message,
-  )) as boolean;
-}
-
-/**
- * Writes the text into the clipboard as plain text.
- * @param {string} text - plain text.
- */
-export async function clipboardWriteText(text: string) {
-  await ipcRenderer.invoke(IPC_CHANNELS.CLIPBOARD_WRITE_TEXT, text);
 }

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -1,74 +1,12 @@
-import {
-  app,
-  BrowserWindow,
-  clipboard,
-  dialog,
-  ipcMain,
-  shell,
-} from 'electron';
-import log from 'electron-log/main';
-import fs from 'fs-extra';
-import path from 'node:path';
+import { dialog, ipcMain } from 'electron';
 import { IPC_CHANNELS } from '../common/ipc';
-import { isParent } from '../shared/apmPath';
-
-const APP_PATH_NAMES = new Set([
-  'home',
-  'appData',
-  'userData',
-  'sessionData',
-  'temp',
-  'exe',
-  'module',
-  'desktop',
-  'documents',
-  'downloads',
-  'music',
-  'pictures',
-  'videos',
-  'recent',
-  'logs',
-  'crashDumps',
-]);
 
 /**
- * Registers the IPC handlers that do not depend on a specific window.
+ * Registers the legacy IPC handlers used by the preload scripts.
+ * メインワールドの renderer は tRPC(api/app.ts の openDialog)を使う。
+ * ここに残るのは preload のエラーハンドラ専用チャンネルのみ(src/common/ipc.ts)
  */
 export function registerIpcHandlers() {
-  ipcMain.handle(IPC_CHANNELS.GET_APP_NAME, () => {
-    return app.name;
-  });
-
-  ipcMain.handle(IPC_CHANNELS.GET_APP_VERSION, () => {
-    return app.getVersion();
-  });
-
-  ipcMain.handle(IPC_CHANNELS.APP_GET_PATH, (event, name) => {
-    if (!APP_PATH_NAMES.has(name)) {
-      throw new Error(`An invalid path name was requested: ${name}`);
-    }
-    return app.getPath(name as Parameters<typeof app.getPath>[0]);
-  });
-
-  ipcMain.handle(IPC_CHANNELS.APP_QUIT, () => {
-    app.quit();
-  });
-
-  ipcMain.handle(IPC_CHANNELS.OPEN_PATH, async (event, relativePath) => {
-    const dataDir = path.join(app.getPath('userData'), 'Data/');
-    const folderPath = path.join(dataDir, relativePath);
-    // relativePath はリモート由来のパッケージ ID を含むため、データフォルダ外は拒否する
-    if (!isParent(dataDir, folderPath)) {
-      log.error(
-        `Refused to open a path outside the data folder: ${relativePath}`,
-      );
-      return false;
-    }
-    const folderExists = fs.existsSync(folderPath);
-    if (folderExists) await shell.openPath(folderPath);
-    return folderExists;
-  });
-
   ipcMain.handle(
     IPC_CHANNELS.OPEN_DIALOG,
     async (event, title, message, type) => {
@@ -79,27 +17,4 @@ export function registerIpcHandlers() {
       });
     },
   );
-
-  ipcMain.handle(
-    IPC_CHANNELS.OPEN_YES_NO_DIALOG,
-    async (event, title, message) => {
-      const win = BrowserWindow.getFocusedWindow();
-      const response = await dialog.showMessageBox(win, {
-        title: title,
-        message: message,
-        type: 'warning',
-        buttons: ['はい', `いいえ`],
-        cancelId: 1,
-      });
-      if (response.response === 0) {
-        return true;
-      } else {
-        return false;
-      }
-    },
-  );
-
-  ipcMain.handle(IPC_CHANNELS.CLIPBOARD_WRITE_TEXT, async (event, text) => {
-    clipboard.writeText(text);
-  });
 }


### PR DESCRIPTION
## 概要

Phase 5(#2379)の **#A1**: 旧 `ipcMain.handle` の tRPC 集約と lib / common の整理です。

調査の結果、「集約」はほぼ完了済みで、残っていたのは死にコードでした。Phase 4 の React 化で renderer の呼び出し元は順次 tRPC(`api/app.ts` の `openDialog` / `writeClipboardText` / `getAppName` / `getAppVersion` / `quitApp` 等)へ移行済みで、レガシー 8 チャンネル中 7 つはハンドラとラッパーだけが残る状態でした(`ipcWrapper` の実 import は preload の `openDialog` のみ。`OPEN_PATH` 相当は `packageInstall.ts` に main 側実装済み)。

**挙動は完全に同一**です(呼び出し元のないコードの削除とドキュメント追随のみ)。

## 変更内容

### 1. レガシー IPC を preload 専用の 1 チャンネルへ縮小

- 削除: `GET_APP_NAME` / `GET_APP_VERSION` / `APP_GET_PATH` / `APP_QUIT` / `OPEN_PATH` / `OPEN_YES_NO_DIALOG` / `CLIPBOARD_WRITE_TEXT`(ハンドラ + ラッパー + チャンネル定義。計 -192 行)
- 温存: `OPEN_DIALOG` のみ — preload のエラーハンドラ(`log.errorHandler.startCatching`)が使用。**preload にも tRPC クライアントを置けば全廃できるが、1 窓に複数クライアントを作るとリクエスト ID が衝突する**(AGENTS.md 落とし穴)ため、意図的にレガシーのまま維持。理由を `src/common/ipc.ts` の Why not コメントに記載
- これで `src/lib/`(ipcWrapper)と `src/common/`(ipc.ts)は「preload 専用」という役割が明確になった。チャンネル定義は main / renderer 両方から import するため `common/` に置く構造は維持

### 2. ドキュメント追随

- ARCHITECTURE.md: 「IPC は 2 系統が併存」→「tRPC に集約済み、例外は preload 用 1 チャンネル」。あわせて stale だった「windows.ts の窓依存レガシー IPC ハンドラ」(実態なし)を修正
- AGENTS.md: 構成表の `src/lib/` / `src/common/ipc.ts` の役割を更新。stale だった `api.ts`(現 `api/`)も修正

## 検証

- [x] `yarn lint` / `yarn lint:ts` / `yarn test`(251 件)
- [x] Node 22 で `yarn package` + `yarn test:e2e`(3 件)— preload 経由の起動・ダイアログ経路を実バイナリで通過

マージ後は #DX1(掃除: 未使用 `@types/list.js`・不要 `Store.initRenderer()`)へ進みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
