### PR TITLE
feat(settings): ダウンロードキャッシュの使用量表示と削除を追加する

### DIFF
--- a/e2e/cache.spec.ts
+++ b/e2e/cache.spec.ts
@@ -1,0 +1,22 @@
+import { expect, getMainWindow, test } from './helpers';
+
+test('設定タブでダウンロードキャッシュの使用量を確認できる', async ({
+  launchApp,
+}) => {
+  const app = await launchApp();
+  const window = await getMainWindow(app);
+
+  await window.getByRole('tab', { name: '設定' }).click();
+
+  await expect(window.locator('label[for="clear-cache"]')).toHaveText(
+    'ダウンロードキャッシュ',
+  );
+
+  // 「計算中…」から実際の使用量へ変わる
+  await expect(
+    window.locator('label[for="clear-cache"] ~ div span').first(),
+  ).toContainText('使用中');
+
+  // 隔離した userData で起動するためキャッシュは空。押せる状態にしない
+  await expect(window.locator('#clear-cache')).toBeDisabled();
+});

--- a/src/main/api/settings.ts
+++ b/src/main/api/settings.ts
@@ -1,4 +1,6 @@
 import { dialog } from 'electron';
+import { formatBytes } from '../../shared/formatBytes';
+import { clearCache, getCacheSize } from '../services/cache';
 import { ensureExtraDataUrl, setDataUrls } from '../services/settings';
 import { procedure, stringInput, t, winProcedure } from './trpc';
 
@@ -53,6 +55,24 @@ export const settingsRouter = t.router({
       main: ctx.config.dataUrl.getMain(),
       extra: ctx.config.dataUrl.getExtra(),
     };
+  }),
+  getCacheSize: procedure.query(() => getCacheSize()),
+  clearCache: winProcedure.mutation(async ({ ctx }) => {
+    const size = await getCacheSize();
+    const confirmed =
+      (
+        await dialog.showMessageBox(ctx.win, {
+          title: '確認',
+          message: `ダウンロード済みのアーカイブ(${formatBytes(size)})を削除します。`,
+          detail:
+            'インストール済みのパッケージには影響しません。再インストールや更新のときに再度ダウンロードされます。',
+          type: 'warning',
+          buttons: ['削除', 'キャンセル'],
+          cancelId: 1,
+        })
+      ).response === 0;
+    if (!confirmed) return null;
+    return await clearCache();
   }),
   getAutoUpdate: procedure.query(({ ctx }) => ctx.config.getAutoUpdate()),
   setAutoUpdate: procedure

--- a/src/main/services/cache.test.ts
+++ b/src/main/services/cache.test.ts
@@ -1,0 +1,110 @@
+import { mkdtemp, outputFile, pathExists, remove } from 'fs-extra';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { clearCache, getCacheSize } from './cache';
+
+const mocks = vi.hoisted(() => ({ userData: '' }));
+vi.mock('electron', () => ({
+  app: { getPath: () => mocks.userData },
+}));
+
+/**
+ * cache.ts の特性化テスト。削除対象を archive に限ること
+ * (list.json 等の取得済みデータは残すこと)を仕様として固定する。
+ */
+describe('cache', () => {
+  const tempDirs: string[] = [];
+
+  const makeDataDir = async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'apm-cache-'));
+    tempDirs.push(dir);
+    mocks.userData = dir;
+    return path.join(dir, 'Data');
+  };
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.splice(0).map((dir) => remove(dir)));
+  });
+
+  describe('getCacheSize', () => {
+    it('アーカイブが無いときは 0 を返す', async () => {
+      await makeDataDir();
+      expect(await getCacheSize()).toBe(0);
+    });
+
+    it('core と package の archive を合算する', async () => {
+      const dataDir = await makeDataDir();
+      await outputFile(
+        path.join(dataDir, 'core/archive/a.zip'),
+        'x'.repeat(10),
+      );
+      await outputFile(
+        path.join(dataDir, 'package/archive/b.zip'),
+        'y'.repeat(20),
+      );
+
+      expect(await getCacheSize()).toBe(30);
+    });
+
+    it('archive の外にあるファイルは数えない', async () => {
+      const dataDir = await makeDataDir();
+      await outputFile(path.join(dataDir, 'list.json'), 'x'.repeat(100));
+      await outputFile(
+        path.join(dataDir, 'package/packages.json'),
+        'y'.repeat(50),
+      );
+      await outputFile(
+        path.join(dataDir, 'package/archive/a.zip'),
+        'z'.repeat(5),
+      );
+
+      expect(await getCacheSize()).toBe(5);
+    });
+
+    it('入れ子のディレクトリも再帰的に数える', async () => {
+      const dataDir = await makeDataDir();
+      await outputFile(
+        path.join(dataDir, 'package/archive/nested/deep/a.zip'),
+        'x'.repeat(7),
+      );
+
+      expect(await getCacheSize()).toBe(7);
+    });
+  });
+
+  describe('clearCache', () => {
+    it('archive を削除し、解放したバイト数を返す', async () => {
+      const dataDir = await makeDataDir();
+      await outputFile(
+        path.join(dataDir, 'package/archive/a.zip'),
+        'x'.repeat(42),
+      );
+
+      expect(await clearCache()).toBe(42);
+      expect(await pathExists(path.join(dataDir, 'package/archive'))).toBe(
+        false,
+      );
+      expect(await getCacheSize()).toBe(0);
+    });
+
+    it('archive の外は消さない', async () => {
+      const dataDir = await makeDataDir();
+      await outputFile(path.join(dataDir, 'list.json'), 'x');
+      await outputFile(path.join(dataDir, 'package/packages.json'), 'y');
+      await outputFile(path.join(dataDir, 'package/archive/a.zip'), 'z');
+
+      await clearCache();
+
+      expect(await pathExists(path.join(dataDir, 'list.json'))).toBe(true);
+      expect(
+        await pathExists(path.join(dataDir, 'package/packages.json')),
+      ).toBe(true);
+    });
+
+    it('アーカイブが無くても失敗しない', async () => {
+      await makeDataDir();
+      expect(await clearCache()).toBe(0);
+    });
+  });
+});

--- a/src/main/services/cache.ts
+++ b/src/main/services/cache.ts
@@ -1,0 +1,64 @@
+import { app } from 'electron';
+import { readdir, remove, stat } from 'fs-extra';
+import path from 'node:path';
+
+/**
+ * Returns the directories holding downloaded archives.
+ * 削除対象をアーカイブに限るのは、Data/ 直下の list.json 等が数十 KB で
+ * 容量の利益がほとんど無いのに、消すとパッケージ一覧を取り直すまで
+ * 何も表示できなくなるため。
+ * @returns {string[]} Absolute paths of the archive directories.
+ */
+function getArchiveDirs(): string[] {
+  const dataDir = path.join(app.getPath('userData'), 'Data');
+  return ['core', 'package'].map((sub) => path.join(dataDir, sub, 'archive'));
+}
+
+/**
+ * Returns the total size of the given directory in bytes.
+ * 存在しないディレクトリは 0 として扱う(まだ何もダウンロードしていない)。
+ * @param {string} dir - The directory to measure.
+ * @returns {Promise<number>} The total size in bytes.
+ */
+async function dirSize(dir: string): Promise<number> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  const sizes = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) return await dirSize(entryPath);
+      // 途中で消えたファイルは 0 として数える(削除と競合しても壊れない)
+      try {
+        return (await stat(entryPath)).size;
+      } catch {
+        return 0;
+      }
+    }),
+  );
+  return sizes.reduce((total, size) => total + size, 0);
+}
+
+/**
+ * Returns the total size of the downloaded archives in bytes.
+ * @returns {Promise<number>} The total size in bytes.
+ */
+export async function getCacheSize(): Promise<number> {
+  const sizes = await Promise.all(getArchiveDirs().map(dirSize));
+  return sizes.reduce((total, size) => total + size, 0);
+}
+
+/**
+ * Removes the downloaded archives.
+ * インストール済みのパッケージには影響しない(配置済みのファイルは
+ * インストール先にあり、ここにあるのは取得元のアーカイブだけ)。
+ * @returns {Promise<number>} The number of bytes freed.
+ */
+export async function clearCache(): Promise<number> {
+  const freed = await getCacheSize();
+  await Promise.all(getArchiveDirs().map((dir) => remove(dir)));
+  return freed;
+}

--- a/src/renderer/main/settings/CacheSettings.tsx
+++ b/src/renderer/main/settings/CacheSettings.tsx
@@ -1,0 +1,73 @@
+import React, { type JSX } from 'react';
+import { formatBytes } from '../../../shared/formatBytes';
+import { TRPCReact } from '../../trpc';
+import { usePhase } from '../usePhase';
+
+/**
+ * The download cache size and a button to clear it (ダウンロードキャッシュ).
+ * @returns {JSX.Element} The rendered component.
+ */
+function CacheSettings(): JSX.Element {
+  const cacheSize = TRPCReact.settings.getCacheSize.useQuery();
+  const clearCache = TRPCReact.settings.clearCache.useMutation();
+  const clear = usePhase();
+
+  const onClick = async () => {
+    clear.start();
+    try {
+      const freed = await clearCache.mutateAsync();
+      // null はダイアログでキャンセルされた場合。メッセージを出さずに戻す
+      if (freed === null) {
+        clear.finishSilently();
+        return;
+      }
+      await cacheSize.refetch();
+      clear.finish(`${formatBytes(freed)}を削除`, 'success');
+    } catch {
+      clear.finish('エラー', 'danger');
+    }
+  };
+
+  const color = clear.phase.kind === 'message' ? clear.phase.color : 'primary';
+
+  return (
+    <div className="row mb-3">
+      <label htmlFor="clear-cache" className="col-sm-3 col-form-label">
+        ダウンロードキャッシュ
+      </label>
+      <div className="col-sm-6 d-flex align-items-center">
+        <span className="text-body-secondary">
+          {cacheSize.data === undefined
+            ? '計算中…'
+            : `${formatBytes(cacheSize.data)} 使用中`}
+        </span>
+      </div>
+      <div className="col-sm-3">
+        <button
+          type="button"
+          className={`btn btn-outline-${color} w-100`}
+          id="clear-cache"
+          disabled={clear.phase.kind === 'loading' || !cacheSize.data}
+          onClick={() => void onClick()}
+        >
+          {clear.phase.kind === 'loading' ? (
+            <>
+              <span
+                className="spinner-border spinner-border-sm"
+                role="status"
+                aria-hidden="true"
+              ></span>
+              <span className="visually-hidden">Loading...</span>
+            </>
+          ) : clear.phase.kind === 'message' ? (
+            clear.phase.message
+          ) : (
+            '削除'
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default CacheSettings;

--- a/src/renderer/main/settings/SettingsTab.tsx
+++ b/src/renderer/main/settings/SettingsTab.tsx
@@ -1,5 +1,6 @@
 import React, { type JSX } from 'react';
 import { MonacoEditorRenderer } from '../monacoEditorRenderer';
+import CacheSettings from './CacheSettings';
 import DataUrlSettings from './DataUrlSettings';
 import ManualUpdateTable from './ManualUpdateTable';
 import PreferencesSettings from './PreferencesSettings';
@@ -7,7 +8,7 @@ import PreferencesSettings from './PreferencesSettings';
 /**
  * The whole pane of the settings tab (旧 index.html の section#settings の
  * 中身): データ取得先・追加テキストデータ(Monaco エディタ)・環境設定・
- * 手動更新テーブル。
+ * ダウンロードキャッシュ・手動更新テーブル。
  * @returns {JSX.Element} The rendered component.
  */
 function SettingsTab(): JSX.Element {
@@ -25,6 +26,7 @@ function SettingsTab(): JSX.Element {
               <MonacoEditorRenderer />
             </div>
             <PreferencesSettings />
+            <CacheSettings />
             <hr />
             <div className="row mb-3">
               <h4>手動更新</h4>

--- a/src/shared/formatBytes.test.ts
+++ b/src/shared/formatBytes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { formatBytes } from './formatBytes';
+
+describe('formatBytes', () => {
+  it('1024 未満はバイトとして整数で表示する', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(1)).toBe('1 B');
+    expect(formatBytes(1023)).toBe('1023 B');
+  });
+
+  it('1024 ごとに単位を繰り上げる', () => {
+    expect(formatBytes(1024)).toBe('1 KB');
+    expect(formatBytes(1024 ** 2)).toBe('1 MB');
+    expect(formatBytes(1024 ** 3)).toBe('1 GB');
+    expect(formatBytes(1024 ** 4)).toBe('1 TB');
+  });
+
+  it('端数は小数第 1 位まで表示し、末尾の 0 は落とす', () => {
+    expect(formatBytes(1536)).toBe('1.5 KB');
+    expect(formatBytes(Math.round(1024 ** 2 * 2.25))).toBe('2.3 MB');
+    expect(formatBytes(1024 ** 2)).toBe('1 MB');
+  });
+
+  it('TB を超えても単位は TB のまま桁を増やす', () => {
+    expect(formatBytes(1024 ** 5)).toBe('1024 TB');
+  });
+
+  it('負数や NaN は 0 B として扱う', () => {
+    expect(formatBytes(-1)).toBe('0 B');
+    expect(formatBytes(NaN)).toBe('0 B');
+  });
+});

--- a/src/shared/formatBytes.ts
+++ b/src/shared/formatBytes.ts
@@ -1,0 +1,25 @@
+const UNITS = ['B', 'KB', 'MB', 'GB', 'TB'] as const;
+
+/**
+ * Formats a byte count for display.
+ * 表示用なので厳密さより読みやすさを優先し、1024 で桁を繰り上げる。
+ * @param {number} bytes - The number of bytes.
+ * @returns {string} The formatted size, e.g. "1.5 GB".
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return '0 B';
+
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < UNITS.length - 1) {
+    value /= 1024;
+    unit++;
+  }
+
+  // B は整数、それ以外は小数第 1 位まで(1.0 MB のような末尾 0 は落とす)
+  const text =
+    unit === 0
+      ? String(Math.round(value))
+      : String(Math.round(value * 10) / 10);
+  return `${text} ${UNITS[unit]}`;
+}


### PR DESCRIPTION
## 概要

設定タブに**ダウンロードキャッシュの使用量表示と削除ボタン**を追加する。#1787 の「アーカイブが C ドライブを圧迫している」に対応する。

3 つの論点のうち、方針が出ていた「基本は保持、全部削除できる機能はあり」に沿ったもの。

## 背景

ダウンロードしたアーカイブは `%APPDATA%\AviUtl Package Manager\Data\{core,package}\archive\` に溜まり続け、**削除する手段が無かった**。場所を知っている人が手で消すしかない状態。

## 削除対象を archive に限る理由

`Data/` 直下には `list.json` などの取得済みデータも同居しているが、これらは数十 KB しかない。丸ごと消すと**容量の利益がほとんど無いのに、パッケージ一覧を取り直すまで何も表示できなくなる**。

なお #270(ハッシュが一致したらキャッシュを再利用したい)とは要求が逆向きだが、**手動削除であれば両立する**(自動削除だと衝突する)。

## 実装

| ファイル | 内容 |
| --- | --- |
| `src/main/services/cache.ts` | `getCacheSize()` / `clearCache()` |
| `src/shared/formatBytes.ts` | 表示用のバイト整形。main(ダイアログ文言)と renderer(表示)の両方から使うため shared に置く |
| `src/main/api/settings.ts` | tRPC の手続き。削除前に確認ダイアログ |
| `src/renderer/main/settings/CacheSettings.tsx` | 使用量と削除ボタン |

確認ダイアログでは**インストール済みのパッケージには影響しないこと**を明示する。実際、ここにあるのは取得元のアーカイブだけで、配置済みのファイルはインストール先にある。

キャンセル時は `null` を返し、UI 側はメッセージを出さずにボタンを戻す。

## 検証

- [x] `yarn lint` / `yarn lint:ts`
- [x] `yarn test` — **254 → 266 件**(`formatBytes` 5 件、`cache` 7 件を追加)
  - `cache.test.ts` は「archive の外(`list.json` / `packages.json`)を消さないこと」も固定している
- [x] `yarn package` / `yarn test:e2e` — **3 → 4 件**
  - 追加した E2E は実機で設定タブを開き、使用量が「計算中…」から実際の表示へ変わることを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)
