### PR TITLE
fix(main): ブラウザ経由のダウンロードが完了しなかったら失敗として扱う

### DIFF
--- a/src/main/services/browser.ts
+++ b/src/main/services/browser.ts
@@ -7,19 +7,22 @@ const icon =
     ? path.join(__dirname, '../icon/apm1024.png')
     : undefined;
 
-export type OpenBrowserResult = {
-  savePath: string;
-  history: string[];
-} | null;
+/**
+ * ブラウザ窓での取得結果。
+ * completed = ダウンロードが完了した / closed = 取得せず窓を閉じた
+ * failed = ダウンロードが始まったが完了しなかった(中断・キャンセル)
+ */
+export type OpenBrowserResult =
+  | { status: 'completed'; savePath: string; history: string[] }
+  | { status: 'closed' }
+  | { status: 'failed' };
 
 /**
  * Opens a modal browser window and waits for the user to download a file.
- * 旧 windows.ts の OPEN_BROWSER ハンドラと同一の挙動。ウィンドウが閉じられたら
- * null(キャンセル)を返す。
  * @param {BrowserWindow} parent - The parent (main) window.
  * @param {string} url - The URL to open.
  * @param {'core' | 'package'} type - The subdirectory in the data folder to save the file.
- * @returns {Promise<OpenBrowserResult>} The download result, or null if canceled.
+ * @returns {Promise<OpenBrowserResult>} The download result.
  */
 export function openBrowser(
   parent: BrowserWindow,
@@ -81,9 +84,17 @@ export function openBrowser(
         : [type];
       item.setSavePath(resolveInside(dir, ...subDirs, filename));
 
-      item.once('done', () => {
+      item.once('done', (_event, state) => {
         history.push(...item.getURLChain(), item.getFilename());
-        resolve({ savePath: item.getSavePath(), history: history });
+        // Chromium は完了時に中間ファイル(.crdownload)を savePath へ
+        // リネームして確定する。state を見ずに resolve すると、中断時に
+        // 存在しないパス(あるいは前回の取得で残った古いファイル)を
+        // 「取得成功」として先へ渡してしまう。
+        resolve(
+          state === 'completed'
+            ? { status: 'completed', savePath: item.getSavePath(), history }
+            : { status: 'failed' },
+        );
         if (!browserWindow.isDestroyed()) browserWindow.close();
       });
     };
@@ -93,7 +104,7 @@ export function openBrowser(
       // partition は openBrowser 呼び出し間で共有される。DL せずに閉じた
       // とき once リスナーが残留して次回の DL を横取りしないよう外す
       ses.removeListener('will-download', onWillDownload);
-      resolve(null);
+      resolve({ status: 'closed' });
     });
   });
 }

--- a/src/main/services/packageInstall.ts
+++ b/src/main/services/packageInstall.ts
@@ -173,9 +173,15 @@ export async function installPackageFlow(
         packageState.info.downloadURLs[0],
         'package',
       );
-      if (!downloadResult) {
+      if (downloadResult.status === 'closed') {
         log.info('The installation was canceled.');
         return { failure: 'canceled' as const };
+      }
+      if (downloadResult.status === 'failed') {
+        log.error(
+          `The download did not complete. URL:${packageState.info.downloadURLs[0]}`,
+        );
+        return { failure: 'downloadFailed' as const };
       }
       return { archivePath: downloadResult.savePath };
     },
@@ -212,9 +218,15 @@ export async function installPackageFlow(
         packageState.info.downloadURLs[0],
         'package',
       );
-      if (!redownloadResult) {
+      if (redownloadResult.status === 'closed') {
         log.info('The installation was canceled.');
         return { failure: 'canceled' as const };
+      }
+      if (redownloadResult.status === 'failed') {
+        log.error(
+          `The re-download did not complete. URL:${packageState.info.downloadURLs[0]}`,
+        );
+        return { failure: 'redownloadFailed' as const };
       }
       return { archivePath: redownloadResult.savePath };
     },

--- a/src/main/services/packages.test.ts
+++ b/src/main/services/packages.test.ts
@@ -343,7 +343,7 @@ describe('packages service', () => {
     });
 
     it('ブラウザ経由のキャンセルは canceled', async () => {
-      mocks.openBrowser.mockResolvedValueOnce(null);
+      mocks.openBrowser.mockResolvedValueOnce({ status: 'closed' });
 
       const result = await installPackageFlow(
         ctx,
@@ -366,6 +366,27 @@ describe('packages service', () => {
         'https://example.com/dl',
         'package',
       );
+    });
+
+    it('ブラウザ経由のダウンロードが完了しなければ downloadFailed', async () => {
+      mocks.openBrowser.mockResolvedValueOnce({ status: 'failed' });
+
+      const result = await installPackageFlow(
+        ctx,
+        inst,
+        {
+          id: 'a/b',
+          info: {
+            name: 'x',
+            latestVersion: '1',
+            files: [],
+            downloadURLs: ['https://example.com/dl'],
+          },
+        } as unknown as Parameters<typeof installPackageFlow>[2],
+        {},
+      );
+
+      expect(result).toBe('downloadFailed');
     });
 
     it('integrity 不一致で再ダウンロードを断ると corrupt', async () => {

--- a/src/main/services/scriptInstall.ts
+++ b/src/main/services/scriptInstall.ts
@@ -258,7 +258,11 @@ export async function installScriptArchive(
 }
 
 export type InstallScriptFlowResult =
-  | { route: 'flow'; status: 'canceled' | 'notSupported' | 'redirectNotFound' }
+  | {
+      route: 'flow';
+      status:
+        'canceled' | 'downloadFailed' | 'notSupported' | 'redirectNotFound';
+    }
   | { route: 'script'; status: InstallScriptResult }
   | { route: 'redirect'; status: InstallPackageResult };
 
@@ -278,9 +282,13 @@ export async function installScriptFlow(
   url: string,
 ): Promise<InstallScriptFlowResult> {
   const downloadResult = await openBrowser(ctx.win, url, 'package');
-  if (!downloadResult) {
+  if (downloadResult.status === 'closed') {
     log.info('The installation was canceled.');
     return { route: 'flow', status: 'canceled' };
+  }
+  if (downloadResult.status === 'failed') {
+    log.error(`The download did not complete. URL:${url}`);
+    return { route: 'flow', status: 'downloadFailed' };
   }
 
   const archivePath = downloadResult.savePath;

--- a/src/renderer/main/packages/PackageActions.tsx
+++ b/src/renderer/main/packages/PackageActions.tsx
@@ -140,6 +140,8 @@ function PackageActions({
     } else if (result.route === 'flow') {
       if (result.status === 'canceled') {
         install.finish('インストールがキャンセルされました。', 'info');
+      } else if (result.status === 'downloadFailed') {
+        install.finish('ダウンロード中にエラーが発生しました。', 'danger');
       } else if (result.status === 'notSupported') {
         install.finish('未対応のスクリプトです。', 'danger');
       } else {


### PR DESCRIPTION
## 症状

ブラウザ窓でのダウンロードが**中断されても「取得成功」として先へ進む**。ユーザーには実態と違うメッセージが出る。

| パッケージ | 実際に出るもの |
| --- | --- |
| integrity あり | 「ダウンロードされたファイルは破損しています。再ダウンロードしますか？」 |
| integrity なし | 「エラーが発生しました。」(unzip の ENOENT) |

どちらも「ダウンロードが完了しなかった」とは伝えていない。

さらに悪いケースがある。**同名アーカイブの再取得が中断した場合、`savePath` には前回の完了済みファイルが残る。** Chromium は完了時に中間ファイル(`.crdownload`)を `savePath` へリネームして確定するため、中断では上書きが起きない。この場合は検証も展開も通り、**古い版が黙ってインストールされる**。

## 原因

`openBrowser` の `done` ハンドラが `DownloadItem` の state を受け取っていない。

```ts
item.once('done', () => {
  history.push(...item.getURLChain(), item.getFilename());
  resolve({ savePath: item.getSavePath(), history: history });   // ← state を見ていない
  …
```

`done` の第 2 引数は `'completed' | 'cancelled' | 'interrupted'` だが、どれであっても同じ結果を返していた。`null` を返すのは `browserWindow.once('closed')`(＝取得せずに窓を閉じた)だけなので、**「窓は開いたまま DL が中断した」経路は必ず成功扱い**になる。

直リンク経路(`downloadFile`)は electron-dl が中断で reject するのを `catch` して `downloadFailed` に落としている。**ブラウザ経路だけが区別を持っていなかった。**

## 修正

`OpenBrowserResult` を状態つきの直和に変え、3 つを区別する。

| status | 意味 | 流す先 |
| --- | --- | --- |
| `completed` | 完了した | そのまま先へ |
| `closed` | 取得せず窓を閉じた | `canceled`(従来どおり) |
| `failed` | 始まったが完了しなかった | `downloadFailed` / `redownloadFailed` |

新しい失敗値は作っていない。`downloadFailed` / `redownloadFailed` は既にあり、renderer にも表示分岐がある(「ダウンロード中にエラーが発生しました。」/「ファイルのダウンロードに失敗しました。」)。

スクリプト経路(`installScriptFlow`)だけは flow ルートに `downloadFailed` が無かったので追加し、`PackageActions.tsx` に対応する分岐を足した。

## テスト

`packages.test.ts` に「ブラウザ経由のダウンロードが完了しなければ downloadFailed」を追加。既存の「ブラウザ経由のキャンセルは canceled」は新しい戻り値の形(`{ status: 'closed' }`)に合わせて更新した — **窓を閉じた場合が引き続き canceled であること**の確認も兼ねている。

## 確認できていないこと

実際に中断を起こす E2E は書いていない(ネットワークの中断を再現する仕掛けが要る)。state の分岐そのものはユニットテストで固定してある。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
