### PR TITLE
refactor(renderer): main 窓の Bootstrap クラスを react-bootstrap のコンポーネントへ置き換える

### DIFF
--- a/src/renderer/main/aviutl/AviutlTab.tsx
+++ b/src/renderer/main/aviutl/AviutlTab.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useSyncExternalStore } from 'react';
+import { Card, Container, Form, ListGroup, Navbar } from 'react-bootstrap';
 import apmIcon from '../../../../icon/apm32.png';
 import {
   getInstallationPath,
@@ -22,10 +23,12 @@ function AviutlTab(): JSX.Element {
     getInstallationPath,
   );
   return (
-    <div className="container-lg py-2 m-w-800">
-      <nav className="navbar navbar-light">
-        <div className="container-fluid">
-          <span className="navbar-brand">
+    <Container fluid="lg" className="py-2 m-w-800">
+      {/* expand の既定値 true は navbar-expand を足して折り返しを止めるため、
+          横幅いっぱいに広がるこの行では明示的に無効にする */}
+      <Navbar expand={false}>
+        <Container fluid>
+          <Navbar.Brand>
             <img
               src={apmIcon}
               alt=""
@@ -34,20 +37,20 @@ function AviutlTab(): JSX.Element {
               height="20"
             />
             <span className="ms-1 align-middle">AviUtl Package Manager</span>
-          </span>
-        </div>
-      </nav>
+          </Navbar.Brand>
+        </Container>
+      </Navbar>
       <TutorialAlert />
-      <div className="row my-2 card">
-        <div className="card-body">
+      <Card className="row my-2">
+        <Card.Body>
           <div className="mb-3 d-flex">
             <div
               className="flex-grow-1 border rounded-start d-flex align-items-center ps-3"
               id="addon-wrapping"
             >
               <i className="bi bi-folder2 me-3"></i>
-              <input
-                className="form-control-plaintext"
+              <Form.Control
+                plaintext
                 id="installation-path"
                 type="text"
                 placeholder="AviUtlフォルダ"
@@ -60,31 +63,31 @@ function AviutlTab(): JSX.Element {
               <SelectInstallationPathButton />
             </div>
           </div>
-          <ul className="list-group mb-3" id="batch-install-packages">
-            <li className="list-group-item py-0 pe-0 d-flex">
+          <ListGroup as="ul" className="mb-3" id="batch-install-packages">
+            <ListGroup.Item as="li" className="py-0 pe-0 d-flex">
               <ProgramRow
                 program="aviutl"
                 label="AviUtl"
                 iconClass="bi-film"
                 buttonRoundedClass="rounded-start-0 rounded-bottom-0"
               />
-            </li>
-            <li className="list-group-item py-0 pe-0 d-flex">
+            </ListGroup.Item>
+            <ListGroup.Item as="li" className="py-0 pe-0 d-flex">
               <ProgramRow
                 program="exedit"
                 label="拡張編集"
                 iconClass="bi-calendar3-range"
                 buttonRoundedClass="rounded-0"
               />
-            </li>
+            </ListGroup.Item>
             <BatchInstallList />
-          </ul>
+          </ListGroup>
           <div className="d-flex justify-content-end">
             <BatchInstallButton />
           </div>
-        </div>
-      </div>
-    </div>
+        </Card.Body>
+      </Card>
+    </Container>
   );
 }
 

--- a/src/renderer/main/aviutl/BatchInstallButton.tsx
+++ b/src/renderer/main/aviutl/BatchInstallButton.tsx
@@ -1,5 +1,6 @@
 import type { Core } from 'apm-schema';
 import React, { type JSX, useEffect, useRef, useState } from 'react';
+import { Button, Spinner } from 'react-bootstrap';
 import { states } from '../../../shared/packageDisplay';
 import { programs } from '../../../shared/programs';
 import type { PackageState } from '../../../types/packageState';
@@ -107,20 +108,21 @@ function BatchInstallButton(): JSX.Element {
   };
 
   return (
-    <button
-      type="button"
-      className={`btn btn-${phase.kind === 'message' ? phase.color : 'primary'}`}
+    <Button
+      variant={phase.kind === 'message' ? phase.color : 'primary'}
       id="batch-install"
       disabled={phase.kind === 'loading'}
       onClick={() => void onClick()}
     >
       {phase.kind === 'loading' ? (
         <>
-          <span
-            className="spinner-border spinner-border-sm"
+          <Spinner
+            as="span"
+            animation="border"
+            size="sm"
             role="status"
             aria-hidden="true"
-          ></span>
+          />
           <span className="visually-hidden">Loading...</span>
         </>
       ) : phase.kind === 'message' ? (
@@ -128,7 +130,7 @@ function BatchInstallButton(): JSX.Element {
       ) : (
         IDLE_LABEL
       )}
-    </button>
+    </Button>
   );
 }
 

--- a/src/renderer/main/aviutl/BatchInstallList.tsx
+++ b/src/renderer/main/aviutl/BatchInstallList.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useEffect, useState } from 'react';
+import { ListGroup } from 'react-bootstrap';
 import type { PackageState } from '../../../types/packageState';
 import { TRPCReact } from '../../trpc';
 import { getInstallationPath } from '../installationPath';
@@ -42,9 +43,10 @@ function BatchInstallList(): JSX.Element {
   return (
     <>
       {batchInstallPackages.map((p) => (
-        <li
+        <ListGroup.Item
+          as="li"
           key={p.id}
-          className="list-group-item py-0 d-flex py-2 batch-install-package"
+          className="py-0 d-flex py-2 batch-install-package"
         >
           <div className="d-flex align-items-center flex-grow-1">
             <i className="bi bi-box-seam me-3"></i>
@@ -53,7 +55,7 @@ function BatchInstallList(): JSX.Element {
           <div>
             <span className="installed-version">{p.installationStatus}</span>
           </div>
-        </li>
+        </ListGroup.Item>
       ))}
     </>
   );

--- a/src/renderer/main/aviutl/ProgramRow.tsx
+++ b/src/renderer/main/aviutl/ProgramRow.tsx
@@ -1,6 +1,6 @@
 import type { Core } from 'apm-schema';
 import React, { type JSX, useEffect, useRef, useState } from 'react';
-import { Dropdown } from 'react-bootstrap';
+import { Dropdown, Spinner } from 'react-bootstrap';
 import { releaseLabel } from '../../../shared/coreVersionText';
 import { TRPCReact } from '../../trpc';
 import { getInstallationPath } from '../installationPath';
@@ -143,11 +143,13 @@ function ProgramRow({
           >
             {phase === 'loading' ? (
               <>
-                <span
-                  className="spinner-border spinner-border-sm"
+                <Spinner
+                  as="span"
+                  animation="border"
+                  size="sm"
                   role="status"
                   aria-hidden="true"
-                ></span>
+                />
                 <span className="visually-hidden">Loading...</span>
               </>
             ) : phase === 'idle' ? (

--- a/src/renderer/main/aviutl/SelectInstallationPathButton.tsx
+++ b/src/renderer/main/aviutl/SelectInstallationPathButton.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX } from 'react';
+import { Button } from 'react-bootstrap';
 import { TRPCReact } from '../../trpc';
 import { getInstallationPath, setInstallationPath } from '../installationPath';
 
@@ -51,14 +52,14 @@ function SelectInstallationPathButton(): JSX.Element {
   };
 
   return (
-    <button
-      type="button"
-      className="btn btn-primary rounded-0 rounded-end"
+    <Button
+      variant="primary"
+      className="rounded-0 rounded-end"
       id="select-installation-path"
       onClick={() => void selectInstallationPath()}
     >
       AviUtlインストールフォルダを選択
-    </button>
+    </Button>
   );
 }
 

--- a/src/renderer/main/aviutl/TutorialAlert.tsx
+++ b/src/renderer/main/aviutl/TutorialAlert.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useState, useSyncExternalStore } from 'react';
+import { Alert, Row } from 'react-bootstrap';
 import { getFirstLaunch, subscribeFirstLaunch } from '../startup';
 
 /**
@@ -18,27 +19,22 @@ function TutorialAlert(): JSX.Element | null {
 
   if (!firstLaunch || dismissed) return null;
   return (
-    <div id="tutorial-alert" className="row my-2">
-      <div
-        className="my-0 alert alert-info alert-dismissible fade show"
-        role="alert"
+    <Row id="tutorial-alert" className="my-2">
+      <Alert
+        variant="info"
+        dismissible
+        // 既定は 'Close alert'。旧マークアップの aria-label を保つ
+        closeLabel="Close"
+        onClose={() => setDismissed(true)}
+        className="my-0"
       >
         apmへようこそ！
-        <a
-          href="https://team-apm.github.io/apm/#apm%E3%81%AE%E3%83%81%E3%83%A5%E3%83%BC%E3%83%88%E3%83%AA%E3%82%A2%E3%83%AB"
-          className="alert-link"
-        >
+        <Alert.Link href="https://team-apm.github.io/apm/#apm%E3%81%AE%E3%83%81%E3%83%A5%E3%83%BC%E3%83%88%E3%83%AA%E3%82%A2%E3%83%AB">
           チュートリアル
-        </a>
+        </Alert.Link>
         から使い方を確認できます。
-        <button
-          type="button"
-          className="btn-close"
-          aria-label="Close"
-          onClick={() => setDismissed(true)}
-        ></button>
-      </div>
-    </div>
+      </Alert>
+    </Row>
   );
 }
 

--- a/src/renderer/main/monacoEditorRenderer.tsx
+++ b/src/renderer/main/monacoEditorRenderer.tsx
@@ -12,6 +12,7 @@ import schema from 'apm-schema/v3/schema/packages.json';
 // Enum values must be taken from the `monaco` instance passed to onMount.
 import type { editor } from 'monaco-editor';
 import React, { useRef } from 'react';
+import { Button, Col, Spinner } from 'react-bootstrap';
 import { TRPCReact } from '../trpc';
 import { getInstallationPath } from './installationPath';
 import { usePhase } from './usePhase';
@@ -282,7 +283,7 @@ export const MonacoEditorRenderer: React.FC = () => {
 
   return (
     <>
-      <div className="col-sm-9">
+      <Col sm={9}>
         <div id="container" className="border rounded">
           <MonacoEditor
             height="50vh"
@@ -292,22 +293,24 @@ export const MonacoEditorRenderer: React.FC = () => {
             onMount={editorDidMount}
           />
         </div>
-      </div>
-      <div className="col-sm-3">
-        <button
-          type="button"
-          className={`btn btn-${saveColor} w-100`}
+      </Col>
+      <Col sm={3}>
+        <Button
+          variant={saveColor}
+          className="w-100"
           id="save-editor-data"
           disabled={save.phase.kind === 'loading'}
           onClick={() => void saveEditorData()}
         >
           {save.phase.kind === 'loading' ? (
             <>
-              <span
-                className="spinner-border spinner-border-sm"
+              <Spinner
+                as="span"
+                animation="border"
+                size="sm"
                 role="status"
                 aria-hidden="true"
-              ></span>
+              />
               <span className="visually-hidden">Loading...</span>
             </>
           ) : save.phase.kind === 'message' ? (
@@ -315,8 +318,8 @@ export const MonacoEditorRenderer: React.FC = () => {
           ) : (
             '保存 (Ctrl + S)'
           )}
-        </button>
-      </div>
+        </Button>
+      </Col>
     </>
   );
 };

--- a/src/renderer/main/nicommons/NicommonsTab.tsx
+++ b/src/renderer/main/nicommons/NicommonsTab.tsx
@@ -1,4 +1,14 @@
 import React, { type JSX, useEffect, useMemo, useState } from 'react';
+import {
+  Badge,
+  Button,
+  Card,
+  Col,
+  Container,
+  Form,
+  ListGroup,
+  Row,
+} from 'react-bootstrap';
 import { parsePackageType } from '../../../shared/packageDisplay';
 import type { PackageState } from '../../../types/packageState';
 import { TRPCReact } from '../../trpc';
@@ -40,25 +50,25 @@ function NicommonsRow({
       : null;
 
   return (
-    <li className="list-group-item list-group-item-action">
+    <ListGroup.Item as="li" action>
       <label className="d-block">
-        <div className="row">
-          <div className="col-auto d-flex align-items-center">
-            <input
-              className="form-check-input m-0"
+        <Row>
+          <Col xs="auto" className="d-flex align-items-center">
+            <Form.Check.Input
+              className="m-0"
               type="checkbox"
               name="nicommons-id"
               value={item.nicommons}
               checked={checked}
               onChange={(e) => onChange(e.target.checked)}
             />
-          </div>
-          <div className="col-sm-1 d-flex align-items-center thumbnail">
+          </Col>
+          <Col sm={1} className="d-flex align-items-center thumbnail">
             {thumbnailURL && (
               <img src={thumbnailURL} className="img-fluid" alt="" />
             )}
-          </div>
-          <div className="col">
+          </Col>
+          <Col>
             <h5 className="d-inline-block name">{item.name}</h5>
             <div className="text-primary d-inline-block ms-2 developer">
               {item.originalDeveloper
@@ -67,22 +77,25 @@ function NicommonsRow({
             </div>
             <div className="d-inline-block ms-1 type">
               {item.typeBadges.map((e, i) => (
-                <span
+                /* bg の既定値 primary は bg-primary(!important)を足して
+                   main.css の .badge の配色を上書きするため空文字で外す */
+                <Badge
                   key={i}
-                  className="badge list-group-item-light d-block fw-normal"
+                  bg=""
+                  className="list-group-item-light d-block fw-normal"
                 >
                   {e}
-                </span>
+                </Badge>
               ))}
             </div>
             <br />
             <div className="d-inline-block text-break nicommons text-muted">
               {item.nicommons}
             </div>
-          </div>
-        </div>
+          </Col>
+        </Row>
       </label>
-    </li>
+    </ListGroup.Item>
   );
 }
 
@@ -189,39 +202,35 @@ function NicommonsTab(): JSX.Element {
   );
 
   return (
-    <div className="container-lg">
-      <div className="row card border-top-0 border-bottom-0 rounded-0">
-        <div className="card-body d-flex flex-column py-2">
-          <div className="row pb-2 border-bottom">
-            <div className="col-auto">
-              <button
-                type="button"
-                className="btn btn-primary"
+    <Container fluid="lg">
+      <Card className="row border-top-0 border-bottom-0 rounded-0">
+        <Card.Body className="d-flex flex-column py-2">
+          <Row className="pb-2 border-bottom">
+            <Col xs="auto">
+              <Button
+                variant="primary"
                 id="copy-nicommons-id-textarea"
                 onClick={() =>
                   writeClipboardMutation.mutate({ text: idListText })
                 }
               >
                 コピー
-              </button>
-            </div>
-            <div className="col">
-              <textarea
+              </Button>
+            </Col>
+            <Col>
+              <Form.Control
+                as="textarea"
                 rows={1}
                 name="nicommons-id-textarea"
                 id="nicommons-id-textarea"
-                className="form-control"
                 readOnly
                 value={idListText}
-              ></textarea>
-            </div>
-          </div>
-          <div className="row flex-grow-1 overflow-auto">
-            <div className="col">
-              <ul
-                className="list-group list-group-flush"
-                id="nicommons-id-list"
-              >
+              />
+            </Col>
+          </Row>
+          <Row className="flex-grow-1 overflow-auto">
+            <Col>
+              <ListGroup as="ul" variant="flush" id="nicommons-id-list">
                 {items.map((item) => (
                   <NicommonsRow
                     key={item.nicommons}
@@ -237,12 +246,12 @@ function NicommonsTab(): JSX.Element {
                     }
                   />
                 ))}
-              </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+              </ListGroup>
+            </Col>
+          </Row>
+        </Card.Body>
+      </Card>
+    </Container>
   );
 }
 

--- a/src/renderer/main/others/OthersTab.tsx
+++ b/src/renderer/main/others/OthersTab.tsx
@@ -1,4 +1,12 @@
 import React, { type JSX } from 'react';
+import {
+  Button,
+  ButtonGroup,
+  Card,
+  Col,
+  Container,
+  Row,
+} from 'react-bootstrap';
 import { TRPCReact } from '../../trpc';
 
 /**
@@ -12,98 +20,95 @@ function OthersTab() {
   const quitApp = TRPCReact.quitApp.useMutation();
 
   return (
-    <div className="container-lg py-2">
-      <div className="row my-2">
-        <div className="card">
-          <div className="card-body">
-            <h3 className="card-title">その他</h3>
-            <div className="row mb-3">
-              <p className="col-sm-6 col-form-label">
+    <Container fluid="lg" className="py-2">
+      <Row className="my-2">
+        <Card>
+          <Card.Body>
+            <Card.Title as="h3">その他</Card.Title>
+            <Row className="mb-3">
+              <Col as="p" sm={6} className="col-form-label">
                 <span className="app-name">{appName}</span>について
-              </p>
-              <div className="col-sm-6 btn-group-vertical">
-                <button
-                  type="button"
-                  className="btn btn-primary"
+              </Col>
+              <ButtonGroup vertical className="col-sm-6">
+                <Button
+                  variant="primary"
                   id="open-about-window"
                   onClick={() => openAboutWindow.mutate()}
                 >
                   このアプリについて
-                </button>
+                </Button>
 
-                <div className="btn-group" role="group">
-                  <a
+                <ButtonGroup>
+                  <Button
+                    variant="primary"
                     href="https://github.com/team-apm/apm"
-                    role="button"
-                    className="btn btn-primary"
                   >
                     <i className="bi bi-github"></i> GitHub
-                  </a>
-                  <a
+                  </Button>
+                  <Button
+                    variant="primary"
                     href="https://discord.gg/YEQRqnGsG2"
-                    role="button"
-                    className="btn btn-primary"
                   >
                     <i className="bi bi-discord"></i> Discord
-                  </a>
-                </div>
-              </div>
-            </div>
-            <div className="row mb-3">
-              <p className="col-sm-6 col-form-label">
+                  </Button>
+                </ButtonGroup>
+              </ButtonGroup>
+            </Row>
+            <Row className="mb-3">
+              <Col as="p" sm={6} className="col-form-label">
                 プラグイン&スクリプトデータの作成
-              </p>
-              <div className="col-sm-6">
-                <a
+              </Col>
+              <Col sm={6}>
+                <Button
+                  variant="primary"
+                  className="w-100"
                   href="https://team-apm.github.io/apm-web/"
-                  role="button"
-                  className="btn btn-primary w-100"
                 >
                   開く <i className="bi bi-box-arrow-up-right"></i>
-                </a>
-              </div>
-            </div>
-            <div className="row mb-3">
-              <p className="col-sm-6 col-form-label">
+                </Button>
+              </Col>
+            </Row>
+            <Row className="mb-3">
+              <Col as="p" sm={6} className="col-form-label">
                 機能要求・バグ報告（外部ブラウザが開きます）
-              </p>
-              <div className="col-sm-3">
-                <a
+              </Col>
+              <Col sm={3}>
+                <Button
+                  variant="primary"
+                  className="w-100"
                   href="https://docs.google.com/forms/d/e/1FAIpQLSf0N-X_u_abi8rrWHVDdiK3YeYuQ7J1f8bQAy6QTD-OR94DWQ/viewform?usp=sf_link"
-                  role="button"
-                  className="btn btn-primary w-100"
                 >
                   Googleフォーム <i className="bi bi-box-arrow-up-right"></i>
-                </a>
-              </div>
-              <div className="col-sm-3">
-                <a
+                </Button>
+              </Col>
+              <Col sm={3}>
+                <Button
+                  variant="primary"
+                  className="w-100"
                   href="https://github.com/team-apm/apm/issues"
-                  role="button"
-                  className="btn btn-primary w-100"
                 >
                   <i className="bi bi-github"></i> GitHub (要アカウント)
                   <i className="bi bi-box-arrow-up-right"></i>
-                </a>
-              </div>
-            </div>
-            <div className="row mb-3">
-              <p className="col-sm-6 col-form-label"></p>
-              <div className="col-sm-6">
-                <button
-                  type="button"
-                  className="btn btn-primary w-100"
+                </Button>
+              </Col>
+            </Row>
+            <Row className="mb-3">
+              <Col as="p" sm={6} className="col-form-label"></Col>
+              <Col sm={6}>
+                <Button
+                  variant="primary"
+                  className="w-100"
                   id="quit-app"
                   onClick={() => quitApp.mutate()}
                 >
                   終了
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+                </Button>
+              </Col>
+            </Row>
+          </Card.Body>
+        </Card>
+      </Row>
+    </Container>
   );
 }
 

--- a/src/renderer/main/packages/PackageActions.tsx
+++ b/src/renderer/main/packages/PackageActions.tsx
@@ -1,5 +1,6 @@
 import type { Scripts } from 'apm-schema';
 import React, { type JSX, useEffect } from 'react';
+import { Button, Spinner } from 'react-bootstrap';
 import { states } from '../../../shared/packageDisplay';
 import type { PackageState } from '../../../types/packageState';
 import { TRPCReact } from '../../trpc';
@@ -35,20 +36,22 @@ function ActionButton({
 }) {
   const color = phase.kind === 'message' ? phase.color : 'primary';
   return (
-    <button
-      type="button"
-      className={`btn btn-${color} ms-2`}
+    <Button
+      variant={color}
+      className="ms-2"
       id={id}
       disabled={phase.kind === 'loading'}
       onClick={onClick}
     >
       {phase.kind === 'loading' ? (
         <>
-          <span
-            className="spinner-border spinner-border-sm"
+          <Spinner
+            as="span"
+            animation="border"
+            size="sm"
             role="status"
             aria-hidden="true"
-          ></span>
+          />
           <span className="visually-hidden">Loading...</span>
         </>
       ) : phase.kind === 'message' ? (
@@ -56,7 +59,7 @@ function ActionButton({
       ) : (
         label
       )}
-    </button>
+    </Button>
   );
 }
 

--- a/src/renderer/main/packages/PackagesTab.tsx
+++ b/src/renderer/main/packages/PackagesTab.tsx
@@ -6,6 +6,17 @@ import React, {
   useState,
   useSyncExternalStore,
 } from 'react';
+import {
+  Alert,
+  Badge,
+  Card,
+  Col,
+  Container,
+  Form,
+  ListGroup,
+  Row,
+  Spinner,
+} from 'react-bootstrap';
 import { compareVersion } from '../../../shared/compareVersion';
 import { matchesFuzzyFilter } from '../../../shared/fuzzySearch';
 import { parsePackageType, states } from '../../../shared/packageDisplay';
@@ -346,20 +357,23 @@ function PackagesTab(): JSX.Element {
   );
 
   return (
-    <div className="container-lg">
-      <div className="row card border-top-0 border-bottom-0 rounded-0">
-        <div className="card-body py-2">
+    <Container fluid="lg">
+      <Card className="row border-top-0 border-bottom-0 rounded-0">
+        <Card.Body className="py-2">
           <div className="d-flex flex-column h-100">
             <div className="flex-shrink-1">
               <div className="d-flex mb-2">
                 <div className="border rounded flex-grow-1 w-auto d-flex">
                   {/* 検索欄は非制御にして DOM の入力値をそのまま残し、
                       state には trim した文字列だけを持つ(旧実装と同一) */}
-                  <input
-                    className="form-control border-0 flex-grow-1 w-auto"
+                  <Form.Control
+                    className="border-0 flex-grow-1 w-auto"
                     placeholder="🔍︎ 検索  |  共有貼り付け"
                     aria-label="検索 / 共有"
-                    size={2}
+                    // size は Bootstrap のサイズ指定に使われるため、
+                    // HTML の size 属性(既定 20 文字幅より縮められるように
+                    // する)は htmlSize で渡す
+                    htmlSize={2}
                     onChange={(e) => {
                       setSearchString(e.target.value.trim());
                       setAlertDismissed(false);
@@ -380,8 +394,16 @@ function PackagesTab(): JSX.Element {
               </div>
             </div>
             <div className="h-100 min-h-0">
-              <div className="row h-100">
-                <div className="col-sm-auto overflow-x-hidden overflow-y-auto h-100">
+              <Row className="h-100">
+                <Col
+                  sm="auto"
+                  className="overflow-x-hidden overflow-y-auto h-100"
+                >
+                  {/* dropdown-menu は開閉するメニューではなく、常時表示の
+                      サイドバーとして見た目だけを借りている。react-bootstrap
+                      の Dropdown は開閉の振る舞いを持つコンポーネントなので
+                      ここには合わず、クラスのまま使う(配下の dropdown-item /
+                      dropdown-divider も同じ理由) */}
                   <ul
                     id="filter"
                     className="list-unstyled dropdown-menu d-block position-static border-0"
@@ -552,41 +574,41 @@ function PackagesTab(): JSX.Element {
                       </a>
                     </li>
                   </ul>
-                </div>
-                <div className="col d-flex flex-column h-100">
+                </Col>
+                <Col className="d-flex flex-column h-100">
                   <div>
                     {alertStrings.length > 0 && !alertDismissed && (
-                      <div
-                        className="mt-2 mb-1 alert alert-info alert-dismissible fade show"
-                        role="alert"
+                      <Alert
+                        variant="info"
+                        dismissible
+                        // 既定は 'Close alert'。旧マークアップの aria-label を保つ
+                        closeLabel="Close"
+                        onClose={() => setAlertDismissed(true)}
+                        className="mt-2 mb-1"
                       >
                         {alertStrings.map((s) => (
                           <div key={s}>{s}</div>
                         ))}
-                        <button
-                          type="button"
-                          className="btn-close"
-                          aria-label="Close"
-                          onClick={() => setAlertDismissed(true)}
-                        />
-                      </div>
+                      </Alert>
                     )}
                   </div>
-                  <div className="row flex-grow-1 overflow-auto">
-                    <div className="col" id="packages-table">
-                      <ul
-                        className="list list-group list-group-flush"
+                  <Row className="flex-grow-1 overflow-auto">
+                    <Col id="packages-table">
+                      <ListGroup
+                        as="ul"
+                        variant="flush"
+                        className="list"
                         id="packages-list"
                       >
                         {visibleRows.map(({ row, values }) => (
-                          <li
-                            key={row.key}
-                            className={
-                              'list-group-item list-group-item-action text-muted' +
-                              (selectedKey === row.key
-                                ? ' list-group-item-light'
-                                : '')
+                          <ListGroup.Item
+                            as="li"
+                            action
+                            variant={
+                              selectedKey === row.key ? 'light' : undefined
                             }
+                            key={row.key}
+                            className="text-muted"
                             onClick={() => selectRow(row)}
                           >
                             <input
@@ -596,8 +618,8 @@ function PackagesTab(): JSX.Element {
                               readOnly
                             />
                             <label className="d-block">
-                              <div className="row">
-                                <div className="col-sm-9 clearfix">
+                              <Row>
+                                <Col sm={9} className="clearfix">
                                   <div className="d-none packageID">
                                     {values.packageID}
                                   </div>
@@ -607,17 +629,24 @@ function PackagesTab(): JSX.Element {
                                         ? (row.p.type ?? [])
                                         : [],
                                     ).map((e, i) => (
-                                      <span
+                                      // bg の既定値 primary は bg-primary
+                                      // (!important)を足して main.css の
+                                      // .badge の配色を上書きするため外す
+                                      <Badge
                                         key={i}
-                                        className="badge list-group-item-light d-block fw-normal"
+                                        bg=""
+                                        className="list-group-item-light d-block fw-normal"
                                       >
                                         {e}
-                                      </span>
+                                      </Badge>
                                     ))}
                                     {row.kind === 'scriptSite' && (
-                                      <span className="badge list-group-item-success d-block fw-normal">
+                                      <Badge
+                                        bg=""
+                                        className="list-group-item-success d-block fw-normal"
+                                      >
                                         スクリプト配布サイト
-                                      </span>
+                                      </Badge>
                                     )}
                                   </div>
                                   <h5 className="float-none d-inline mb-1 me-2 text-break text-body name">
@@ -645,8 +674,8 @@ function PackagesTab(): JSX.Element {
                                       </a>
                                     </div>
                                   </div>
-                                </div>
-                                <div className="col-sm-3">
+                                </Col>
+                                <Col sm={3}>
                                   <div className="text-break latestVersion">
                                     {values.latestVersion}
                                   </div>
@@ -695,38 +724,38 @@ function PackagesTab(): JSX.Element {
                                   <div className="text-break installationStatus">
                                     {values.installationStatus}
                                   </div>
-                                </div>
-                              </div>
+                                </Col>
+                              </Row>
                             </label>
-                          </li>
+                          </ListGroup.Item>
                         ))}
-                      </ul>
-                      <ul
-                        className="list-group list-group-flush"
-                        id="packages-list2"
-                      >
+                      </ListGroup>
+                      <ListGroup as="ul" variant="flush" id="packages-list2">
                         {manuallyInstalledFiles.map((file) => (
-                          <li
+                          <ListGroup.Item
+                            as="li"
+                            action
+                            variant="secondary"
                             key={file}
-                            className="list-group-item list-group-item-action text-muted list-group-item-secondary"
+                            className="text-muted"
                           >
                             <label className="d-block">
-                              <div className="row">
-                                <div className="col-sm-9 clearfix">
+                              <Row>
+                                <Col sm={9} className="clearfix">
                                   <h5 className="float-none d-inline mb-1 me-2 text-break text-body name">
                                     {file}
                                   </h5>
                                   <div className="text-break overview">
                                     手動で追加されたファイル
                                   </div>
-                                </div>
-                                <div className="col-sm-3"></div>
-                              </div>
+                                </Col>
+                                <Col sm={3}></Col>
+                              </Row>
                             </label>
-                          </li>
+                          </ListGroup.Item>
                         ))}
-                      </ul>
-                    </div>
+                      </ListGroup>
+                    </Col>
                     <div
                       className={
                         'd-flex justify-content-center align-items-center fade' +
@@ -737,18 +766,18 @@ function PackagesTab(): JSX.Element {
                         zIndex: checkPhase.kind === 'loading' ? 1000 : -1,
                       }}
                     >
-                      <div className="spinner-border" role="status">
+                      <Spinner animation="border" role="status">
                         <span className="visually-hidden">Loading...</span>
-                      </div>
+                      </Spinner>
                     </div>
-                  </div>
-                </div>
-              </div>
+                  </Row>
+                </Col>
+              </Row>
             </div>
           </div>
-        </div>
-      </div>
-    </div>
+        </Card.Body>
+      </Card>
+    </Container>
   );
 }
 

--- a/src/renderer/main/settings/CacheSettings.tsx
+++ b/src/renderer/main/settings/CacheSettings.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX } from 'react';
+import { Button, Col, Form, Row, Spinner } from 'react-bootstrap';
 import { formatBytes } from '../../../shared/formatBytes';
 import { TRPCReact } from '../../trpc';
 import { usePhase } from '../usePhase';
@@ -31,32 +32,34 @@ function CacheSettings(): JSX.Element {
   const color = clear.phase.kind === 'message' ? clear.phase.color : 'primary';
 
   return (
-    <div className="row mb-3">
-      <label htmlFor="clear-cache" className="col-sm-3 col-form-label">
+    <Row className="mb-3">
+      <Form.Label htmlFor="clear-cache" column sm={3}>
         ダウンロードキャッシュ
-      </label>
-      <div className="col-sm-6 d-flex align-items-center">
+      </Form.Label>
+      <Col sm={6} className="d-flex align-items-center">
         <span className="text-body-secondary">
           {cacheSize.data === undefined
             ? '計算中…'
             : `${formatBytes(cacheSize.data)} 使用中`}
         </span>
-      </div>
-      <div className="col-sm-3">
-        <button
-          type="button"
-          className={`btn btn-outline-${color} w-100`}
+      </Col>
+      <Col sm={3}>
+        <Button
+          variant={`outline-${color}`}
+          className="w-100"
           id="clear-cache"
           disabled={clear.phase.kind === 'loading' || !cacheSize.data}
           onClick={() => void onClick()}
         >
           {clear.phase.kind === 'loading' ? (
             <>
-              <span
-                className="spinner-border spinner-border-sm"
+              <Spinner
+                as="span"
+                animation="border"
+                size="sm"
                 role="status"
                 aria-hidden="true"
-              ></span>
+              />
               <span className="visually-hidden">Loading...</span>
             </>
           ) : clear.phase.kind === 'message' ? (
@@ -64,9 +67,9 @@ function CacheSettings(): JSX.Element {
           ) : (
             '削除'
           )}
-        </button>
-      </div>
-    </div>
+        </Button>
+      </Col>
+    </Row>
   );
 }
 

--- a/src/renderer/main/settings/DataUrlSettings.tsx
+++ b/src/renderer/main/settings/DataUrlSettings.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useEffect, useRef, useState } from 'react';
+import { Button, Col, Form, Row, Spinner } from 'react-bootstrap';
 import { TRPCReact } from '../../trpc';
 
 type ButtonPhase = 'idle' | 'loading' | 'success' | 'danger';
@@ -61,22 +62,17 @@ function DataUrlSettings() {
     timer.current = setTimeout(() => setPhase('idle'), 3000);
   };
 
-  const buttonClass =
-    phase === 'success'
-      ? 'btn btn-success w-100'
-      : phase === 'danger'
-        ? 'btn btn-danger w-100'
-        : 'btn btn-primary w-100';
+  const variant =
+    phase === 'success' ? 'success' : phase === 'danger' ? 'danger' : 'primary';
 
   return (
     <>
-      <div className="row mb-3">
-        <label htmlFor="data-url" className="col-sm-3 col-form-label">
+      <Row className="mb-3">
+        <Form.Label htmlFor="data-url" column sm={3}>
           データ取得先
-        </label>
-        <div className="col-sm-6">
-          <input
-            className="form-control"
+        </Form.Label>
+        <Col sm={6}>
+          <Form.Control
             id="data-url"
             type="text"
             placeholder="空白でデフォルト"
@@ -84,22 +80,24 @@ function DataUrlSettings() {
             value={mainValue}
             onChange={(e) => setMainUrl(e.target.value)}
           />
-        </div>
-        <div className="col-sm-3">
-          <button
-            type="button"
-            className={buttonClass}
+        </Col>
+        <Col sm={3}>
+          <Button
+            variant={variant}
+            className="w-100"
             id="set-data-url"
             disabled={phase === 'loading'}
             onClick={onSet}
           >
             {phase === 'loading' ? (
               <>
-                <span
-                  className="spinner-border spinner-border-sm"
+                <Spinner
+                  as="span"
+                  animation="border"
+                  size="sm"
                   role="status"
                   aria-hidden="true"
-                ></span>
+                />
                 <span className="visually-hidden">Loading...</span>
               </>
             ) : phase === 'success' ? (
@@ -109,25 +107,25 @@ function DataUrlSettings() {
             ) : (
               '設定'
             )}
-          </button>
-        </div>
-      </div>
-      <div className="row mb-3">
-        <label htmlFor="extra-data-url" className="col-sm-3 col-form-label">
+          </Button>
+        </Col>
+      </Row>
+      <Row className="mb-3">
+        <Form.Label htmlFor="extra-data-url" column sm={3}>
           追加データ取得先
-        </label>
-        <div className="col-sm-6">
-          <textarea
-            className="form-control"
+        </Form.Label>
+        <Col sm={6}>
+          <Form.Control
+            as="textarea"
             id="extra-data-url"
             placeholder="例: https://example.com/packages.json"
             aria-label="Extra Data URL"
             value={extraValue}
             onChange={(e) => setExtraUrls(e.target.value)}
-          ></textarea>
-        </div>
-        <div className="col-sm-3"></div>
-      </div>
+          />
+        </Col>
+        <Col sm={3}></Col>
+      </Row>
     </>
   );
 }

--- a/src/renderer/main/settings/ManualUpdateTable.tsx
+++ b/src/renderer/main/settings/ManualUpdateTable.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useEffect, useSyncExternalStore } from 'react';
+import { Button, Spinner } from 'react-bootstrap';
 import { TRPCReact } from '../../trpc';
 import { getInstallationPath } from '../installationPath';
 import {
@@ -27,20 +28,22 @@ function UpdateButton({
 }) {
   const color = phase.kind === 'message' ? phase.color : 'primary';
   return (
-    <button
-      type="button"
-      className={`btn btn-${color} w-100`}
+    <Button
+      variant={color}
+      className="w-100"
       id={id}
       disabled={phase.kind === 'loading'}
       onClick={onClick}
     >
       {phase.kind === 'loading' ? (
         <>
-          <span
-            className="spinner-border spinner-border-sm"
+          <Spinner
+            as="span"
+            animation="border"
+            size="sm"
             role="status"
             aria-hidden="true"
-          ></span>
+          />
           <span className="visually-hidden">Loading...</span>
         </>
       ) : phase.kind === 'message' ? (
@@ -48,7 +51,7 @@ function UpdateButton({
       ) : (
         '更新'
       )}
-    </button>
+    </Button>
   );
 }
 
@@ -197,14 +200,14 @@ function ManualUpdateTable(): JSX.Element {
         <td>
           <div className="bg-body">
             {/* 旧実装どおりボタンの状態遷移はなし(結果は main 側のダイアログ) */}
-            <button
-              type="button"
-              className="btn btn-primary w-100"
+            <Button
+              variant="primary"
+              className="w-100"
               id="check-apm-update"
               onClick={() => checkUpdateMutation.mutate()}
             >
               更新
-            </button>
+            </Button>
           </div>
         </td>
       </tr>

--- a/src/renderer/main/settings/PreferencesSettings.tsx
+++ b/src/renderer/main/settings/PreferencesSettings.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX, useState } from 'react';
+import { Col, Form, Row } from 'react-bootstrap';
 import { TRPCReact } from '../../trpc';
 
 const ZOOM_OPTIONS = [
@@ -42,13 +43,12 @@ function PreferencesSettings() {
 
   return (
     <>
-      <div className="row mb-3">
-        <label htmlFor="zoom-factor-select" className="col-sm-3 col-form-label">
+      <Row className="mb-3">
+        <Form.Label htmlFor="zoom-factor-select" column sm={3}>
           拡大率
-        </label>
-        <div className="col-sm-6">
-          <select
-            className="form-select"
+        </Form.Label>
+        <Col sm={6}>
+          <Form.Select
             id="zoom-factor-select"
             aria-label="Zoom level select"
             value={zoomValue}
@@ -62,43 +62,36 @@ function PreferencesSettings() {
                 {label}
               </option>
             ))}
-          </select>
-        </div>
-        <div className="col-sm-3"></div>
-      </div>
-      <div className="row mb-3">
-        <label htmlFor="zoom-factor-select" className="col-sm-3 col-form-label">
+          </Form.Select>
+        </Col>
+        <Col sm={3}></Col>
+      </Row>
+      <Row className="mb-3">
+        <Form.Label htmlFor="zoom-factor-select" column sm={3}>
           apmの自動更新
-        </label>
-        <div className="col-sm-6">
-          <div className="col">
+        </Form.Label>
+        <Col sm={6}>
+          <Col>
             {AUTO_UPDATE_OPTIONS.map(([value, label]) => (
-              <div className="form-check" key={value}>
-                <input
-                  className="form-check-input"
-                  type="radio"
-                  name="auto-update"
-                  id={`auto-update-${value}`}
-                  value={value}
-                  checked={autoUpdateValue === value}
-                  disabled={value === 'download' && exeVersion === false}
-                  onChange={() => {
-                    setAutoUpdateValue(value);
-                    setAutoUpdate.mutate(value);
-                  }}
-                />
-                <label
-                  className="form-check-label"
-                  htmlFor={`auto-update-${value}`}
-                >
-                  {label}
-                </label>
-              </div>
+              <Form.Check
+                key={value}
+                type="radio"
+                name="auto-update"
+                id={`auto-update-${value}`}
+                value={value}
+                label={label}
+                checked={autoUpdateValue === value}
+                disabled={value === 'download' && exeVersion === false}
+                onChange={() => {
+                  setAutoUpdateValue(value);
+                  setAutoUpdate.mutate(value);
+                }}
+              />
             ))}
-          </div>
-        </div>
-        <div className="col-sm-3"></div>
-      </div>
+          </Col>
+        </Col>
+        <Col sm={3}></Col>
+      </Row>
     </>
   );
 }

--- a/src/renderer/main/settings/SettingsTab.tsx
+++ b/src/renderer/main/settings/SettingsTab.tsx
@@ -1,5 +1,5 @@
 import React, { type JSX } from 'react';
-import { Card, Container, Form, Row, Table } from 'react-bootstrap';
+import { Card, Col, Container, Form, Row, Table } from 'react-bootstrap';
 import { MonacoEditorRenderer } from '../monacoEditorRenderer';
 import CacheSettings from './CacheSettings';
 import DataUrlSettings from './DataUrlSettings';
@@ -32,14 +32,14 @@ function SettingsTab(): JSX.Element {
               <Table borderless striped>
                 <thead>
                   <tr>
-                    <th scope="col" className="col-sm-3"></th>
-                    <th scope="col" className="col-sm-3">
+                    <Col as="th" scope="col" sm={3}></Col>
+                    <Col as="th" scope="col" sm={3}>
                       リスト更新日時
-                    </th>
-                    <th scope="col" className="col-sm-3">
+                    </Col>
+                    <Col as="th" scope="col" sm={3}>
                       最終更新日時
-                    </th>
-                    <th scope="col" className="col-sm-3"></th>
+                    </Col>
+                    <Col as="th" scope="col" sm={3}></Col>
                   </tr>
                 </thead>
                 <tbody className="align-middle" id="manual-update-tbody">

--- a/src/renderer/main/settings/SettingsTab.tsx
+++ b/src/renderer/main/settings/SettingsTab.tsx
@@ -1,4 +1,5 @@
 import React, { type JSX } from 'react';
+import { Card, Container, Form, Row, Table } from 'react-bootstrap';
 import { MonacoEditorRenderer } from '../monacoEditorRenderer';
 import CacheSettings from './CacheSettings';
 import DataUrlSettings from './DataUrlSettings';
@@ -13,24 +14,22 @@ import PreferencesSettings from './PreferencesSettings';
  */
 function SettingsTab(): JSX.Element {
   return (
-    <div className="container-lg py-2">
-      <div className="row my-2">
-        <div className="card">
-          <div className="card-body">
-            <h3 className="card-title">設定</h3>
+    <Container fluid="lg" className="py-2">
+      <Row className="my-2">
+        <Card>
+          <Card.Body>
+            <Card.Title as="h3">設定</Card.Title>
             <DataUrlSettings />
-            <div className="row mb-3">
-              <label htmlFor="container" className="form-label">
-                追加テキストデータ
-              </label>
+            <Row className="mb-3">
+              <Form.Label htmlFor="container">追加テキストデータ</Form.Label>
               <MonacoEditorRenderer />
-            </div>
+            </Row>
             <PreferencesSettings />
             <CacheSettings />
             <hr />
-            <div className="row mb-3">
+            <Row className="mb-3">
               <h4>手動更新</h4>
-              <table className="table table-borderless table-striped">
+              <Table borderless striped>
                 <thead>
                   <tr>
                     <th scope="col" className="col-sm-3"></th>
@@ -46,12 +45,12 @@ function SettingsTab(): JSX.Element {
                 <tbody className="align-middle" id="manual-update-tbody">
                   <ManualUpdateTable />
                 </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+              </Table>
+            </Row>
+          </Card.Body>
+        </Card>
+      </Row>
+    </Container>
   );
 }
 


### PR DESCRIPTION
## Description

main 窓の JSX に手書きしていた Bootstrap のクラスを、react-bootstrap のコンポーネントへ置き換えました。renderer の 16 ファイル、タブ単位で 6 コミットに分けています。

置き換えた対応:

| 生クラス | コンポーネント |
| --- | --- |
| `container-lg` / `row` / `col-*` | `Container fluid="lg"` / `Row` / `Col` |
| `btn btn-*`（`a role="button"` を含む） | `Button`（`href` を渡すと `a` で描画される） |
| `card` / `list-group` / `alert` / `badge` / `table` / `navbar` / `btn-group` / `spinner-border` | `Card` / `ListGroup` / `Alert` / `Badge` / `Table` / `Navbar` / `ButtonGroup` / `Spinner` |
| `form-control` / `form-select` / `form-check` / `col-form-label` | `Form.Control` / `Form.Select` / `Form.Check` / `Form.Label column` |

**あえてクラスのまま残したもの**（理由はコード中のコメントに記載）:

- `d-flex` `mb-3` `text-break` などのユーティリティと、`app-name` `overview` などのアプリ固有クラス。対応するコンポーネントが存在しない
- パッケージタブの絞り込みサイドバー `#filter`。`dropdown-menu` を「常時表示のサイドバー」として見た目だけ借りており、開閉の振る舞いを持つ `Dropdown` には合わない（配下の `dropdown-item` / `dropdown-divider` も同じ理由）
- `<p class="col-sm-6 col-form-label">`。`Form.Label` は `label` を描画するため、`p` のままにしたいここには使えない

## Related Issue

なし

## Motivation and Context

JSX に生の Bootstrap クラスを書いていると、クラス名の綴りも、コンポーネント固有の構造（`form-check` の input と label の組など）も型で守れません。react-bootstrap はどちらもコンポーネントの API として与えるため、Bootstrap 5.3 のマークアップ規約を型検査に乗せられます。react-bootstrap は既に依存に入っていて、`App.tsx` の `Nav` / `Tab`、About 窓、`ProgramRow` の `Dropdown` で使われていたので、残りを揃えた形です。

移行中に react-bootstrap の既定値が旧マークアップと食い違う箇所が 3 つ見つかりました。いずれも現行の見た目を保つ側に倒し、理由をコメントに残しています。

- `Navbar` の `expand` は既定が `true` で `navbar-expand` が付き、`flex-wrap: nowrap` が効いてしまう → `expand={false}` を明示
- `Badge` の `bg` は既定が `primary`。`bg-primary` は `!important` なので `main.css` の `.badge` の配色指定を上書きしてバッジの色が変わる → `bg=""` でクラスを付けさせない
- `Form.Control` の `size` は Bootstrap のサイズ指定（`form-control-sm` / `lg`）で、HTML の `size` 属性を奪う。パッケージタブの検索欄の `size={2}` は入力欄が既定の 20 文字幅より縮められるようにするためのもの → `htmlSize={2}` へ移動

3 つめは `tsc` が型エラーとして検出したもので、生クラスのままでは気づけない類の衝突でした。この移行の効果が出ている例です。

なお `AGENTS.md` の方針どおり、挙動変更は混ぜていません。移行中に見つけた未使用クラス（`.btn-copy` / `.alert-text`）はこの PR では触らず、別途対応します。

## How Has This Been Tested?

環境: macOS (darwin arm64), Node 24, Electron パッケージ版

- `yarn lint` / `yarn lint:ts` / `yarn test`（268 tests）すべて緑
- `yarn package` → `yarn test:e2e` **5/5 パス**。`launch.spec` は renderer で uncaught exception が出ていないことも検査しており、`monaco.spec` は今回変換した設定タブを通ります
- 変換した各コンポーネントを `renderToStaticMarkup` で描画し、置き換え前のマークアップと 21 ケース照合。属性と class トークンの並び順以外の差分はゼロでした（この照合スクリプトはサードパーティの出力を固定するもので、react-bootstrap の更新のたびに壊れるため、コミットしていません）

`ListGroup` は内部で `@restart/ui` の `BaseNav` を描画するため、`Tab.Container` 配下では `role="tablist"` が付くのではないかと疑いましたが、実際に描画して確認したところ `Tab.Pane` が子に対して `TabContext` を `null` にリセットしているため、素の list-group として描画されます。

## Screenshots (if appropriate):

DOM 出力が変わらない置き換えのため、表示は変わりません。

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

リファクタリング（挙動の変更なし）のため、いずれにも該当しません。

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

テストは追加していません。構造だけを変える変更で、既存のユニットテストと e2e が現行動作の固定として機能するためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
