### PR TITLE
refactor: strict を有効にする

### DIFF
--- a/src/main/services/core.test.ts
+++ b/src/main/services/core.test.ts
@@ -136,7 +136,7 @@ describe('core service', () => {
     it('キャッシュ済みの core.json を返す', async () => {
       await writeCachedCoreInfo({ aviutl: { latestVersion: '1.10' } });
       const info = await getCoreInfo(ctx);
-      expect(info.aviutl.latestVersion).toBe('1.10');
+      expect(info?.aviutl.latestVersion).toBe('1.10');
     });
   });
 

--- a/src/renderer/about/index.tsx
+++ b/src/renderer/about/index.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 
-const root = createRoot(document.getElementById('root'));
+const container = document.getElementById('root');
+if (!container) throw new Error('#root is not found.');
+const root = createRoot(container);
 root.render(
   <React.StrictMode>
     <App />

--- a/src/renderer/main/aviutl/BatchInstallButton.tsx
+++ b/src/renderer/main/aviutl/BatchInstallButton.tsx
@@ -51,6 +51,7 @@ function BatchInstallButton(): JSX.Element {
     try {
       // tRPC の Serialize 型はプロパティを optional 化するため元の型に戻す
       const coreInfo = (await utils.core.getCoreInfo.fetch()) as Core | null;
+      if (!coreInfo) throw new Error('The version data do not exist.');
       for (const program of programs) {
         const progInfo = coreInfo[program];
         const result = await installProgramMutation.mutateAsync({

--- a/src/renderer/main/monacoEditorRenderer.tsx
+++ b/src/renderer/main/monacoEditorRenderer.tsx
@@ -49,7 +49,8 @@ class PlaceholderContentWidget {
   placeholder: string;
   editor: editor.IStandaloneCodeEditor;
   positionPreference: editor.ContentWidgetPositionPreference;
-  domNode: HTMLElement;
+  // getDomNode() で初めて生成する
+  domNode?: HTMLElement;
 
   /**
    * @param {string} placeholder - placeholder text
@@ -93,18 +94,19 @@ class PlaceholderContentWidget {
    */
   getDomNode(): HTMLElement {
     if (!this.domNode) {
-      this.domNode = document.createElement('div');
+      const domNode = document.createElement('div');
       this.placeholder.split('\n').map((s) => {
         const spanElm = document.createElement('div');
         spanElm.textContent = s;
-        this.domNode.appendChild(spanElm);
+        domNode.appendChild(spanElm);
       });
 
-      this.domNode.style.whiteSpace = 'pre-wrap';
-      this.domNode.style.width = 'max-content';
-      this.domNode.style.pointerEvents = 'none';
-      this.domNode.style.fontStyle = 'italic';
-      this.editor.applyFontInfo(this.domNode);
+      domNode.style.whiteSpace = 'pre-wrap';
+      domNode.style.width = 'max-content';
+      domNode.style.pointerEvents = 'none';
+      domNode.style.fontStyle = 'italic';
+      this.editor.applyFontInfo(domNode);
+      this.domNode = domNode;
     }
 
     return this.domNode;
@@ -132,7 +134,9 @@ class PlaceholderContentWidget {
   }
 }
 
-self.MonacoEnvironment = null;
+// null ではなく undefined なのは型に合わせるためで、Monaco 側は
+// `MonacoEnvironment?.…` と truthy 判定でしか見ないので両者は同値
+self.MonacoEnvironment = undefined;
 
 // Monaco は loader のデフォルト(cdn.jsdelivr.net)ではなく、monacoAssets
 // プラグインが index.html と同じ階層へ同梱する AMD ビルドから読み込む
@@ -166,7 +170,9 @@ export const MonacoEditorRenderer: React.FC = () => {
 
     save.start();
 
-    await editor.getAction('editor.action.formatDocument').run();
+    // getAction / getModel が null を返すのはエディタ破棄後。ここは
+    // 直前に editor の生存を確かめているので必ず取れる
+    await editor.getAction('editor.action.formatDocument')!.run();
     let error =
       monaco.editor
         .getModelMarkers({})
@@ -218,7 +224,7 @@ export const MonacoEditorRenderer: React.FC = () => {
   const editorDidMount: OnMount = (editor, monaco) => {
     editorRef.current = editor;
     monacoRef.current = monaco;
-    editor.getModel().updateOptions({ tabSize: 2 });
+    editor.getModel()!.updateOptions({ tabSize: 2 });
     new PlaceholderContentWidget(
       placeholderStr,
       editor,
@@ -240,7 +246,7 @@ export const MonacoEditorRenderer: React.FC = () => {
         )) as Packages['packages'];
         if (packages.length === 0) return;
         editor.setValue(JSON.stringify(packages));
-        await editor.getAction('editor.action.formatDocument').run();
+        await editor.getAction('editor.action.formatDocument')!.run();
       } catch {
         // nop
       }

--- a/src/renderer/main/nicommons/NicommonsTab.tsx
+++ b/src/renderer/main/nicommons/NicommonsTab.tsx
@@ -162,14 +162,20 @@ function NicommonsTab(): JSX.Element {
         nicommons: 'nc251912',
       },
       ...packages
-        .filter((p) => installedIds.has(p.id) && p.info.nicommons)
-        .map((p) => ({
-          name: p.info.name,
-          developer: p.info.developer,
-          originalDeveloper: p.info.originalDeveloper,
-          typeBadges: parsePackageType(p.type ?? []),
-          nicommons: p.info.nicommons,
-        })),
+        .filter((p) => installedIds.has(p.id))
+        .flatMap((p) =>
+          p.info.nicommons
+            ? [
+                {
+                  name: p.info.name,
+                  developer: p.info.developer,
+                  originalDeveloper: p.info.originalDeveloper,
+                  typeBadges: parsePackageType(p.type ?? []),
+                  nicommons: p.info.nicommons,
+                },
+              ]
+            : [],
+        ),
     ];
   }, [packages, installedIdsQuery.data]);
 

--- a/src/renderer/main/packages/PackagesTab.tsx
+++ b/src/renderer/main/packages/PackagesTab.tsx
@@ -684,6 +684,7 @@ function PackagesTab(): JSX.Element {
                                     {row.kind === 'package' &&
                                       row.p.installationStatus ===
                                         states.installed &&
+                                      row.p.version !== undefined &&
                                       compareVersion(
                                         row.p.info.latestVersion,
                                         row.p.version,

--- a/src/renderer/main/renderer.tsx
+++ b/src/renderer/main/renderer.tsx
@@ -10,7 +10,7 @@ import { TrpcProvider } from './TrpcProvider';
 window.addEventListener('DOMContentLoaded', () => {
   // dark-theme(旧 preload から移設)
   const updateTheme = () => {
-    document.querySelector('html').dataset.bsTheme = window.matchMedia(
+    document.documentElement.dataset.bsTheme = window.matchMedia(
       '(prefers-color-scheme: dark)',
     ).matches
       ? 'dark'
@@ -21,7 +21,9 @@ window.addEventListener('DOMContentLoaded', () => {
     .addEventListener('change', updateTheme);
   updateTheme();
 
-  createRoot(document.getElementById('root')).render(
+  const container = document.getElementById('root');
+  if (!container) throw new Error('#root is not found.');
+  createRoot(container).render(
     <TrpcProvider>
       <App />
     </TrpcProvider>,

--- a/src/shared/packageUtil.test.ts
+++ b/src/shared/packageUtil.test.ts
@@ -340,7 +340,7 @@ describe('computePackagesStatus', () => {
       '1.10',
       '0.92',
     );
-    expect(result[0].detached.map((p) => p.id)).toEqual(['author/dep']);
+    expect(result[0].detached?.map((p) => p.id)).toEqual(['author/dep']);
   });
 
   it('依存のバージョン指定(>=)は compareVersionOp で判定される', () => {
@@ -362,7 +362,7 @@ describe('computePackagesStatus', () => {
     ];
     // 1.5 < 2.0 なので未充足 → or 内でインストール可能な author/alt が候補になる
     const withOld = computePackagesStatus(base('1.5'), '1.10', '0.92');
-    expect(withOld[0].detached.map((p) => p.id)).toEqual(['author/alt']);
+    expect(withOld[0].detached?.map((p) => p.id)).toEqual(['author/alt']);
 
     // 2.1 >= 2.0 で充足 → detached なし
     const withNew = computePackagesStatus(base('2.1'), '1.10', '0.92');

--- a/src/shared/packageUtil.ts
+++ b/src/shared/packageUtil.ts
@@ -231,9 +231,10 @@ export function computePackagesStatus(
 
   packages.forEach((p) => {
     p.doNotInstall = !isInstallable(p.id);
-    p.detached = missingDeps(p.id).map((depsID) =>
-      packages.filter((pp) => pp.id === depsID).find(() => true),
-    );
+    p.detached = missingDeps(p.id).flatMap((depsID) => {
+      const dep = packages.find((pp) => pp.id === depsID);
+      return dep ? [dep] : [];
+    });
   });
   return packages;
 }

--- a/src/shared/parsePackagesXml.test.ts
+++ b/src/shared/parsePackagesXml.test.ts
@@ -141,7 +141,9 @@ describe('parsePackagesXml', () => {
     const packages = parsePackagesXml(xml);
     // 汚染ではなく通常のエントリとして保持される
     expect(Object.keys(packages)).toEqual(['__proto__']);
-    expect(Object.keys(packages['__proto__'].releases)).toEqual(['__proto__']);
+    expect(Object.keys(packages['__proto__'].releases ?? {})).toEqual([
+      '__proto__',
+    ]);
     expect(
       ({} as Record<string, unknown>).polluted,
       'Object.prototype が汚染されていない',

--- a/src/shared/parsePackagesXml.ts
+++ b/src/shared/parsePackagesXml.ts
@@ -127,12 +127,12 @@ export interface ReleaseInfo {
 }
 
 /**
- * @param {RawPackage} parsedData - A object parsed from XML.
+ * @param {RawFiles} parsedFiles - The `<files>` element parsed from XML.
  * @returns {XmlFile[]} An array of files.
  */
-function parseFiles(parsedData: RawPackage): XmlFile[] {
+function parseFiles(parsedFiles: RawFiles): XmlFile[] {
   const files: XmlFile[] = [];
-  for (const file of parsedData.files[0].file) {
+  for (const file of parsedFiles.file) {
     const xmlFile: XmlFile = {
       filename: null,
       isOptional: false,
@@ -144,7 +144,7 @@ function parseFiles(parsedData: RawPackage): XmlFile[] {
     if (typeof file === 'string') {
       xmlFile.filename = file;
     } else if (typeof file === 'object') {
-      xmlFile.filename = file._;
+      xmlFile.filename = file._ ?? null;
       if (file.$optional) xmlFile.isOptional = Boolean(file.$optional[0]);
       if (file.$installOnly)
         xmlFile.isInstallOnly = Boolean(file.$installOnly[0]);
@@ -195,7 +195,10 @@ export class PackageInfo {
     for (const key of defaultKeys) {
       if (parsedPackage[key]) {
         if (key === 'files') {
-          this.files = parseFiles(parsedPackage);
+          // 直前の `parsedPackage[key]` で存在は確かめているが、key が
+          // union のループ変数なので files 自体の絞り込みには効かない
+          const parsedFiles = parsedPackage.files;
+          if (parsedFiles) this.files = parseFiles(parsedFiles[0]);
         } else if (key === 'latestVersion') {
           const parsedValue = parsedPackage[key][0];
           if (typeof parsedValue === 'string') {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,17 +5,8 @@
     "module": "nodenext",
     "skipLibCheck": true,
     "esModuleInterop": true,
-    // TS 6.0 から strict が既定で有効。strict 化は挙動リスクを伴うため
-    // メジャー更新と混ぜず段階導入する。残るのは strictNullChecks と
-    // strictPropertyInitialization。全部立ったら "strict": true へ畳む
-    "strict": false,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
-    "alwaysStrict": true,
-    "strictBindCallApply": true,
-    "strictFunctionTypes": true,
-    "strictBuiltinIteratorReturn": true,
-    "useUnknownInCatchVariables": true,
+    // TS 6.0 の既定。段階導入(#2379)を終えたので個別フラグは畳んである
+    "strict": true,
     "sourceMap": true,
     // TS 6.0 から rootDir の暗黙推論が廃止(TS5011)。include が vite.*.config.ts
     // 等リポジトリ直下も含むため "." を明示する


### PR DESCRIPTION
#2429 → #2432 の続きで最後。renderer / shared / テストに残っていた `strictNullChecks` を解消し、**`strict: true` へ切り替える**。#2379 の Phase 2 follow-up はこれで完了。

起票時 69 件 → Phase 5 の責務分割後 56 件 → **0 件**。

## コミット

| コミット | 内容 | 減 |
| --- | --- | --- |
| refactor(renderer): ルート要素の取得を検証付きにする | createRoot / documentElement | 3 |
| refactor(renderer): monaco 境界の null を型に合わせる | domNode / MonacoEnvironment / getAction | 5 |
| refactor(renderer): 段階的に埋まる値の未確定を扱う | PackageState の optional | 3 |
| refactor(shared): 呼び出し文脈が保証する存在を型でも示す | parseFiles / filename / detached | 3 |
| test: 検証対象が未確定のときテストが落ちるようにする | optional chaining | 4 |
| build(tsconfig): strict を有効にする | 個別フラグを畳む | — |

## 主な判断

**`MonacoEnvironment = null` → `undefined`** — 型が `Environment | undefined` で null を受けない。読み取り側を確認したところ、AMD ビルド(`min/vs/editor/editor.main.js`)は `const u = globalThis.MonacoEnvironment; if (u) {…}` の truthy 判定、ESM ビルドは `monacoEnvironment?.globalAPI` の optional chaining で、**null と undefined はどちらも同じ経路**に落ちる。挙動は変わらない。

**non-null assertion を使ったのは monaco の 3 箇所だけ。** `getAction` / `getModel` が null を返すのはエディタ破棄後で、呼んでいるのは onMount 直後と生存確認直後の 2 文脈しかない。`?.` にすると取れなかったときに黙って進んでしまい今の挙動と変わるため、`!` で型が表現できていない文脈情報を補った。

**apm 自身のドメイン型(`PackageState`)の optional は `!` で塞がなかった。** こちらは「段階的に埋まる」設計そのものなので、到達しないなら挙動同一・到達するならクラッシュ回避になる形(条件の追加、flatMap)に倒している。とくに `PackagesTab` の更新表示は、version 未記録のまま `compareVersion` に渡すと `toLowerCase` で落ちて**描画中の例外=一覧全体を巻き込む**ため、条件を足した。

**テストの 4 件は `!` ではなく `?.`。** null や undefined だったときに落ちてほしいのはテストとしてむしろ正しく、`?.` なら期待値との比較で落ちる。`!` だと通ってしまう。

## 確認

`yarn lint` / `yarn lint:ts` / `yarn test`(266 件)すべて緑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)