### PR TITLE
fix(shared): 依存が循環していてもパッケージ一覧が落ちないようにする

### DIFF
--- a/src/shared/packageUtil.test.ts
+++ b/src/shared/packageUtil.test.ts
@@ -368,4 +368,58 @@ describe('computePackagesStatus', () => {
     const withNew = computePackagesStatus(base('2.1'), '1.10', '0.92');
     expect(withNew[0].detached).toEqual([]);
   });
+
+  it('依存が循環していても落ちず、循環したパッケージはインストール不可になる', () => {
+    const result = computePackagesStatus(
+      [
+        makePackage('author/a', {
+          installationStatus: states.notInstalled,
+          dependencies: ['author/b'],
+        }),
+        makePackage('author/b', {
+          installationStatus: states.notInstalled,
+          dependencies: ['author/a'],
+        }),
+      ],
+      '1.10',
+      '0.92',
+    );
+    expect(result.map((p) => p.doNotInstall)).toEqual([true, true]);
+  });
+
+  it('自分自身に依存していても落ちない', () => {
+    const result = computePackagesStatus(
+      [
+        makePackage('author/a', {
+          installationStatus: states.notInstalled,
+          dependencies: ['author/a'],
+        }),
+      ],
+      '1.10',
+      '0.92',
+    );
+    expect(result[0].doNotInstall).toBe(true);
+  });
+
+  it('循環に巻き込まれていないパッケージの判定は変わらない', () => {
+    const result = computePackagesStatus(
+      [
+        makePackage('author/a', {
+          installationStatus: states.notInstalled,
+          dependencies: ['author/b'],
+        }),
+        makePackage('author/b', {
+          installationStatus: states.notInstalled,
+          dependencies: ['author/a'],
+        }),
+        makePackage('author/ok', {
+          installationStatus: states.notInstalled,
+          dependencies: ['aviutl1.10'],
+        }),
+      ],
+      '1.10',
+      '0.92',
+    );
+    expect(result[2].doNotInstall).toBe(false);
+  });
 });

--- a/src/shared/packageUtil.ts
+++ b/src/shared/packageUtil.ts
@@ -150,7 +150,7 @@ export function computePackagesStatus(
   const aviUtlR = /aviutl\d/;
   const exeditR = /exedit\d/;
 
-  const isInstallable = (id: string): boolean => {
+  const computeInstallable = (id: string): boolean => {
     const thisPackage = packages.filter((p) => p.id === id).find(() => true);
     if (thisPackage) {
       const isDepsInstallable = (): boolean =>
@@ -181,6 +181,23 @@ export function computePackagesStatus(
       return id === 'exedit' + exeditVer;
     } else {
       return false;
+    }
+  };
+  // dependencies はリモート由来(dataURL の packages.json と
+  // {installationPath}/packages.json)なので A→B→A や A→A が書かれうる。
+  // 評価中の id を弾かないと無限再帰で RangeError になり、
+  // getPackagesWithStatus に try/catch が無いためパッケージ一覧が丸ごと
+  // 表示できなくなる。
+  const evaluating = new Set<string>();
+  const isInstallable = (id: string): boolean => {
+    // 循環は「導入できない」に倒す。一覧そのものが出なくなるより、
+    // その 1 件が導入不可と表示されるほうがユーザーは先へ進める。
+    if (evaluating.has(id)) return false;
+    evaluating.add(id);
+    try {
+      return computeInstallable(id);
+    } finally {
+      evaluating.delete(id);
     }
   };
   const isInstalled = (rawId: string): boolean => {


### PR DESCRIPTION
## 症状

パッケージデータの依存に循環(`A → B → A`、あるいは自己依存 `A → A`)が 1 つでもあると、**Plugins タブが丸ごと表示できなくなる**。

## 原因

`computePackagesStatus` の `isInstallable` は依存を再帰で辿るだけで、評価中の id を持っていない。

```ts
const isInstallable = (id: string): boolean => {
  const thisPackage = packages.filter((p) => p.id === id).find(() => true);
  if (thisPackage) {
    const isDepsInstallable = (): boolean =>
      (thisPackage.info.dependencies ?? [])
        .map((orOfID) => orOfID.split('|').map((id2) => isInstallable(id2)).some((x) => x))
        …
```

`dependencies` はリモート由来 — dataURL の `packages.json` と `{installationPath}/packages.json`(`localRepoPath`)— なので循環が書かれうる。書かれると `RangeError: Maximum call stack size exceeded` になる。

呼び出し元の `getPackagesWithStatus`(`src/main/services/packageList.ts`)に try/catch が無いため、この例外は tRPC のクエリごと失敗する。**パッケージ 1 件の記述ミスで一覧全体が死ぬ**うえ、ユーザーには原因が分からない。

## 修正

評価中の id を `Set` で持ち、循環を検出したら `false`(導入できない)を返す。

`false` に倒す理由: 一覧そのものが出なくなるより、その 1 件が「導入不可」と表示されるほうがユーザーは先へ進める。

## 到達経路について

公式データ(apm-data v3、285 パッケージ)を実際に集計したところ **最大依存深さ 2・循環なし**だった。したがって現時点で踏むのは主に次の 2 つ:

- `{installationPath}/packages.json`(ローカルリポジトリ。自作パッケージの検証で手書きされる)
- サードパーティの dataURL

「自作パッケージ・サードパーティデータの検証」は AGENTS.md が明示的に守ると決めているユースケースなので、そこで一覧が落ちるのは避けたい。

## テスト

`computePackagesStatus` に 3 件追加した。修正前は 3 件とも `Maximum call stack size exceeded` で落ち、修正後は通る。

3 件目の「循環に巻き込まれていないパッケージの判定は変わらない」は、**循環の巻き添えで無関係なパッケージまで導入不可にしていないこと**の確認。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
