### PR TITLE
fix(shared): 名前が前方一致するだけのファイルを手動導入判定から除外しない

### DIFF
--- a/src/shared/packageUtil.test.ts
+++ b/src/shared/packageUtil.test.ts
@@ -125,6 +125,39 @@ describe('getManuallyInstalledFiles', () => {
     ).toEqual(['script/other.anm']);
   });
 
+  it('名前が前方一致するだけの別エントリは除外しない', () => {
+    // 実データの衝突: oov/GCMZDrops の "GCMZDrops"(ディレクトリ)が
+    // oov/PSDToolKit の "GCMZDrops.auf" を巻き込んでいた
+    const packages = [
+      makePackage('oov/GCMZDrops', {
+        files: [{ filename: 'GCMZDrops', isDirectory: true }],
+      }),
+    ];
+    expect(
+      getManuallyInstalledFiles(
+        ['GCMZDrops.auf', 'GCMZDrops/inner.anm'],
+        { 'oov/GCMZDrops': { id: 'oov/GCMZDrops', version: '1.0' } },
+        packages,
+      ),
+    ).toEqual(['GCMZDrops.auf']);
+  });
+
+  it('末尾スラッシュ付きのディレクトリ指定でも配下を除外できる', () => {
+    // 実データに "script/ANM_ssd/" のような書き方がある
+    const packages = [
+      makePackage('satsuki/satsuki', {
+        files: [{ filename: 'script/ANM_ssd/', isDirectory: true }],
+      }),
+    ];
+    expect(
+      getManuallyInstalledFiles(
+        ['script/ANM_ssd/a.anm', 'script/ANM_ssd2/b.anm'],
+        { 'satsuki/satsuki': { id: 'satsuki/satsuki', version: '1.0' } },
+        packages,
+      ),
+    ).toEqual(['script/ANM_ssd2/b.anm']);
+  });
+
   it('apm.json に無いパッケージのファイルは除外しない', () => {
     const packages = [
       makePackage('author/pkg', {

--- a/src/shared/packageUtil.ts
+++ b/src/shared/packageUtil.ts
@@ -66,7 +66,14 @@ export function getManuallyInstalledFiles(
           if (!file.isDirectory) {
             retFiles = retFiles.filter((ef) => ef !== file.filename);
           } else {
-            retFiles = retFiles.filter((ef) => !ef.startsWith(file.filename));
+            // 区切りを含めずに前方一致させると、名前が前方一致するだけの
+            // 別エントリまで巻き込む(実データでは oov/GCMZDrops の
+            // "GCMZDrops" が oov/PSDToolKit の "GCMZDrops.auf" を消す)。
+            // installedFiles は getInstalledFiles が組み立てる '/' 区切りの
+            // 相対パスなので、区切りは常に '/'。データ側に "script/ANM_ssd/"
+            // のような末尾スラッシュ付きの指定があるため一度落として付け直す。
+            const prefix = file.filename.replace(/\/+$/, '') + '/';
+            retFiles = retFiles.filter((ef) => !ef.startsWith(prefix));
           }
         }
       }


### PR DESCRIPTION
## 症状

実際には手動導入されているパッケージが、パッケージ一覧で**未インストールと表示される**ことがある。

## 原因

`getManuallyInstalledFiles` は `isDirectory` のエントリを前方一致で除外するが、**直後が区切り文字かを見ていない**。

```ts
retFiles = retFiles.filter((ef) => !ef.startsWith(file.filename));
```

`installedFiles` は `getInstalledFiles`(`src/main/services/packageList.ts`)が `'script/' + name + '/' + file` の形で組み立てる `/` 区切りの相対パスなので、`GCMZDrops` というディレクトリ指定が `GCMZDrops.auf` にも一致してしまう。

## これは机上の話ではない

apm-data v3(285 パッケージ / 787 ファイルエントリ)を実際に突き合わせたところ、**4 件の衝突が存在する**。

| ディレクトリ指定 | 巻き込まれる側 |
| --- | --- |
| `oov/GCMZDrops` の `GCMZDrops` | `oov/PSDToolKit` の `GCMZDrops.auf` |
| `oov/PSDToolKit` の `GCMZDrops` | `oov/GCMZDrops` の `GCMZDrops.auf` |
| `hebiiro/python32` の `plugins/ultimate` | `hebiiro/UltimatePlugin` の `plugins/ultimate.auf` |
| `hebiiro/python32` の `plugins/ultimate` | `hebiiro/UltimatePlugin` の `plugins/ultimate.aul` |

いずれも `.auf` / `.aul` で、`getInstalledFiles` の拡張子フィルタを通る。つまり実際に一覧に載るファイルが消える。

除外されたファイルは `manuallyInstalledFiles` から抜けるので、`getInstalledVersionOfPackage` が `states.manuallyInstalled` を立てられず、そのパッケージは「未インストール」として表示される。

## 修正

区切り文字込みの前方一致にする。データ側に `script/ANM_ssd/` のような末尾スラッシュ付きの指定があるため、一度落としてから付け直している。

## テスト

2 件追加した。

- **名前が前方一致するだけの別エントリは除外しない** — 実データの `GCMZDrops` 衝突をそのまま再現。修正前は落ちる
- **末尾スラッシュ付きのディレクトリ指定でも配下を除外できる** — 実データの `script/ANM_ssd/` 形式。正規化で既存の除外を壊していないことの確認(修正前後どちらでも通る)

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
