### PR TITLE
refactor(renderer): 未使用の CSS クラス btn-copy / alert-text を削除する

### DIFF
--- a/src/renderer/main/nicommons/NicommonsTab.tsx
+++ b/src/renderer/main/nicommons/NicommonsTab.tsx
@@ -196,7 +196,7 @@ function NicommonsTab(): JSX.Element {
             <div className="col-auto">
               <button
                 type="button"
-                className="btn btn-copy btn-primary"
+                className="btn btn-primary"
                 id="copy-nicommons-id-textarea"
                 onClick={() =>
                   writeClipboardMutation.mutate({ text: idListText })

--- a/src/renderer/main/packages/PackagesTab.tsx
+++ b/src/renderer/main/packages/PackagesTab.tsx
@@ -560,11 +560,9 @@ function PackagesTab(): JSX.Element {
                         className="mt-2 mb-1 alert alert-info alert-dismissible fade show"
                         role="alert"
                       >
-                        <div className="alert-text">
-                          {alertStrings.map((s) => (
-                            <div key={s}>{s}</div>
-                          ))}
-                        </div>
+                        {alertStrings.map((s) => (
+                          <div key={s}>{s}</div>
+                        ))}
                         <button
                           type="button"
                           className="btn-close"


### PR DESCRIPTION
## 概要

参照されていない CSS クラスを 2 つ削除します。どちらも CSS に定義が無く、見た目・挙動は変わりません。

- `NicommonsTab.tsx` のコピーボタンから `btn-copy` を外す
- `PackagesTab.tsx` のアラート内 `<div className="alert-text">` を div ごと外す

## 経緯

`.btn-copy` は preload が初期化していた ClipboardJS のセレクタでした。コピー処理が tRPC の `writeClipboardText` に置き換わった時点(同ファイルの JSDoc に経緯あり)で役目を終えていますが、クラスだけが残っていました。

`.alert-text` は定義も参照も無く、スタイルも意味も持たない素の block wrapper になっていました。

## 確認したこと

- `src/` `e2e/` 全体の grep で、2 箇所の使用箇所以外に参照が無いこと
- 実際に読み込まれる CSS の全体集合(`bootstrap.min.css` / `bootstrap-icons.css` / `src/renderer/main.css` / 窓ごとの `index.css`)のいずれにも定義が無いこと。Bootstrap 5.3 にも同名クラスは存在しません
- `alert-text` を div ごと外してもレイアウトが変わらないこと: alert 内の子孫を対象にする Bootstrap のセレクタは `.alert-dismissible .btn-close` の 1 本のみで、これは wrapper の兄弟である閉じるボタンに当たります。`.alert` 自体も block(flex/grid ではない)で `.alert > *` のような子コンビネータも無いため、block の wrapper を外して中の div を直接子にしても縦積みの結果は同一です
- `yarn lint` / `yarn lint:ts` / `yarn test`(27 files / 268 tests)すべて緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)