### PR TITLE
refactor(main): 呼ばれていない migration.byFolder ルートを削除する

### DIFF
--- a/src/main/api/migration.ts
+++ b/src/main/api/migration.ts
@@ -1,11 +1,8 @@
-import { migrationByFolder, migrationGlobal } from '../services/migration';
-import { stringInput, t, winInstProcedure, winProcedure } from './trpc';
+import { migrationGlobal } from '../services/migration';
+import { t, winProcedure } from './trpc';
 
 export const migrationRouter = t.router({
   global: winProcedure.mutation(async ({ ctx }) => {
     await migrationGlobal(ctx);
-  }),
-  byFolder: winInstProcedure.input(stringInput).mutation(async ({ ctx }) => {
-    await migrationByFolder(ctx, ctx.inst);
   }),
 });


### PR DESCRIPTION
## 問題

tRPC の `migration.byFolder` は **どこからも呼ばれていない**。

```
$ git grep -n "byFolder" -- . ':!yarn.lock'
src/shared/convertPackagesV2toV3.test.ts:5:  # 旧実装への言及(コメント)
src/shared/convertPackagesV2toV3.ts:12:     # 同上
```

定義自体が消えたので、残る 2 件はコメント中の歴史的記述だけ。renderer からも e2e からも参照が無い。

フォルダ単位の移行が実際に走るのは [`core.ts` の `changeInstallationPath`](../blob/main/src/main/services/core.ts) が `services/migration.migrationByFolder` を直接呼ぶ経路だけで、この tRPC ルートは旧 IPC 構成の名残。

## なぜ消すか

呼び出し口が 2 つあるように見えると、移行がいつ走るのかを読み違える。実際 [#2437](https://github.com/team-apm/apm/pull/2437) の調査中、私はこのルータを見て呼び出し元を誤認しかけた。

`ARCHITECTURE.md` に追加した移行の節でも「実際の入口は `changeInstallationPath` だけ」と書いているので、コードもその通りにしておきたい。

## 影響

- `services/migration.migrationByFolder` は残る（`core.ts` が呼ぶ本体）
- `winInstProcedure` / `stringInput` は他の 5 ルータが使っているので、この import が減るだけ

## 確認

- `npx tsc --noEmit` — 緑
- `npx eslint .` — 緑
- `npx prettier --check .` — 緑
- `npx vitest run` — 274 passed (27 files)