### PR TITLE
fix(main): Ledger の並行書き込みで導入記録が消える競合を修正(#A3)

### DIFF
--- a/src/main/Ledger.test.ts
+++ b/src/main/Ledger.test.ts
@@ -259,7 +259,7 @@ describe('Ledger', () => {
   });
 
   describe('round-trip', () => {
-    it('書き込んだ内容を別インスタンスで読み直しても同じ値になる', async () => {
+    it('書き込んだ内容がディスクへ反映され、読み直しても同じ値になる', async () => {
       const installationPath = await makeInstPath();
 
       const writer = await Ledger.load(installationPath);
@@ -282,6 +282,53 @@ describe('Ledger', () => {
         id: 'author/plugin',
         version: 'v1.2.3',
       });
+    });
+  });
+
+  describe('共有インスタンス', () => {
+    it('同じインストール先の load は同一インスタンスを返す', async () => {
+      const installationPath = await makeInstPath();
+
+      const [a, b] = await Promise.all([
+        Ledger.load(installationPath),
+        Ledger.load(installationPath),
+      ]);
+
+      expect(a).toBe(b);
+    });
+
+    it('並行する 2 経路の書き込みが互いを消さない(lost update の防止)', async () => {
+      const installationPath = await makeInstPath();
+
+      // インストール(addPackage)と一覧再取得中の整合性採認のように、
+      // 別々に load した 2 経路が同時に書き込む状況を再現する
+      const [installer, adopter] = await Promise.all([
+        Ledger.load(installationPath),
+        Ledger.load(installationPath),
+      ]);
+      await Promise.all([
+        installer.addPackage('author/installed', '1.0'),
+        adopter.addPackage('author/adopted', '2.0'),
+      ]);
+
+      const json = await readJson(Ledger.getPath(installationPath));
+      expect(Object.keys(json.packages).sort()).toEqual([
+        'author/adopted',
+        'author/installed',
+      ]);
+    });
+
+    it('トランザクション中の変更は別経路の load からも見える', async () => {
+      const installationPath = await makeInstPath();
+
+      const writer = await Ledger.load(installationPath);
+      writer.begin();
+      await writer.setCore('aviutl', '1.10');
+
+      const reader = await Ledger.load(installationPath);
+      expect(await reader.get('core.aviutl')).toBe('1.10');
+
+      await writer.commit();
     });
   });
 });

--- a/src/main/Ledger.ts
+++ b/src/main/Ledger.ts
@@ -12,10 +12,21 @@ import { type LedgerObject } from '../types/ledger';
 // 導入記録(ユビキタス言語の Ledger)。ディスク上の実体はインストール
 // フォルダ直下の apm.json で、ファイル名は互換のため変えない
 class Ledger {
+  // 同一 apm.json のインスタンスをプロセス内で共有する。load ごとに別の
+  // メモリコピーを作ると、並行する read-modify-write(インストールの
+  // addPackage と、一覧再取得 query 内の整合性採認など)が互いの書き込みを
+  // 全体書き戻しで消し合う(lost update)。操作単位のミューテックスで直列化
+  // する案は全サービスの呼び出し境界の再定義が必要で差分が大きく、単一
+  // プロセスなら共有オブジェクト化で同じ効果が得られるため採らない。
+  // apm の多重起動(プロセス間の競合)はこの方式では防げない(別課題)
+  private static instances = new Map<string, Promise<Ledger>>();
+
   private path: string;
   private object: LedgerObject;
   private inTransaction = false;
   private dirty = false;
+  // 同じファイルへの writeJson が並行すると内容が交錯しうるため直列化する
+  private saveQueue: Promise<void> = Promise.resolve();
 
   /**
    * Gets the path to `apm.json`.
@@ -27,15 +38,19 @@ class Ledger {
   }
 
   /**
-   * Creates an instance of Ledger.
+   * Creates an instance of Ledger. Instances are shared per installation
+   * so that concurrent operations see and modify the same object.
    * @param {string} [installationPath] - The path to the installation directory.
    * @returns {Promise<Ledger>} A promise that resolves with the instance of Ledger.
    */
   public static async load(installationPath: string): Promise<Ledger> {
-    const ledger = new Ledger();
-    const jsonPath = this.getPath(installationPath);
-    await ledger.load(jsonPath);
-    return ledger;
+    const jsonPath = path.resolve(this.getPath(installationPath));
+    let instance = this.instances.get(jsonPath);
+    if (!instance) {
+      instance = new Ledger().load(jsonPath);
+      this.instances.set(jsonPath, instance);
+    }
+    return await instance;
   }
 
   /**
@@ -70,7 +85,12 @@ class Ledger {
    * @returns {Promise<void>} A promise that resolves when the object is saved.
    */
   private save(): Promise<void> {
-    return writeJson(this.path, this.object, { spaces: 2 });
+    const queued = this.saveQueue.then(() =>
+      writeJson(this.path, this.object, { spaces: 2 }),
+    );
+    // 失敗は呼び出し元へは queued で伝播させ、後続の書き込みは止めない
+    this.saveQueue = queued.catch(() => {});
+    return queued;
   }
 
   /**


### PR DESCRIPTION
## 概要

Phase 5(#2379)のスライス **#A3(挙動改善)**。Ledger(apm.json)の並行 read-modify-write で導入記録が消える競合(lost update)を修正する。

## 問題(裏取り結果)

- Ledger は `inst.ledger()` のたびに apm.json を読み直した**別インスタンス**を返し、書き込みは**メモリ上のオブジェクト全体の書き戻し**。並行する 2 操作は後勝ちで他方の記録を消す
- この競合は通常操作で踏める:
  - `getPackagesWithStatus(adoptManuallyInstalled: true)` と `getInstalledVersionTexts` は **query だが Ledger へ書き込む**(整合性採認 = addPackage / setCore)
  - 一括インストール(BatchInstallButton)はループ途中で `apm-packages-changed` を発火するため、次のインストール(mutation)と上記 query の再取得が並走する
  - インストール / アンインストールボタンは別の `usePhase` で相互排他がなく、同時実行できる
- apm.json への書き込みはすべて Ledger 経由であること、共有される `packages` 参照の読み手(packageUtil)が読み取り専用であることは確認済み

## 修正

- **インストール先ごとに Ledger インスタンスをプロセス内で共有**(`Ledger.load` をキャッシュ化)。全経路が同一オブジェクトを変更するため、書き戻される内容には常に全員の変更が含まれ、lost update が構造的に消える
- **writeJson の直列化**(saveQueue)。同一ファイルへの並行 write による内容交錯の保険
- 採らなかった案(コードコメントにも記載): 操作単位のミューテックスによる直列化は、全サービスの呼び出し境界の再定義が必要で差分が大きい。単一プロセスなら共有オブジェクト化で同じ効果が得られる
- **スコープ外**: apm の多重起動(プロセス間の競合)はこの方式では防げない。single instance lock の導入は別課題として検討

## 検証

- [x] 新規テスト 3 件(同一インスタンス共有 / 並行書き込みの lost update 防止 / トランザクション中の変更の可視性)
- [x] `yarn lint` / `yarn lint:ts` / `yarn test`(254 件)緑
- [x] Node 22 で `yarn package` + `yarn test:e2e`(3 件)緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)
