### PR TITLE
fix(docs): サイトのダウンロードリンクをリリース時に自動更新する

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -19,5 +19,8 @@
       "preset": "angular",
       "infile": "CHANGELOG.md"
     }
+  },
+  "hooks": {
+    "after:bump": "node scripts/updateSiteDownloadUrls.mjs ${version}"
   }
 }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -57,6 +57,8 @@ timezone: Asia/Tokyo
 lang: ja
 logo: /images/apm1024.png
 show_downloads: true
+# リリースのたびに scripts/updateSiteDownloadUrls.mjs が書き換える
+# (.release-it.json の after:bump フック)。手で更新しないこと
 github:
-  exe_url: https://github.com/team-apm/apm/releases/download/v3.8.0/AviUtl.Package.Manager-3.8.0.Setup.exe
-  zip_url: https://github.com/team-apm/apm/releases/download/v3.8.0/AviUtl.Package.Manager-win32-x64-3.8.0.zip
+  exe_url: https://github.com/team-apm/apm/releases/download/v3.14.0/AviUtl.Package.Manager-3.14.0.Setup.exe
+  zip_url: https://github.com/team-apm/apm/releases/download/v3.14.0/AviUtl.Package.Manager-win32-x64-3.14.0.zip

--- a/scripts/updateSiteDownloadUrls.mjs
+++ b/scripts/updateSiteDownloadUrls.mjs
@@ -1,0 +1,45 @@
+// リリース時にサイトのダウンロードリンクを新しいバージョンへ向ける。
+// release-it の after:bump フックから呼ばれ、書き換えた _config.yml は
+// release-it 自身の `git add . --update` でリリースコミットに含まれる
+// (CI から main へ書き戻す必要がない)。
+import { readFile, writeFile } from 'node:fs/promises';
+
+const CONFIG_PATH = new URL('../docs/_config.yml', import.meta.url);
+
+/**
+ * Returns the release asset URLs for a version.
+ * 成果物名は electron-forge の maker が productName とバージョンから
+ * 組み立てるため、バージョンが決まれば URL も決まる。
+ * @param {string} version - The version being released, without the leading v.
+ * @returns {{exe: string, zip: string}} The asset URLs.
+ */
+function assetUrls(version) {
+  const base = `https://github.com/team-apm/apm/releases/download/v${version}`;
+  return {
+    exe: `${base}/AviUtl.Package.Manager-${version}.Setup.exe`,
+    zip: `${base}/AviUtl.Package.Manager-win32-x64-${version}.zip`,
+  };
+}
+
+const version = process.argv[2];
+if (!/^\d+\.\d+\.\d+/.test(version ?? '')) {
+  throw new Error(`Expected a version as the first argument, got ${version}`);
+}
+
+const urls = assetUrls(version);
+const original = await readFile(CONFIG_PATH, 'utf8');
+const updated = original
+  .replace(/^(\s*exe_url:\s*).*$/m, `$1${urls.exe}`)
+  .replace(/^(\s*zip_url:\s*).*$/m, `$1${urls.zip}`);
+
+// 置換されなければキーの名前や構造が変わっている。黙って古い URL を
+// 残すとサイトだけ旧版を配り続けるため、リリースを止める
+if (!updated.includes(urls.exe) || !updated.includes(urls.zip)) {
+  throw new Error(
+    'docs/_config.yml の exe_url / zip_url を書き換えられなかった。' +
+      'キー名か構造が変わっていないか確認すること。',
+  );
+}
+
+if (updated !== original) await writeFile(CONFIG_PATH, updated);
+console.log(`docs/_config.yml のダウンロードリンクを v${version} へ更新した`);


### PR DESCRIPTION
## 概要

公式サイトのダウンロードボタンが **v3.8.0 のインストーラを直接指したまま固定**されていたのを直し、以後リリースのたびに自動更新されるようにする。

v3.14.0 のリリース作業中に発見した。サイト経由の新規ユーザーだけが 6 バージョン古い版を掴む状態で、**今回リリースしたセキュリティ修正 9 件が届いていなかった**。

## 原因

`docs/_config.yml` に URL がベタ書きされ、`docs/_layouts/default.html` がそれを参照していた。リリース手順にサイト更新の項が無いため、**v3.9.0 以降 6 回のリリースで一度も更新されていなかった**。

## 修正

release-it の `after:bump` フックで書き換える。

```json
"hooks": {
  "after:bump": "node scripts/updateSiteDownloadUrls.mjs ${version}"
}
```

release-it は commit 前に `git add . --update` を実行するため、**書き換えた `_config.yml` はそのままリリースコミットに含まれる**。CI から `main` へ書き戻す必要がなく、バージョン更新とサイト更新が 1 コミットで揃う。

成果物名は productName とバージョンから決まるので、バージョンさえ分かれば URL は組み立てられる。

`_config.yml` は現行の v3.14.0 に合わせてある(手動更新はこれが最後)。

## インストーラ名からバージョンを外す案は採らない

`releases/latest/download/<固定名>` の直リンクが張れるので一見きれいだが、**手元に残ったファイルがどの版か分からなくなる**。複数落とすと `...(1).exe` になって区別がつかず、不具合報告で「どのインストーラを使ったか」が特定できなくなる。ワンクリックは維持したうえで、名前は versioned のままにする。

## 置換に失敗したらリリースを止める

キー名や構造が変わって置換できなかった場合、スクリプトは throw する。黙って古い URL を残すと、**まさに今回の「サイトだけ旧版を配り続ける」状態が再発する**ため。

## 検証

- [x] スクリプト単体: 正常系(`3.99.0` を渡して両 URL が書き換わる)/ 異常系(引数なしで throw)
- [x] 生成される URL が実在すること(v3.14.0 の 2 資産とも HTTP 200)
- [x] `yarn lint`

次回リリース時に、リリースコミットへ `_config.yml` の差分が含まれることを確認したい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
