### PR TITLE
build(deps-dev): monaco-editor を 0.56.0 へ更新する

### DIFF
--- a/e2e/monaco.spec.ts
+++ b/e2e/monaco.spec.ts
@@ -13,7 +13,7 @@ type MonacoWindow = {
       }[];
       getModelMarkers: (filter: object) => { message: string }[];
     };
-    languages: { json?: { jsonDefaults?: unknown } };
+    json?: { jsonDefaults?: unknown };
   };
 };
 
@@ -56,13 +56,12 @@ test('設定タブの Monaco エディタが表示・入力・スキーマ検証
     timeout: 120_000,
   });
 
-  // 0.55 で languages.json は非推奨になったが、AMD の editor.main が互換のため
-  // 再付与している。それに依存しているので生きていることを確かめる
+  // 0.55 で languages.json はトップレベルの json へ移り、型が付いているのは
+  // 新しい方だけなのでそちらを使っている。実体があることを確かめる
+  // (旧 languages.json も editor.main が互換で再付与しているが依存しない)
   expect(
     await window.evaluate(
-      () =>
-        !!(window as unknown as MonacoWindow).monaco.languages.json
-          ?.jsonDefaults,
+      () => !!(window as unknown as MonacoWindow).monaco.json?.jsonDefaults,
     ),
   ).toBe(true);
 

--- a/e2e/monaco.spec.ts
+++ b/e2e/monaco.spec.ts
@@ -98,9 +98,13 @@ test('設定タブの Monaco エディタが表示・入力・スキーマ検証
   await setModelValue('[{"id":"a/b","name":"n"}]');
   await viewLines.click();
   await window.keyboard.press('Shift+Alt+F');
-  // editorDidMount の updateOptions({ tabSize: 2 }) 込みで確かめる
+  // editorDidMount の updateOptions({ tabSize: 2 }) 込みで確かめる。
+  // 既定の EOL はプラットフォーム依存(Windows は CRLF)で、ここで見たいのは
+  // インデントなので改行は正規化する
   await expect
-    .poll(modelValue, { timeout: 60_000 })
+    .poll(async () => (await modelValue()).replace(/\r\n/g, '\n'), {
+      timeout: 60_000,
+    })
     .toBe('[\n  {\n    "id": "a/b",\n    "name": "n"\n  }\n]');
 
   // --- codicon(0.56 で .ttf ファイルから data: URI 埋め込みに変わった)---

--- a/e2e/monaco.spec.ts
+++ b/e2e/monaco.spec.ts
@@ -1,0 +1,117 @@
+import { expect, getMainWindow, test } from './helpers';
+
+// Monaco は Vite の依存解決に載せず AMD ビルドを丸ごと同梱する構成のため、
+// 同梱物が欠けてもビルドは通り、起動して初めて落ちる。バージョン更新のたびに
+// パッケージ版で実際に触って確かめる。
+type MonacoWindow = {
+  monaco: {
+    editor: {
+      ContentWidgetPositionPreference?: unknown;
+      getModels: () => {
+        getValue: () => string;
+        setValue: (value: string) => void;
+      }[];
+      getModelMarkers: (filter: object) => { message: string }[];
+    };
+    languages: { json?: { jsonDefaults?: unknown } };
+  };
+};
+
+const PLACEHOLDER_PHRASE = 'ローカルリポジトリ';
+
+test('設定タブの Monaco エディタが表示・入力・スキーマ検証・整形まで動く', async ({
+  launchApp,
+}) => {
+  const app = await launchApp();
+  const window = await getMainWindow(app);
+
+  const problems: string[] = [];
+  window.on('pageerror', (e) => problems.push('pageerror: ' + String(e)));
+  window.on('console', (m) => {
+    // nicommons のサムネイル取得失敗など、Monaco と無関係な通信エラーは除く
+    // (CSP 違反は "Failed to load resource" ではなく専用の文言で出るので残る)
+    if (m.type() === 'error' && !m.text().includes('Failed to load resource'))
+      problems.push('console: ' + m.text());
+  });
+
+  const modelValue = () =>
+    window.evaluate(() =>
+      (window as unknown as MonacoWindow).monaco.editor
+        .getModels()[0]
+        .getValue(),
+    );
+  const setModelValue = (value: string) =>
+    window.evaluate(
+      (v) =>
+        (window as unknown as MonacoWindow).monaco.editor
+          .getModels()[0]
+          .setValue(v),
+      value,
+    );
+
+  await window.getByRole('tab', { name: '設定' }).click();
+
+  // --- 表示 ---
+  await expect(window.locator('#container .monaco-editor')).toBeVisible({
+    timeout: 120_000,
+  });
+
+  // 0.55 で languages.json は非推奨になったが、AMD の editor.main が互換のため
+  // 再付与している。それに依存しているので生きていることを確かめる
+  expect(
+    await window.evaluate(
+      () =>
+        !!(window as unknown as MonacoWindow).monaco.languages.json
+          ?.jsonDefaults,
+    ),
+  ).toBe(true);
+
+  // --- プレースホルダ(ContentWidget)---
+  const placeholder = window
+    .locator('#container')
+    .getByText(PLACEHOLDER_PHRASE, { exact: false });
+  await expect(placeholder).toBeVisible();
+
+  // --- 入力 ---
+  // 0.56 の入力受け口は textarea.inputarea ではなくなったため、実ユーザ同様に
+  // 行領域をクリックしてフォーカスを取る
+  const viewLines = window.locator('#container .monaco-editor .view-lines');
+  await viewLines.click();
+  await window.keyboard.type('[]');
+  await expect.poll(modelValue).toBe('[]');
+  await expect(placeholder).toHaveCount(0);
+
+  // --- スキーマ検証(json worker が生きているか)---
+  await setModelValue('[{"foo":"bar"}]');
+  await expect
+    .poll(
+      () =>
+        window.evaluate(() =>
+          (window as unknown as MonacoWindow).monaco.editor
+            .getModelMarkers({})
+            .map((marker) => marker.message),
+        ),
+      { timeout: 60_000 },
+    )
+    .toContain('Missing property "id".');
+
+  // --- 整形(Shift+Alt+F)---
+  await setModelValue('[{"id":"a/b","name":"n"}]');
+  await viewLines.click();
+  await window.keyboard.press('Shift+Alt+F');
+  // editorDidMount の updateOptions({ tabSize: 2 }) 込みで確かめる
+  await expect
+    .poll(modelValue, { timeout: 60_000 })
+    .toBe('[\n  {\n    "id": "a/b",\n    "name": "n"\n  }\n]');
+
+  // --- codicon(0.56 で .ttf ファイルから data: URI 埋め込みに変わった)---
+  // font-display: block のため描画されるまで status は unloaded のままなので、
+  // CSP に阻まれていないことを見るには明示的にロードさせる
+  expect(
+    await window.evaluate(() =>
+      document.fonts.load('16px codicon').then((f) => f.length),
+    ),
+  ).toBeGreaterThan(0);
+
+  expect(problems).toEqual([]);
+});

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "globals": "^17.11.0",
     "husky": "^9.1.7",
     "lint-staged": "^17.3.0",
-    "monaco-editor": "0.52.2",
+    "monaco-editor": "0.56.0",
     "npm-run-all2": "^9.0.3",
     "prettier": "^3.9.6",
     "prettier-plugin-packagejson": "^3.0.2",

--- a/src/renderer/main/index.html
+++ b/src/renderer/main/index.html
@@ -5,10 +5,15 @@
 		<!-- https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP -->
 		<!-- Monaco はローカル同梱(main_window/vs)から読むため CDN 許可は無い。
 		     worker-src blob: は Monaco の AMD loader が worker を blob 経由で起動するため、
-		     style-src 'unsafe-inline' は Monaco と Bootstrap の動的スタイルのために残している -->
+		     style-src 'unsafe-inline' は Monaco と Bootstrap の動的スタイルのために残している。
+		     font-src data: は Monaco 0.56 が codicon フォントを .ttf ファイルではなく
+		     editor.main.css へ data: URI で埋め込むようになったため(0.55 以前は
+		     vs/base/.../codicon.ttf という実ファイルで 'self' に収まっていた)。
+		     外さないこと: 阻まれてもエディタは動くので、折りたたみ・検索ウィジェット等の
+		     アイコンだけが無言で消える -->
 		<meta
 			http-equiv="Content-Security-Policy"
-			content="default-src 'self'; script-src-elem 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https://*.nicovideo.jp https://*.nicoseiga.jp https://nicovideo.cdn.nimg.jp"
+			content="default-src 'self'; script-src-elem 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data: https://*.nicovideo.jp https://*.nicoseiga.jp https://nicovideo.cdn.nimg.jp"
 		/>
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>AviUtl Package Manager</title>

--- a/src/renderer/main/monacoEditorRenderer.tsx
+++ b/src/renderer/main/monacoEditorRenderer.tsx
@@ -1,7 +1,6 @@
 import MonacoEditor, {
   BeforeMount,
   loader,
-  Monaco,
   OnMount,
 } from '@monaco-editor/react';
 import { Packages } from 'apm-schema';
@@ -16,6 +15,17 @@ import React, { useRef } from 'react';
 import { TRPCReact } from '../trpc';
 import { getInstallationPath } from './installationPath';
 import { usePhase } from './usePhase';
+
+// beforeMount / onMount が渡してくるのは window.monaco そのもの。一方
+// @monaco-editor/react の Monaco 型は 'monaco-editor/esm/vs/editor/editor.api'
+// を型 import しており、monaco-editor 0.56 の exports マップ
+// ("./*": "./esm/vs/*.js")がこのパスを esm/vs/esm/vs/... へ写像するため解決
+// できない。skipLibCheck が失敗を隠すので any に劣化し、コールバック引数が
+// 暗黙 any になって noImplicitAny で落ちる。
+// 解決できる方("." の exports)の型を実体として使い、境界で一度だけ被せる。
+// editor.api を paths で直接指させないのは、language 系(json 等)が 0.55 で
+// index 側へ移っており editor.api では表現できないため
+type Monaco = typeof import('monaco-editor');
 
 const placeholderStr = `
 ここに書いたパッケージデータは AviUtl フォルダ内の editorPackages.json に保存されます。
@@ -208,8 +218,12 @@ export const MonacoEditorRenderer: React.FC = () => {
   const saveEditorDataRef = useRef(saveEditorData);
   saveEditorDataRef.current = saveEditorData;
 
-  const editorWillMount: BeforeMount = (monaco) => {
-    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+  const editorWillMount: BeforeMount = (monacoInstance) => {
+    const monaco = monacoInstance as unknown as Monaco;
+    // 0.55 で languages.json はトップレベルの json へ移った。AMD の
+    // editor.main が互換のため languages.json も再付与しているので実行時は
+    // どちらでも動くが、型が付いているのは新しい方だけ
+    monaco.json.jsonDefaults.setDiagnosticsOptions({
       validate: true,
       schemas: [
         {
@@ -221,7 +235,8 @@ export const MonacoEditorRenderer: React.FC = () => {
     });
   };
 
-  const editorDidMount: OnMount = (editor, monaco) => {
+  const editorDidMount: OnMount = (editor, monacoInstance) => {
+    const monaco = monacoInstance as unknown as Monaco;
     editorRef.current = editor;
     monacoRef.current = monaco;
     editor.getModel()!.updateOptions({ tabSize: 2 });

--- a/vite.plugins.config.ts
+++ b/vite.plugins.config.ts
@@ -72,26 +72,33 @@ export function assertExternals(allowed: string[]): Plugin {
   };
 }
 
-// JSON エディタに不要な言語サービス・UI 翻訳は同梱しない(-8MB 超)。
-// JSON のハイライトは basic-languages ではなく language/json が持つ
+// JSON エディタから到達しない大物は同梱しない(27MB -> 6MB 弱)。
+// 0.53 で AMD ビルドが Rollup 製に変わりチャンク名にハッシュが付いたため、
+// ディレクトリ名の前方一致ではなく正規表現で表す。
+//   language/  : 0.52 までの単独エントリの名残。editor/editor.main.js は同じ
+//                worker を assets/ 配下のハッシュ付きチャンク経由で読むので、
+//                同じ内容が二重に入っている
+//   nls/       : vs/nls の availableLanguages を設定したときだけ読まれる。
+//                apm は設定しないので Monaco の UI は英語のまま(0.52 で
+//                nls.messages.*.js を除外していたのと結果は同じ)
+//   assets/{css,html,ts}.worker : その言語のモデルを作った時点で初めて
+//                fetch される。apm が開くのは JSON だけ
+// basic-languages と各言語のトークナイザは除外しない。前者は editor.main の
+// 静的依存に入っており(欠けると AMD の解決が止まる)、後者は合計 0.5MB 程度
 const MONACO_EXCLUDED = [
-  'language/css',
-  'language/html',
-  'language/typescript',
-  'basic-languages',
+  /^language(?:\/|$)/,
+  /^nls(?:\/|$)/,
+  /^assets\/(?:css|html|ts)\.worker-[^/]*\.js$/,
 ];
 
 /**
- * Returns whether the given path under `vs` should be bundled.
+ * Returns the exclusion pattern covering the given path, if any.
  * @param {string} relative - Path relative to the `vs` directory.
- * @returns {boolean} True when the file should be copied.
+ * @returns {RegExp | undefined} The matching pattern, or undefined to copy.
  */
-function isMonacoAssetIncluded(relative: string): boolean {
+function monacoExclusionFor(relative: string): RegExp | undefined {
   const normalized = relative.split(path.sep).join('/');
-  if (/(^|\/)nls\.messages\..*\.js$/.test(normalized)) return false;
-  return !MONACO_EXCLUDED.some(
-    (dir) => normalized === dir || normalized.startsWith(`${dir}/`),
-  );
+  return MONACO_EXCLUDED.find((pattern) => pattern.test(normalized));
 }
 
 /**
@@ -135,13 +142,31 @@ export function monacoAssets(projectRoot: string): Plugin {
       });
     },
     async writeBundle() {
+      const used = new Set<RegExp>();
       await cp(source, path.join(outDir, 'vs'), {
         recursive: true,
         filter: (src) => {
           const relative = path.relative(source, src);
-          return relative === '' || isMonacoAssetIncluded(relative);
+          if (relative === '') return true;
+          const pattern = monacoExclusionFor(relative);
+          if (!pattern) return true;
+          used.add(pattern);
+          return false;
         },
       });
+
+      // 1 件も当たらない除外は、Monaco 側の min/vs の構成が変わって意図した
+      // 除外が効かなくなった合図。同梱物が増えるだけなら気付けないのに、
+      // 逆に必要なものが除外側へ回り込むと「ビルドは通るのに起動時に落ちる」
+      // ため、構成が動いたこと自体をここで落とす
+      const dead = MONACO_EXCLUDED.filter((pattern) => !used.has(pattern));
+      if (dead.length > 0) {
+        throw new Error(
+          `一致しなかった Monaco の除外パターンがあります: ${dead.join(', ')}\n` +
+            'monaco-editor の min/vs の構成が変わっている。同梱すべきものが' +
+            '除外されていないか確かめて MONACO_EXCLUDED を見直すこと。',
+        );
+      }
     },
   };
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2239,6 +2239,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/trusted-types@^2.0.7":
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.7.tgz#baccb07a970b91707df3a3e8ba6896c57ead2d11"
+  integrity sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==
+
 "@types/warning@^3.0.3":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.4.tgz#ebc0c83180dc83994d902bbd51ab0af8a445b1f9"
@@ -3923,6 +3928,13 @@ dom-helpers@^5.0.1, dom-helpers@^5.2.0, dom-helpers@^5.2.1:
   dependencies:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
+
+dompurify@3.4.8:
+  version "3.4.8"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.8.tgz#6c54f8c207160e7f83fcb7f4fd05a82ac36b1cdc"
+  integrity sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==
+  optionalDependencies:
+    "@types/trusted-types" "^2.0.7"
 
 dot-prop@^5.1.0:
   version "5.3.0"
@@ -6264,6 +6276,11 @@ map-age-cleaner@^0.1.1:
   dependencies:
     p-defer "^1.0.0"
 
+marked@14.0.0:
+  version "14.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-14.0.0.tgz#79a1477358a59e0660276f8fec76de2c33f35d83"
+  integrity sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==
+
 matcher@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/matcher/-/matcher-3.0.0.tgz#bd9060f4c5b70aa8041ccc6f80368760994f30ca"
@@ -6493,10 +6510,13 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-monaco-editor@0.52.2:
-  version "0.52.2"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.52.2.tgz#53c75a6fcc6802684e99fd1b2700299857002205"
-  integrity sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==
+monaco-editor@0.56.0:
+  version "0.56.0"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.56.0.tgz#e85ac00b7ab7092ca1d077894504919af5073cf0"
+  integrity sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==
+  dependencies:
+    dompurify "3.4.8"
+    marked "14.0.0"
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

`monaco-editor` を 0.52.2 → 0.56.0 へ更新する。0.x のマイナー上げは semver 上は破壊的変更が許される枠なので、[AGENTS.md](../blob/main/AGENTS.md) の「メジャー依存更新は 1 PR = 1 major」に相当する扱いとして依存更新 PR から切り出した。

実際に破壊的変更が 3 件あった。うち 2 件は **lint・型・ユニットテスト・ビルドをすべて通過したうえで、起動時に初めて壊れる**種類のもので、残る 1 件は型解決そのものが壊れて CI の型チェックが落ちるものだった。

### 1. `min/vs` の構成が変わり、同梱物の除外リストが空振りしていた

0.53 で AMD ビルドが Rollup 製に置き換わり、チャンク名にハッシュが付くようになった。`basic-languages` の各言語と `base/` はルート直下のフラットなチャンクへ、`nls.messages.*.js` は `nls/lang/*.js` + `nls.messages-loader.js` へ移動している。

このため従来の `MONACO_EXCLUDED`(ディレクトリ名の前方一致)は、

- `basic-languages` → 残っているのは `basic-languages/monaco.contribution.js` **1 ファイルだけ**で、これは `editor/editor.main.js` の**静的依存**。除外すると AMD の解決が止まりエディタが表示されない
- `nls.messages.*.js` の正規表現 → 何にも一致しない空振り

という状態になっていた。

`editor/editor.main.js` からの AMD 依存グラフ(静的 `define` + 動的 `require([...])` + `toUrl()` のアセット参照)を辿り直して除外を正規表現で表しなおした。`jsonMode` が動的 `require` で読まれるため「必要なものを列挙する allowlist」は成立せず、既定が安全側の denylist を維持している。

除外するのは以下の 3 つ。**27MB → 7.8MB**。

| パターン | 理由 |
| --- | --- |
| `language/` | 0.52 までの単独エントリの名残。`editor.main` は同じ worker を `assets/` 配下のハッシュ付きチャンク経由で読むため、同じ内容が二重に入っている |
| `nls/` | `vs/nls` の `availableLanguages` を設定したときだけ読まれる。apm は設定しないので Monaco の UI は英語のまま(0.52 で `nls.messages.*.js` を除外していたのと結果は同じ) |
| `assets/{css,html,ts}.worker-*` | その言語のモデルを作った時点で初めて fetch される。apm が開くのは JSON だけ |

あわせて、**除外パターンが 1 件も一致しなければビルドを落とす**ガードを入れた。同梱物が増えるだけの空振りは気付けないまま放置され、次に構成が動いたときに必要なものを除外側へ回り込ませてしまうため、構成が変わったこと自体を検出線にしている(`assertExternals` と同じ発想)。

### 2. codicon フォントが data: URI 埋め込みに変わり CSP に阻まれていた

0.55 以前は `vs/base/browser/ui/codicons/codicon/codicon.ttf` という実ファイルで `font-src 'self'` に収まっていたが、0.56 では `editor.main.css` へ `data:font/ttf;base64,...` として埋め込まれ、`.ttf` 自体が配布物から消えた。

阻まれてもエディタ本体は動くため、折りたたみ・検索ウィジェット・補完候補などの**アイコンだけが無言で消える**。`font-src` に `data:` を追加した。

### 3. `@monaco-editor/react` の `Monaco` 型が解決できなくなり型が全部 `any` に落ちていた

`@monaco-editor/react` 4.7.0 の `Monaco` 型は `import * as monaco from 'monaco-editor/esm/vs/editor/editor.api'` を使っているが、0.56 が追加した `exports` マップの `"./*": "./esm/vs/*.js"` がこのパスを `esm/vs/esm/vs/...` へ写像するため**解決できない**(Node リゾルバでも `MODULE_NOT_FOUND`)。`skipLibCheck: true` が失敗を握りつぶすので `Monaco` は `any` に劣化し、`beforeMount` / `onMount` で渡される `monaco` が丸ごと型無しになる。

結果、`getModelMarkers` の結果を `filter` するコールバックの引数が暗黙 any になり、`noImplicitAny` で落ちる。

`editor.api` を `paths` で直接指す手もあるが、language 系(`json` 等)の名前空間は 0.55 で `index` 側へ移っており `editor.api` では表現できない。解決できる方(`.` の exports)の型を実体として使い、境界で一度だけ被せている。

あわせて `jsonDefaults` の参照を `languages.json` からトップレベルの `json` へ移した。実行時は AMD の `editor.main` が `languages.json` も互換で再付与しているためどちらでも動くが、型が付いているのは新しい方だけ。

なお `IOverlayWidgetPosition.stackOridinal` → `stackOrdinal` の改名は overlay widget 側で、本コードが使う content widget には影響しない。

## Related Issue

なし(依存更新)

## Motivation and Context

上記のとおり、既存のチェック(lint / 型 / ユニットテスト / ビルド)がいずれも検出線にならない壊れ方だったため、更新そのものより「壊れていることに気付ける状態にする」ことが主眼になっている。

変更を最小に保つ方針からは `languages.json` のままにしたかったが、3 の型修正で `Monaco` に実体の型が付いた結果、非推奨スタブ(`{ deprecated: true }`)では型が通らなくなったため、あわせて移している。

### レビュー時に知っておいてほしいこと

上記 3 のとおり、`@monaco-editor/react` 側の型 import が 0.56 の `exports` マップと噛み合っていない。この PR では利用側(境界で実体の型を被せる)で回避しているが、本来は上流が直すべきもの。上流が `Monaco` の定義を直したら、この回避は外せる。

`monaco.languages.json` は非推奨だが実行時にはまだ生きている。将来 AMD ビルドごと消える可能性があるので、0.53 のリリースノートが告知している **AMD ビルドの非推奨化**もいずれ効いてくる。そのときは `vite.plugins.config.ts` のコピー方式ごと作り直しになる(この PR では扱わない)。

## How Has This Been Tested?

環境: macOS (darwin-arm64), Node 24.19.0, yarn 1.22.22

- `yarn lint` / `yarn lint:ts` / `yarn test` (27 files / 268 tests) すべて緑
- `yarn package` でパッケージ版をビルドし、同梱された `vs/` に必要なファイルが揃っていること・`language/` と `nls/` と css/html/ts の worker 実体が除外されていることを確認
- `yarn test:e2e` 5/5 緑
- 3 の型修正は、**祖先に `node_modules` を持たない場所へソースを写して CI と同じ解決条件を再現**したうえで確認した(この worktree は親チェックアウトの 0.52.2 の型まで遡って拾ってしまい、ローカルの `lint:ts` が CI と一致しないため)。修正前は同条件で `TS7006` が再現し、修正後は緑になる

E2E テスト(`e2e/monaco.spec.ts`)を追加した。パッケージ版を実際に起動して、以下を通しで確かめる。

- エディタの描画
- プレースホルダ(ContentWidget)の表示と、入力後に消えること
- **実キーストロークでの入力**(0.56 で入力受け口が `textarea.inputarea` から変わったため、実ユーザ同様に行領域をクリックする)
- apm-schema による検証 = json worker の生存(`Missing property "id".` が出ること)
- Shift+Alt+F での整形(`tabSize: 2` 込み)
- codicon フォントの読み込み(CSP に阻まれないこと)

このテスト自体が有効なガードであることも確認済み。`assets/json.worker-*` を意図的に除外してビルドすると、スキーマ検証のアサーションで落ちる。同様に、除外パターンの空振り検知も意図的に空振りさせてビルドが落ちることを確認した。

## Screenshots (if appropriate):

なし

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
