### PR TITLE
docs: リリース手順の Node 22 前提を実態に合わせる

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,7 +4,7 @@ This project uses [release-it](https://github.com/release-it/release-it) with [@
 
 ## Prerequisites
 
-- Node.js 22 (22.22.2+ recommended; see `package.json` engines). Release CI also pins Node 22 because electron-forge 6.4.1 does not complete `make`/`publish` on Node 24 yet.
+- Node.js 24 or 22 (see `package.json` engines). Release CI uses Node 24.
 - Yarn 1.x
 - `GITHUB_TOKEN` with permission to create releases (when publishing release notes to GitHub)
 - Write access to this repository
@@ -62,4 +62,4 @@ Release notes are generated from [Conventional Commits](https://www.conventional
 
 - If GitHub release creation fails, set `GITHUB_TOKEN` and retry, or create the release manually from `CHANGELOG.md`.
 - If CI publish fails on one OS, check the workflow log; you may need to re-run the failed job after fixing the issue.
-- If the draft release has no assets but CI is green, check that `release.yml` uses Node 22 and that `yarn make` completes locally (`Making distributables` / `Artifacts available` in the log). Node 24 can exit early during packaging with no error.
+- If the draft release has no assets but CI is green, check that `yarn make` completes locally (`Making distributables` / `Artifacts available` in the log). Packaging can exit early with no error at all — on Node 24.16 / 24.17 this happens because of a broken `yauzl@2` inside `extract-zip` (electron/forge#4277). The `resolutions` entry in `package.json` works around it; make sure the install actually applied it.


### PR DESCRIPTION
## 概要

`docs/RELEASING.md` の前提条件が古くなっていたので、実態に合わせる。**ドキュメントのみ。**

v3.14.0 のリリース準備中に見つけた。

## 内容

修正前:

> Node.js 22 (22.22.2+ recommended). Release CI also pins Node 22 because **electron-forge 6.4.1** does not complete `make`/`publish` on Node 24 yet.

この前提は 2 重に古い。

1. **forge は 6.4.1 ではなく 7.11.2**
2. **無言失敗の原因は forge ではなかった** — Node 24.16 / 24.17 限定の `extract-zip`(`yauzl@2`)のバグ(electron/forge#4277)。#2415 で `resolutions` による回避を入れ、CI も Node 24 へ移している

トラブルシュートの項も、「`release.yml` が Node 22 を使っているか確認」から「`resolutions` が実際に効いているか確認」へ差し替えた。原因が分かった今、Node 22 へ戻す指示は誤った方向へ誘導してしまうため。

## 検証

- [x] `yarn lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
