### PR TITLE
ci: stacked PR でも CI が回るようにする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,9 @@ name: Build
 on:
   push:
     branches: [main]
+  # base を main に限定しない: 中間ブランチ宛ての PR(stacked PR)にも CI を回すため。
+  # branches フィルタは head ではなく base を見るので、限定すると stacked PR が無検証になる。
   pull_request:
-    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,13 @@ on:
   # branches フィルタは head ではなく base を見るので、限定すると stacked PR が無検証になる。
   pull_request:
 
+# 同一 PR の古い実行は打ち切る。push イベントでは打ち切らない:
+# main の各コミットは Actions のステータスとして残す必要があり、
+# 短時間に複数マージが来たときに先行分を消してしまうため。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,9 @@ name: 'CodeQL'
 on:
   push:
     branches: [main]
+  # base を main に限定しない: 中間ブランチ宛ての PR(stacked PR)にも CI を回すため。
+  # branches フィルタは head ではなく base を見るので、限定すると stacked PR が無検証になる。
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [main]
   schedule:
     - cron: '43 19 * * 5'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,13 @@ on:
   schedule:
     - cron: '43 19 * * 5'
 
+# 同一 PR の古い実行は打ち切る。push イベントでは打ち切らない:
+# main の各コミットは Actions のステータスとして残す必要があり、
+# 短時間に複数マージが来たときに先行分を消してしまうため。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,9 @@ name: E2E
 on:
   push:
     branches: [main]
+  # base を main に限定しない: 中間ブランチ宛ての PR(stacked PR)にも CI を回すため。
+  # branches フィルタは head ではなく base を見るので、限定すると stacked PR が無検証になる。
   pull_request:
-    branches: [main]
 
 jobs:
   e2e:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,13 @@ on:
   # branches フィルタは head ではなく base を見るので、限定すると stacked PR が無検証になる。
   pull_request:
 
+# 同一 PR の古い実行は打ち切る。push イベントでは打ち切らない:
+# main の各コミットは Actions のステータスとして残す必要があり、
+# 短時間に複数マージが来たときに先行分を消してしまうため。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   e2e:
     name: E2E (Playwright)

--- a/.github/workflows/electronegativity.yml
+++ b/.github/workflows/electronegativity.yml
@@ -3,9 +3,9 @@ name: 'Electronegativity'
 on:
   push:
     branches: [main]
+  # base を main に限定しない: 中間ブランチ宛ての PR(stacked PR)にも CI を回すため。
+  # branches フィルタは head ではなく base を見るので、限定すると stacked PR が無検証になる。
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [main]
   schedule:
     - cron: '43 19 * * 5'
 

--- a/.github/workflows/electronegativity.yml
+++ b/.github/workflows/electronegativity.yml
@@ -9,6 +9,13 @@ on:
   schedule:
     - cron: '43 19 * * 5'
 
+# 同一 PR の古い実行は打ち切る。push イベントでは打ち切らない:
+# main の各コミットは Actions のステータスとして残す必要があり、
+# 短時間に複数マージが来たときに先行分を消してしまうため。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build_job:
     name: Analyze

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,6 +7,13 @@ on:
   # branches フィルタは head ではなく base を見るので、限定すると stacked PR が無検証になる。
   pull_request:
 
+# 同一 PR の古い実行は打ち切る。push イベントでは打ち切らない:
+# main の各コミットは Actions のステータスとして残す必要があり、
+# 短時間に複数マージが来たときに先行分を消してしまうため。
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,8 +3,9 @@ name: Node CI
 on:
   push:
     branches: [main]
+  # base を main に限定しない: 中間ブランチ宛ての PR(stacked PR)にも CI を回すため。
+  # branches フィルタは head ではなく base を見るので、限定すると stacked PR が無検証になる。
   pull_request:
-    branches: [main]
 
 jobs:
   lint:


### PR DESCRIPTION
## 背景

各ワークフローの `pull_request` に `branches: [main]` が付いている。このフィルタは head ではなく **base ブランチ**を見るため、base が中間ブランチの PR(stacked PR)には Build / Node CI / E2E / CodeQL / Electronegativity のどれもトリガされない。チェックが 1 つも走らないので、PR を 1 本ずつマージ待ちしてから次をリベースする直列運用しかできず、独立した変更が互いを待っていた。

## 変更

### 1. `pull_request` の `branches` フィルタを外す(`push` は `[main]` のまま)

team-apm/apm は public リポジトリで標準ランナーの実行時間に課金が無いため、外すコストは実質的に無い。

ruleset `main` の required status checks(`CodeQL` / `Electronegativity` / `Build (windows-latest)` / `E2E (Playwright)`)は `refs/heads/main` へのマージだけを対象にしているので、**ゲート条件は変わらない**。チェック名も増減しない。

stack の途中の PR が親のマージで main へリターゲットされたときは `pull_request` の `synchronize` が発火する(GitHub の仕様上 "when the base branch is changed" を含む)ので、main を base にした検証があらためて走る。base=中間ブランチで通った緑がそのまま main 向けの必須チェックを満たしてしまうことは無い。

### 2. `concurrency` グループを追加する

1 で実行数が増える分の相殺。同一 PR に連続 push したときに古い実行を打ち切る。

`push` イベントを対象外にしているのは、main の各コミットについてビルドが通ったことを残しておきたいため。短時間に複数マージが来ると先行コミットの実行が打ち切られてしまう。

## 対象外

- `release.yml`(タグ起動)— 打ち切られると困る
- `dependabot-auto-merge.yml`(レビュー起動)— PR/push トリガではない

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
