### PR TITLE
fix(renderer): パッケージ版で AviUtl タブのアイコンが表示されないのを修正する

### DIFF
--- a/src/renderer/main/aviutl/AviutlTab.tsx
+++ b/src/renderer/main/aviutl/AviutlTab.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useSyncExternalStore } from 'react';
+import apmIcon from '../../../../icon/apm32.png';
 import {
   getInstallationPath,
   subscribeInstallationPath,
@@ -26,7 +27,7 @@ function AviutlTab(): JSX.Element {
         <div className="container-fluid">
           <span className="navbar-brand">
             <img
-              src="../../../icon/apm32.png"
+              src={apmIcon}
               alt=""
               className="d-inline-block"
               width="20"


### PR DESCRIPTION
## 概要

パッケージ版で AviUtl タブのナビゲーションバーのアイコンが `net::ERR_FILE_NOT_FOUND` になる問題を修正する。closes #2419

Windows 実機スモークテスト(#2379)で発見された。

## 原因

`AviutlTab.tsx` の img が**生の文字列**で画像を指しており、バンドラが出力対象にしていなかった。

```diff
-<img src="../../../icon/apm32.png" ... />
+import apmIcon from '../../../../icon/apm32.png';
+<img src={apmIcon} ... />
```

相対パスも直している。`AviutlTab.tsx` からリポジトリ直下の `icon/` までは 4 階層(`aviutl` → `main` → `renderer` → `src`)で、従来の `../../../` は文字列として解決されたとしても誤りだった(`About.tsx` が 3 階層なのはファイルの位置が 1 つ浅いため)。

## Vite 移行が原因ではない

`34842f00`「refactor(renderer): aviutl タブ pane を単一の React ルートに統合」(2026-08-21)で `index.html` から JSX へ移した時点から壊れていた。Vite 移行(2026-08-22)の前日にあたる。

それまでこの img は `index.html` にあり webpack の `html-loader` が解決していたが、JSX へ移った時点で loader の対象から外れ、以降どちらのバンドラでも出力されなくなっていた。

## 検証

ビルド前後で出力を比較した。

修正前は `main_window/assets/` に画像が 1 つも無い(`about_window/assets/` には `import` 経由の `apm1024-*.png` がある)。修正後は追加ファイルが増えず、代わりに **data URI として埋め込まれる**。`icon/apm32.png` は 1006 バイトで Vite の既定のインライン閾値(4096)未満のため。

埋め込まれたバイト列が元ファイルと一致することも確認した。

```
埋め込み:   1006 bytes  sha256: a21c148d846129c9
元ファイル: 1006 bytes  sha256: a21c148d846129c9
一致: true
```

CSP は `img-src 'self' data:` を許可しているため、追加の緩和は不要。

- [x] `yarn lint` / `yarn lint:ts` / `yarn test`(254 件)
- [x] `yarn package` / `yarn test:e2e`(3 件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
