### PR TITLE
refactor: strictNullChecks 以外の strict 系フラグを有効にする

### DIFF
--- a/src/main/Ledger.ts
+++ b/src/main/Ledger.ts
@@ -69,7 +69,7 @@ class Ledger {
         throw new Error('Invalid apm.json.');
       }
     } catch (e) {
-      if (e.code !== 'ENOENT') log.error(e);
+      if ((e as NodeJS.ErrnoException).code !== 'ENOENT') log.error(e);
       this.object = {
         dataVersion: '3',
         core: {},

--- a/src/main/services/packageList.ts
+++ b/src/main/services/packageList.ts
@@ -170,7 +170,7 @@ async function getInstalledFiles(installationPath: string) {
     try {
       return await fsReaddir(path, { withFileTypes: true });
     } catch (e) {
-      if (e.code === 'ENOENT') return [];
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return [];
       log.error(e);
       throw e;
     }

--- a/src/renderer/main/aviutl/BatchInstallButton.tsx
+++ b/src/renderer/main/aviutl/BatchInstallButton.tsx
@@ -22,7 +22,7 @@ const IDLE_LABEL = 'AviUtl・拡張編集とおすすめプラグインのイン
  */
 function BatchInstallButton(): JSX.Element {
   const [phase, setPhase] = useState<ButtonPhase>({ kind: 'idle' });
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   useEffect(() => () => clearTimeout(timer.current), []);
 
   const utils = TRPCReact.useUtils();

--- a/src/renderer/main/aviutl/ProgramRow.tsx
+++ b/src/renderer/main/aviutl/ProgramRow.tsx
@@ -34,7 +34,7 @@ function ProgramRow({
   );
   const [phase, setPhase] = useState<ButtonPhase>('idle');
   const [buttonMessage, setButtonMessage] = useState('');
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   useEffect(() => () => clearTimeout(timer.current), []);
 
   const utils = TRPCReact.useUtils();

--- a/src/renderer/main/settings/DataUrlSettings.tsx
+++ b/src/renderer/main/settings/DataUrlSettings.tsx
@@ -14,7 +14,7 @@ function DataUrlSettings() {
   const [mainUrl, setMainUrl] = useState<string | null>(null);
   const [extraUrls, setExtraUrls] = useState<string | null>(null);
   const [phase, setPhase] = useState<ButtonPhase>('idle');
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   useEffect(() => () => clearTimeout(timer.current), []);
 
   const setDataUrls = TRPCReact.settings.setDataUrls.useMutation();

--- a/src/renderer/main/usePhase.ts
+++ b/src/renderer/main/usePhase.ts
@@ -12,7 +12,7 @@ export type ActionPhase =
  */
 export function usePhase() {
   const [phase, setPhase] = useState<ActionPhase>({ kind: 'idle' });
-  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   useEffect(() => () => clearTimeout(timer.current), []);
 
   // 前回の復帰タイマーを残したまま次の遷移をすると、3 秒前の操作の

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,16 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     // TS 6.0 から strict が既定で有効。strict 化は挙動リスクを伴うため
-    // メジャー更新と混ぜず、従来の設定(noImplicitAny のみ)を明示して維持する
+    // メジャー更新と混ぜず段階導入する。ここに並ぶのはコード修正なしで
+    // 満たせたフラグで、残るのは strictNullChecks / strictPropertyInitialization
+    // / useUnknownInCatchVariables。全部立ったら "strict": true へ畳む
     "strict": false,
     "noImplicitAny": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "strictBindCallApply": true,
+    "strictFunctionTypes": true,
+    "strictBuiltinIteratorReturn": true,
     "sourceMap": true,
     // TS 6.0 から rootDir の暗黙推論が廃止(TS5011)。include が vite.*.config.ts
     // 等リポジトリ直下も含むため "." を明示する

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,8 @@
     "skipLibCheck": true,
     "esModuleInterop": true,
     // TS 6.0 から strict が既定で有効。strict 化は挙動リスクを伴うため
-    // メジャー更新と混ぜず段階導入する。ここに並ぶのはコード修正なしで
-    // 満たせたフラグで、残るのは strictNullChecks / strictPropertyInitialization
-    // / useUnknownInCatchVariables。全部立ったら "strict": true へ畳む
+    // メジャー更新と混ぜず段階導入する。残るのは strictNullChecks と
+    // strictPropertyInitialization。全部立ったら "strict": true へ畳む
     "strict": false,
     "noImplicitAny": true,
     "noImplicitThis": true,
@@ -16,6 +15,7 @@
     "strictBindCallApply": true,
     "strictFunctionTypes": true,
     "strictBuiltinIteratorReturn": true,
+    "useUnknownInCatchVariables": true,
     "sourceMap": true,
     // TS 6.0 から rootDir の暗黙推論が廃止(TS5011)。include が vite.*.config.ts
     // 等リポジトリ直下も含むため "." を明示する


### PR DESCRIPTION
#2379 の Phase 2 follow-up(`strict` 有効化)の 1 スライス目。

TS 6.0 更新(#2381)では挙動リスクを避けて `strict: false` を明示したまま据え置いていた。その後の Phase 5 の責務分割で型の曖昧さが減り、strict 化で出るエラーは起票時の 69 件から **56 件**へ落ちていた。

## 何をしたか

内訳を測ると 50 件は `strictNullChecks` に由来し、それ以外のフラグはほぼ満たしていた。そこで **`strictNullChecks` と `strictPropertyInitialization` 以外を全部立てる**ところまでを 1 PR にした。

| コミット | 内容 | 減 |
| --- | --- | --- |
| build(tsconfig) | `noImplicitThis` / `alwaysStrict` / `strictBindCallApply` / `strictFunctionTypes` / `strictBuiltinIteratorReturn` を明示(コード変更 0 = 既に満たしていた) | — |
| refactor(renderer) | `clearTimeout` が受け取れない `null` を保持していた 4 箇所の型を `undefined` 基準へ | 13 |
| refactor(main) | `catch` した値のプロパティを読む 2 箇所を `unknown` 前提に + `useUnknownInCatchVariables` | 2 |

結果 **56 → 41 件**。挙動変更は無い(`as` は実行時に消え、タイマー型変更も `clearTimeout(undefined)` = 何もしない、で従来と同じ)。

## 分割の理由

`strict: true` へ一気に切り替えなかったのは、残る 41 件が「`null` 到達時に何をすべきか」という設計判断を含むため。型を絞れるのか、明示的に投げるのか(挙動は同じくエラー、メッセージが読めるようになるだけ)、それとも呼び出し側で分岐すべきか(これは挙動変更なので別 PR)を、`core.ts` / `modList.ts` の `getInfo()` 系から順に裏取りして進める。全部立った時点で `strict: true` の一行へ畳み、個別フラグの列は消す。

## 確認

`yarn lint` / `yarn lint:ts` / `yarn test`(266 件)すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)