### PR TITLE
chore: 未使用の @types/list.js と Store.initRenderer() を削除(Phase 5 #DX1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "@types/electron-prompt": "^1.6.5",
     "@types/electron-window-state": "^5.0.2",
     "@types/fs-extra": "^11.0.4",
-    "@types/list.js": "^2.3.5",
     "@types/node-7z": "^2.1.11",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,6 @@
 import { app, BrowserWindow, dialog, MessageBoxOptions } from 'electron';
 import debug from 'electron-debug';
 import log from 'electron-log/main';
-import Store from 'electron-store';
 import path from 'node:path';
 import 'source-map-support/register';
 import { getConfig } from './Config';
@@ -56,7 +55,6 @@ if (userDataDir) {
 }
 debug({ showDevTools: false }); // Press F12 to open DevTools
 
-Store.initRenderer();
 const config = getConfig();
 
 ensureAutoUpdateDefault(config);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2184,11 +2184,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/list.js@^2.3.5":
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/@types/list.js/-/list.js-2.3.5.tgz#20f405ce7a11686ce7feec2af031f36d7e1b69ac"
-  integrity sha512-IBtZ+tt42NxB4zzEKItnBIEa35AUXUMuWbIDKkpZYpu1HHbxj9Yd9fHYkM9l+xkHhGgCWGtDqwqGo+hktl9h3g==
-
 "@types/mime@^1":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.5.tgz#1ef302e01cf7d2b5a0fa526790c9123bf1d06690"


### PR DESCRIPTION
## 概要

Phase 5(#2379)のスライス **#DX1(掃除)**。React 化・tRPC 集約で不要になった残骸 2 件を削除する。挙動変更なし。

## 変更内容

- **`@types/list.js` を devDependencies から削除** — list.js 本体は React 化(#2391)で `shared/fuzzySearch.ts` への移植により依存から外れており、型パッケージだけが残っていた(本体なき @types は tsc / webpack ともエラーにしないため棚卸しで検出)
- **`Store.initRenderer()` の呼び出しを削除**(`src/main/index.ts`)— renderer プロセスから electron-store を使うための橋渡し登録 API だが、renderer の設定アクセスは tRPC へ集約済みで、electron-store の利用は main の `Config.ts` のみ

## 検証

- [x] `yarn lint` / `yarn lint:ts` / `yarn test`(251 件)緑
- [x] Node 22 で `yarn package` + `yarn test:e2e`(3 件)緑

マージ後は #A3(Ledger の read-modify-write 排他制御。挙動改善のため別 PR)へ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
