### PR TITLE
refactor(main): main 側の strictNullChecks を解消する

### DIFF
--- a/src/main/Ledger.ts
+++ b/src/main/Ledger.ts
@@ -21,8 +21,11 @@ class Ledger {
   // apm の多重起動(プロセス間の競合)はこの方式では防げない(別課題)
   private static instances = new Map<string, Promise<Ledger>>();
 
-  private path: string;
-  private object: LedgerObject;
+  // 生成は必ず静的ファクトリ(load / getInstance)経由で、どちらも
+  // new した直後に load() を呼ぶ。load() は成功・失敗のどちらの経路でも
+  // この 2 つを設定するが、コンストラクタからは追えないため明示する
+  private path!: string;
+  private object!: LedgerObject;
   private inTransaction = false;
   private dirty = false;
   // 同じファイルへの writeJson が並行すると内容が交錯しうるため直列化する

--- a/src/main/api/app.ts
+++ b/src/main/api/app.ts
@@ -1,4 +1,10 @@
-import { app, BrowserWindow, clipboard, dialog } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  dialog,
+  type OpenDialogOptions,
+} from 'electron';
 import { openAboutWindow } from '../aboutWindow';
 import {
   checkUpdate as checkAppUpdate,
@@ -74,12 +80,17 @@ export const appProcedures = {
   }),
   // フォルダ選択ダイアログ(旧 OPEN_DIR_DIALOG チャンネルと同一の挙動)
   openDirDialog: procedure.input(dirDialogInput).mutation(async ({ input }) => {
-    const win = BrowserWindow.getFocusedWindow();
-    const dir = await dialog.showOpenDialog(win, {
+    const options: OpenDialogOptions = {
       title: input.title,
       defaultPath: input.defaultPath,
       properties: ['openDirectory'],
-    });
+    };
+    // フォーカス窓が無いときは窓なしのオーバーロードへ回す。null を親として
+    // 渡す書き方は型が許さず、すぐ上の openDialog も窓なしで呼んでいる
+    const win = BrowserWindow.getFocusedWindow();
+    const dir = await (win
+      ? dialog.showOpenDialog(win, options)
+      : dialog.showOpenDialog(options));
     return dir.filePaths;
   }),
   writeClipboardText: procedure.input(clipboardInput).mutation(({ input }) => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -23,13 +23,13 @@ log.errorHandler.startCatching({
   // ハードハングになる(#2401)。electron-log は onError の戻り値(Promise)を
   // 待たずにログを書くので、ダイアログ応答後の quit でもログは失われない
   onError: async () => {
-    const options: MessageBoxOptions = {
+    const options = {
       title: 'エラー',
       message: `予期しないエラーが発生したため、AviUtl Package Managerを終了します。\nログファイル: ${
         log.transports.file.getFile().path
       }`,
       type: 'error',
-    };
+    } satisfies MessageBoxOptions;
     if (app.isReady()) {
       await dialog.showMessageBox(options);
     } else {
@@ -96,15 +96,19 @@ app.on(
       if (allowedHosts.includes(host)) {
         callback(true);
       } else {
-        const win = BrowserWindow.getFocusedWindow();
-        const response = await dialog.showMessageBox(win, {
+        const options: MessageBoxOptions = {
           title: '安全ではない接続',
           message: `このサイトでは古いセキュリティ設定を使用しています。このサイトに情報を送信すると流出する恐れがあります。`,
           detail: error,
           type: 'warning',
           buttons: ['戻る', `${host}にアクセスする（安全ではありません）`],
           cancelId: 0,
-        });
+        };
+        // フォーカス窓が無いときは窓なしのオーバーロードへ回す
+        const win = BrowserWindow.getFocusedWindow();
+        const response = await (win
+          ? dialog.showMessageBox(win, options)
+          : dialog.showMessageBox(options));
         if (response.response === 1) {
           allowedHosts.push(host);
           callback(true);

--- a/src/main/services/core.ts
+++ b/src/main/services/core.ts
@@ -167,6 +167,9 @@ export async function installCoreProgram(
 
   const progInfo = coreInfo[program] as Program;
   const release = progInfo.releases.find((r) => r.version === version);
+  if (!release) {
+    throw new Error(`No release found. program:${program} version:${version}`);
+  }
   const url = release.url;
 
   return await runInstallFlow<'downloadFailed' | 'redownloadFailed'>(win, {

--- a/src/main/services/migration.ts
+++ b/src/main/services/migration.ts
@@ -301,8 +301,9 @@ export async function migrationByFolder(
   });
 
   // 2. Update the path to the online and local xml files.
+  // repository は削除対象なので optional。必須と書くと delete が型で弾かれる
   const packages = (await ledger.get('packages')) as {
-    [key: string]: { repository: string };
+    [key: string]: { repository?: string };
   };
   for (const id of Object.keys(packages)) {
     if (Object.hasOwn(packages[id], 'repository'))

--- a/src/main/services/modList.ts
+++ b/src/main/services/modList.ts
@@ -41,24 +41,26 @@ export async function updateInfo(win: BrowserWindow, config: Config) {
 
 /**
  * Returns an object parsed from list.json, downloading it if not cached.
- * 旧 src/lib/modList.ts の getInfo と同一の挙動(読めなければ null)。
+ * 旧 src/lib/modList.ts の getInfo は読めなければ null を返したが、
+ * 呼び出し側 8 箇所はいずれも即座にプロパティを参照していて null を
+ * 扱っておらず、返しても呼び出し元で TypeError になるだけだった。
  * @param {BrowserWindow} win - A browser window used for the download session.
  * @param {Config} config - The config instance.
- * @returns {Promise<List | null>} An object parsed from list.json.
+ * @returns {Promise<List>} An object parsed from list.json.
  */
 export async function getInfo(
   win: BrowserWindow,
   config: Config,
-): Promise<List | null> {
+): Promise<List> {
   if (!existsTempFile('list.json').exists) {
     await updateInfo(win, config);
   }
   const modFile = existsTempFile('list.json');
-  if (!modFile.exists) return null;
+  if (!modFile.exists) throw new Error('list.json is not downloaded.');
   try {
     return (await readJson(modFile.path)) as List;
-  } catch {
-    return null;
+  } catch (e) {
+    throw new Error('Failed to parse list.json.', { cause: e });
   }
 }
 

--- a/src/main/services/packageInstall.ts
+++ b/src/main/services/packageInstall.ts
@@ -150,11 +150,18 @@ export async function installPackageFlow(
     resolveArchive: async () => {
       if (archivePath) return { archivePath };
       if (direct) {
-        const resolvedArchivePath = await downloadFile(
-          win,
-          packageState.info.directURL,
-          { loadCache: true, subDir: 'package' },
-        );
+        // direct 指定なのに directURL を持たないパッケージは、この先の
+        // ダウンロードで必ず失敗する
+        const directURL = packageState.info.directURL;
+        if (!directURL) {
+          throw new Error(
+            `The package has no direct URL. id:${packageState.id}`,
+          );
+        }
+        const resolvedArchivePath = await downloadFile(win, directURL, {
+          loadCache: true,
+          subDir: 'package',
+        });
         if (!resolvedArchivePath) {
           log.error('Failed downloading a file.');
           return { failure: 'downloadFailed' as const };
@@ -181,12 +188,16 @@ export async function installPackageFlow(
     corruptLogUrl: packageState.info.directURL,
     redownloadArchive: async () => {
       if (direct) {
+        const directURL = packageState.info.directURL;
+        if (!directURL) {
+          throw new Error(
+            `The package has no direct URL. id:${packageState.id}`,
+          );
+        }
         // 再ダウンロード先が subDir 'core' なのは旧実装のままの挙動
-        const resolvedArchivePath = await downloadFile(
-          win,
-          packageState.info.directURL,
-          { subDir: 'core' },
-        );
+        const resolvedArchivePath = await downloadFile(win, directURL, {
+          subDir: 'core',
+        });
         if (!resolvedArchivePath) {
           log.error(
             `Failed downloading the archive file. URL:${packageState.info.directURL}`,

--- a/src/main/services/packageList.ts
+++ b/src/main/services/packageList.ts
@@ -251,9 +251,9 @@ export async function adoptManuallyInstalledPackages(
   let modified = false;
   ledger.begin();
   for (const p of packages.filter(
-    (p) => p.info.releases && p.installationStatus === states.manuallyInstalled,
+    (p) => p.installationStatus === states.manuallyInstalled,
   )) {
-    for (const release of p.info.releases) {
+    for (const release of p.info.releases ?? []) {
       if (await checkIntegrity(inst.path, release.integrity.file)) {
         await ledger.addPackage(p.id, release.version);
         modified = true;

--- a/src/main/services/scriptInstall.ts
+++ b/src/main/services/scriptInstall.ts
@@ -306,6 +306,9 @@ export async function installScriptFlow(
       return { route: 'flow', status: 'redirectNotFound' };
     }
     const packageToInstall = packages.find((p) => p.id === packageId);
+    if (!packageToInstall) {
+      throw new Error(`The redirect target is not listed. id:${packageId}`);
+    }
     return {
       route: 'redirect',
       status: await installPackageFlow(ctx, inst, packageToInstall, {


### PR DESCRIPTION
#2429 の続き(#2379 の Phase 2 follow-up)。main 側の非テストコードから `strictNullChecks` 由来のエラーを無くす。**56 → 18 件**(残りは renderer 9 / shared 5 / テスト 4)。

`strict: true` への切り替えはまだ行わない。すべて片付いた最後のスライスで、個別フラグの列ごと一行へ畳む。

## コミット

| コミット | 内容 | 減 |
| --- | --- | --- |
| refactor(main): getInfo の戻り値から null を外す | 契約が虚構だった | 11 |
| refactor(main): 親窓なしのダイアログ呼び出しを型どおり分岐する | Electron のオーバーロード | 3 |
| refactor(main): 実態より厳しい/緩い型注釈を実態に合わせる | Ledger / migration / packageList | 3 |
| refactor(main): 見つからなかった場合を明示的に投げる | find() と optional な directURL | 5 |

## 主な判断

**`getInfo` の `| null` は誰も消費していなかった。** 呼び出し側 8 箇所はいずれも `modInfo.core.path` のように即座にプロパティを参照していて、null を扱う分岐はゼロ。返しても呼び出し元で `TypeError` になるだけで、安全側に倒しているように見えて何も守っていなかった。8 箇所に同じ null チェックを並べるのではなく、返す側で投げる。

**`find()` の undefined 3 箇所も同じく例外のまま保存した。** ただしこちらは事情が違い、`installCore` には `noVersionData`、`installScript` には `redirectNotFound` という**名前の付いた失敗値が既にある**のに、そこへ落とさず undefined を先へ流していた。本来はそちらへ寄せるほうがユーザーには親切だが、クラッシュを UI のエラー表示に変える挙動変更になるため、この PR では発生位置とメッセージだけを読めるようにして別 issue へ回す。

## 挙動について

どの変更も「例外 → 例外」で、観測できる差はエラーの発生位置とメッセージの質だけ。`satisfies` への置き換えと型注釈の修正は実行時コードに影響しない。

## 確認

`yarn lint` / `yarn lint:ts` / `yarn test`(266 件)すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)