### PR TITLE
docs(shared): 7za の chmod が要る理由を実態に合わせる

### DIFF
--- a/src/shared/unzip.ts
+++ b/src/shared/unzip.ts
@@ -14,9 +14,10 @@ if (!isDevEnv) {
   pathTo7zip = pathTo7zip.replace('app.asar', 'app.asar.unpacked');
 }
 
-// パッケージ版では asset relocator が native_modules へコピーした 7za の
-// 実行ビットが落ちていて spawn が EACCES になる(macOS / Linux のみ。
-// dev の node_modules 直下は実行可能なので無症状)。spawn 前に付与する
+// 7za の実行ビットが落ちていて spawn が EACCES になることがある
+// (macOS / Linux のみ)。パッケージ版で asar からコピーされるときだけでなく、
+// yarn がキャッシュから node_modules へ展開する時点で落ちている例もあるため、
+// dev でも起こりうる。spawn 前に付与する
 if (process.platform !== 'win32') {
   try {
     chmodSync(pathTo7zip, 0o755);


### PR DESCRIPTION
## 概要

`src/shared/unzip.ts` の 7za に `chmodSync` している箇所のコメントが、Vite 移行(#2416)後の実態と食い違っていたので直す。**コメントのみでコードは変更なし。**

## 内容

修正前:

> パッケージ版では asset relocator が native_modules へコピーした 7za の実行ビットが落ちていて spawn が EACCES になる(macOS / Linux のみ。**dev の node_modules 直下は実行可能なので無症状**)。

2 点ずれていた。

1. **asset relocator と `native_modules` はもう無い**。Vite 移行で 7za の場所は `node_modules/7zip-bin`(パッケージ版は `app.asar.unpacked` 配下)になった
2. **「dev では無症状」も誤り**。yarn がキャッシュから `node_modules` へ展開する時点で実行ビットが落ちている環境があり、開発ツリーでも `EACCES` になる。#2180 の調査中にこのリポジトリで実際に踏んだ(yarn のキャッシュ内の 7za が `-rw-r--r--` になっていた)

②は「なぜ dev でも chmod が要るのか」の説明なので、消さずに直しておきたい。

## 検証

- [x] `yarn lint` / `yarn lint:ts` / `yarn test`(254 件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
