### PR TITLE
fix(main): requestSingleInstanceLock で多重起動を防止

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -55,6 +55,25 @@ if (userDataDir) {
 }
 debug({ showDevTools: false }); // Press F12 to open DevTools
 
+// 多重起動ガード。同一プロファイルの 2 プロセスが同じインストール先を操作すると
+// apm.json / config.json の read-modify-write がプロセス間で競合し後勝ちで
+// 消失するため(#2379 #A3 の派生)、2 個目は起動せず既存窓へフォーカスを渡す。
+// ロックは userData 単位なので、setPath('userData') より後で取得すること
+// (--user-data-dir 隔離の E2E や _Dev プロファイルの開発起動と干渉させない)。
+// ロック失敗時に即 return せず後続のトップレベル初期化を素通しするのは
+// electron-squirrel-startup と同じ流儀 — quit 済みなら ready が発火せず
+// 窓生成(launch)には到達しない
+if (!app.requestSingleInstanceLock()) {
+  app.quit();
+} else {
+  app.on('second-instance', () => {
+    const win = BrowserWindow.getAllWindows().find((w) => !w.isDestroyed());
+    if (!win) return;
+    if (win.isMinimized()) win.restore();
+    win.focus();
+  });
+}
+
 const config = getConfig();
 
 ensureAutoUpdateDefault(config);


### PR DESCRIPTION
## 概要

apm には多重起動ガードがなく、同一プロファイルで 2 プロセス起動して同じインストール先を操作すると、`apm.json`(導入記録 Ledger)の read-modify-write がプロセス間で競合し後勝ちで消失しうる。プロセス内の lost update は Ledger の共有インスタンス化(#2413)で解消済みだが、プロセス間の排他は「別課題」として残っていた(#2379 #A3 のメモ参照)。

`app.requestSingleInstanceLock()` + `second-instance` イベントで既存窓をフォーカスする一般的なパターンを導入し、2 個目の起動を中止する。

## 設計メモ

- **ロック取得位置**: Electron のロックは呼び出し時点の userData 配下に作られるため、`--user-data-dir` の自前解釈(`setPath('userData')`)より**後**に取得する。これにより E2E の一時プロファイル同士・`_Dev` プロファイルの開発起動と本番は互いに干渉しない
- **ロック失敗時に後続のトップレベル初期化を素通しする**のは electron-squirrel-startup と同じ流儀。quit 済みなら `ready` が発火せず窓生成(`launch`)には到達しない。`else` で初期化全体を包むと差分が実質全行になるため採らなかった
- 2 プロセス目でも評価される `ensureAutoUpdateDefault` は autoUpdate キー未設定時のみの書き込み(初回起動時の同値書き込み)で実害なし

## 検証

- [x] `yarn lint` / `yarn lint:ts` / `yarn test`(254 件)緑
- [x] `yarn test:e2e`(3 件)緑 — 隔離プロファイル起動が壊れていないことの確認
- [x] パッケージ版(darwin-arm64)で手動検証: 同一 `--user-data-dir` の 2 個目は exit 0 で即終了・1 個目は生存、別プロファイル同士は共存可能

Refs #2379

🤖 Generated with [Claude Code](https://claude.com/claude-code)