### PR TITLE
fix(shared): 末尾スラッシュの無い dataURL でデータを解決できるようにする

### DIFF
--- a/src/shared/resolvePath.test.ts
+++ b/src/shared/resolvePath.test.ts
@@ -25,6 +25,47 @@ describe('resolvePath', () => {
     });
   });
 
+  // 設定画面は「フォルダのURLを入力してください。」としか案内しないので、
+  // 末尾スラッシュ無しで保存された dataURL が現実に渡ってくる
+  describe('末尾スラッシュの無い http(s) の base', () => {
+    const base = 'https://example.com/data';
+
+    it('フォルダの中として解決する', () => {
+      expect(resolvePath(base, 'packages/list.json')).toBe(
+        'https://example.com/data/packages/list.json',
+      );
+    });
+
+    it('親ディレクトリへ出る相対パスは拒否する', () => {
+      expect(() => resolvePath(base, '../secret.json')).toThrow(
+        'list.json can only specify files in the same or child directories.',
+      );
+    });
+
+    it('別オリジンは拒否する', () => {
+      expect(() => resolvePath(base, 'https://evil.example/list.json')).toThrow(
+        'list.json can only specify files from the same origin.',
+      );
+    });
+
+    it('クエリ付きの base でもフォルダとして解決する', () => {
+      expect(resolvePath('https://example.com/data?v=1', 'core.json')).toBe(
+        'https://example.com/data/core.json',
+      );
+    });
+
+    it('既定の dataURL から末尾スラッシュを落としても解決できる', () => {
+      expect(
+        resolvePath(
+          'https://cdn.jsdelivr.net/gh/team-apm/apm-data@main/v3',
+          'packages/rigaya.json',
+        ),
+      ).toBe(
+        'https://cdn.jsdelivr.net/gh/team-apm/apm-data@main/v3/packages/rigaya.json',
+      );
+    });
+  });
+
   describe('with a local base', () => {
     // path.join だと Windows でドライブレターが付かず、実装側の path.resolve の結果と一致しない
     const base = path.resolve('/data', 'apm');

--- a/src/shared/resolvePath.ts
+++ b/src/shared/resolvePath.ts
@@ -9,8 +9,16 @@ import { isParent } from './apmPath';
  */
 export function resolvePath(base: string, relative: string) {
   if (base.startsWith('http')) {
-    const retURL = new URL(relative, base);
+    // base はデータ取得先の「フォルダ」を指す(設定画面も「フォルダのURLを
+    // 入力してください。」と案内する)。new URL() をそのまま使わないのは、
+    // 末尾に / が無いと最後のセグメントをファイル名とみなして 1 階層上に
+    // 解決してしまい、ローカルパス側の path.resolve(base, relative)
+    // — 末尾セパレータの有無に影響されない — と挙動が食い違うため。
+    // pathname だけを直すのは、base に付いたクエリ・フラグメントを
+    // 文字列連結で壊さないため。
     const baseURL = new URL(base);
+    if (!baseURL.pathname.endsWith('/')) baseURL.pathname += '/';
+    const retURL = new URL(relative, baseURL);
     if (retURL.origin !== baseURL.origin) {
       throw new Error('list.json can only specify files from the same origin.');
     }


### PR DESCRIPTION
## 症状

設定タブのデータ取得先に **末尾スラッシュ無し**の URL(例 `https://example.com/data`)を入れると、パッケージ一覧・core・convert・scripts が一切読めなくなる。

出るエラーは `list.json can only specify files in the same or child directories.` で、入力内容とは無関係な文面のため原因が分からない。

## 原因

`new URL(relative, base)` は base の末尾に `/` が無いと最終セグメントを**ファイル名**とみなし、1 階層上を基準に解決する。

```
https://example.com/data/  + core.json → https://example.com/data/core.json   ✅
https://example.com/data   + core.json → https://example.com/core.json        ❌
```

後者は `isParent('/data', '/core.json')` が false になり `resolvePath` が throw する。

**この入力は普通に通ってしまう。** `validateDataUrls`(`src/shared/dataUrl.ts`)がメイン URL について見ているのは「拡張子が `.json` でないこと」だけで、末尾スラッシュは要求していない。UI の案内も「フォルダのURLを入力してください。」だけ。

さらに紛らわしいことに、**`list.json` の取得だけは成功する**。`modList.ts` のダウンロードは `joinUrlOrPath`(末尾スラッシュを付け直す)を通るため。取得が成功した直後の解決だけが落ちる。

同じ関数のローカルパス側は `path.resolve(base, relative)` で、末尾セパレータの有無に影響されない。**http(s) 側だけが食い違っていた。**

## 修正

http(s) の base の `pathname` をディレクトリへ正規化してから解決し、ローカルパス側と挙動を揃える。

文字列連結(`base + '/'`)ではなく `pathname` だけを直すのは、base に付いたクエリ・フラグメントを壊さないため。

## テスト

`src/shared/resolvePath.test.ts` に末尾スラッシュ無しの base の describe を追加した。修正前は 3 件が落ち、修正後は全通過する。

うち **「親ディレクトリへ出る相対パスは拒否する」「別オリジンは拒否する」の 2 件は修正前後どちらでも通る** — 正規化でセキュリティ境界(同一オリジン + 親ディレクトリ脱出禁止)を緩めていないことの確認として置いている。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
