### PR TITLE
fix(shared): isOptional の改名で説明文まで書き換わる問題を修正する

### DIFF
--- a/src/shared/convertPackagesV2toV3.test.ts
+++ b/src/shared/convertPackagesV2toV3.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { convertPackagesV2toV3 } from './convertPackagesV2toV3';
 import { parsePackagesXml } from './parsePackagesXml';
 
-// migration2to3.byFolder が行う「packages.xml → packages.json」変換の
-// 特性化テスト。パース → 変換のパイプライン全体を現行挙動のまま固定する
+// 「packages.xml → packages.json」変換のテスト。
+// パース → 変換のパイプライン全体を通して出力の形を固定する
 const fixtureXml = `<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package>
@@ -110,16 +110,34 @@ describe('convertPackagesV2toV3', () => {
     });
   });
 
-  it('isOptional の変換は JSON 文字列全体への置換として働く(現行挙動の固定)', () => {
-    // キーだけでなく値に含まれる isOptional も置換される。
-    // 旧実装の JSON.stringify + replaceAll をそのまま移植しているため
+  it('isOptional の改名はファイル要素のキーだけに効き、説明文は書き換えない', () => {
     const result = convertPackagesV2toV3([
-      { id: 'x', overview: 'isOptional を説明する文章' },
+      {
+        id: 'x',
+        overview: 'isOptional を説明する文章',
+        files: [
+          {
+            filename: 'readme.txt',
+            isOptional: true,
+            isInstallOnly: false,
+            isDirectory: false,
+            isObsolete: false,
+            archivePath: null,
+          },
+        ],
+      },
     ]);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((result.packages[0] as any).overview).toBe(
-      'isUninstallOnly を説明する文章',
-    );
+    const converted = result.packages[0] as any;
+    expect(converted.overview).toBe('isOptional を説明する文章');
+    expect(converted.files[0]).toEqual({
+      filename: 'readme.txt',
+      isUninstallOnly: true,
+      isInstallOnly: false,
+      isDirectory: false,
+      isObsolete: false,
+      archivePath: null,
+    });
   });
 
   it('releases が無いパッケージは downloadURLs の組み立てのみ行う', () => {

--- a/src/shared/convertPackagesV2toV3.ts
+++ b/src/shared/convertPackagesV2toV3.ts
@@ -9,19 +9,31 @@ export interface PackagesJsonV3 {
 /**
  * Converts packages parsed from the v2 `packages.xml` into the v3
  * `packages.json` format.
- * 旧 migration2to3.byFolder のインライン実装の忠実な移植。
- * `isOptional` → `isUninstallOnly` の変換は JSON 文字列全体への
- * replaceAll であり、キー以外(説明文等)に isOptional という文字列が
- * 含まれていても置換されるという性質ごと維持している。
+ * 旧 migration2to3.byFolder のインライン実装の移植。ただし
+ * `isOptional` → `isUninstallOnly` の改名だけはファイル要素のキーに対して
+ * 行う(旧実装の JSON 文字列全体への replaceAll は、説明文に isOptional と
+ * いう文字列が含まれていると値まで書き換えてしまう)。
  * @param {PackageInfo[]} packages - Packages parsed from `packages.xml`.
  * @returns {PackagesJsonV3} The v3 `packages.json` data.
  */
 export function convertPackagesV2toV3(packages: PackageInfo[]): PackagesJsonV3 {
-  let v3Packages = JSON.parse(
-    JSON.stringify(packages).replaceAll('isOptional', 'isUninstallOnly'),
-  );
+  // 以降のステップが破壊的に書き換えるため、freeze された PackageInfo とは
+  // 別の可変オブジェクトへ複製する
+  let v3Packages = JSON.parse(JSON.stringify(packages));
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   v3Packages = v3Packages.map((p: any) => {
+    // isOptional は <file> の属性由来のキー(parsePackagesXml の XmlFile)。
+    // 出現箇所が分かっているので文字列置換にはしない。entries を組み直すのは
+    // delete + 代入だと改名したキーが末尾へ移り、出力の並びが変わるため
+    if (Array.isArray(p.files)) {
+      p.files = p.files.map((file: Record<string, unknown>) =>
+        Object.fromEntries(
+          Object.entries(file).map(([key, value]) =>
+            key === 'isOptional' ? ['isUninstallOnly', value] : [key, value],
+          ),
+        ),
+      );
+    }
     if (p?.dependencies?.dependency) p.dependencies = p.dependencies.dependency;
     if (p?.releases)
       p.releases = Object.entries(p.releases).map(([k, v]) => {


### PR DESCRIPTION
## 問題

v2 → v3 変換の `isOptional` → `isUninstallOnly` は、**JSON 文字列全体への `replaceAll`** で実装されている。

```ts
JSON.parse(JSON.stringify(packages).replaceAll('isOptional', 'isUninstallOnly'))
```

キーだけでなく値も置換するので、`overview` や `description` に `isOptional` という文字列を含むパッケージは、**本文まで書き換えられた `packages.json`** が書き出される。

`isOptional` は `<file optional="true">` 由来で、出現箇所は `package.files[]` のキーだけと分かっている(`parsePackagesXml` の `XmlFile`)。文字列置換にする理由が無い。

## 修正

そのキーに対する改名にする。改名後もキーの並びが変わらないよう `entries` を組み直している(`delete` + 代入だと改名したキーが末尾へ移り、出力の並びが変わるため)。

```ts
if (Array.isArray(p.files)) {
  p.files = p.files.map((file) =>
    Object.fromEntries(
      Object.entries(file).map(([key, value]) =>
        key === 'isOptional' ? ['isUninstallOnly', value] : [key, value],
      ),
    ),
  );
}
```

## 方針との関係

旧挙動は「移行中は現行動作を保存する」に従って**意図的に**維持されていたもので、JSDoc と特性化テストの両方にその旨が書かれていた。

[#2431](https://github.com/team-apm/apm/pull/2431) でその原則の適用範囲を明示した(移行が済んだ領域の設計しなおしでは、現行動作は前提ではなく検討対象)ので、それに沿って挙動を直し、テストを新しい期待値へ更新する。

## 影響範囲

`convertPackagesV2toV3` は v2 → v3 移行時のローカルリポジトリ変換でしか呼ばれない。したがって:

- **既に壊れた `packages.json` が書き出されたユーザーは救えない。** 移行は一度きりなので、手元のファイルを直してもらうしかない
- 今後 v2 から上がってくるユーザーには効く

優先度としては高くないが、修正自体は小さく、直さない理由も無いという判断。

## テスト

現行挙動を固定していた 1 件を新しい期待値へ更新した。**旧実装に差し戻すと落ちる**ことを確認済み。

```
× isOptional の改名はファイル要素のキーだけに効き、説明文は書き換えない
  → expected 'isUninstallOnly を説明する文章' to be 'isOptional を説明する文章'
```

パイプライン全体を通す既存テスト(`files[].isUninstallOnly` の期待値を含む)は**変更なしで緑**。

## 確認

- `npx tsc --noEmit` — 緑
- `npx eslint src` — 緑
- `npx prettier --check` — 緑
- `npx vitest run` — 268 passed (27 files)