### PR TITLE
fix(main): nicommons ID を URL に埋める前にエスケープする

### DIFF
--- a/src/main/services/nicommons.test.ts
+++ b/src/main/services/nicommons.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { getNicommonsData } from './nicommons';
+
+const mocks = vi.hoisted(() => ({ fetch: vi.fn() }));
+
+vi.mock('electron', () => ({ net: { fetch: mocks.fetch } }));
+vi.mock('electron-log/main', () => ({
+  default: { error: vi.fn(), debug: vi.fn() },
+}));
+
+describe('getNicommonsData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('works エンドポイントに ID を渡して data を返す', async () => {
+    mocks.fetch.mockResolvedValueOnce({
+      status: 200,
+      json: async () => ({ data: { node: { thumbnailURL: 'x' } } }),
+    });
+
+    expect(await getNicommonsData('sm123')).toEqual({
+      node: { thumbnailURL: 'x' },
+    });
+    expect(mocks.fetch.mock.calls[0][0]).toBe(
+      'https://public-api.commons.nicovideo.jp/v1/works/sm123?with_meta=1',
+    );
+  });
+
+  it('URL の構文になる文字を含む ID でも works エンドポイントから外れない', async () => {
+    mocks.fetch.mockResolvedValueOnce({ status: 404 });
+
+    await getNicommonsData('../../v1/other?x=1');
+
+    const url = new URL(mocks.fetch.mock.calls[0][0] as string);
+    expect(url.pathname.startsWith('/v1/works/')).toBe(true);
+    expect(url.searchParams.get('with_meta')).toBe('1');
+    expect(url.searchParams.get('x')).toBeNull();
+  });
+
+  it('404 は false', async () => {
+    mocks.fetch.mockResolvedValueOnce({ status: 404 });
+    expect(await getNicommonsData('sm404')).toBe(false);
+  });
+
+  it('取得に失敗しても false に畳む', async () => {
+    mocks.fetch.mockRejectedValueOnce(new Error('offline'));
+    expect(await getNicommonsData('sm1')).toBe(false);
+  });
+});

--- a/src/main/services/nicommons.ts
+++ b/src/main/services/nicommons.ts
@@ -11,8 +11,13 @@ import log from 'electron-log/main';
  */
 export async function getNicommonsData(id: string): Promise<unknown> {
   try {
+    // id はパッケージデータ(リモート由来)の nicommons をそのまま渡した
+    // ものなので、'?' や '..' が URL の構文として解釈されないよう通す。
+    // 形を正規表現で縛らないのは、公式データが sm 系だけでも nicommons の
+    // ID には nc / im / td 等があり、サードパーティのデータを不当に
+    // 弾きたくないため
     const response = await net.fetch(
-      `https://public-api.commons.nicovideo.jp/v1/works/${id}?with_meta=1`,
+      `https://public-api.commons.nicovideo.jp/v1/works/${encodeURIComponent(id)}?with_meta=1`,
       { signal: AbortSignal.timeout(10000) },
     );
     if (response.status === 404) {


### PR DESCRIPTION
## 内容

`getNicommonsData` は nicommons ID を URL テンプレートへ直接埋めている。

```ts
await net.fetch(
  `https://public-api.commons.nicovideo.jp/v1/works/${id}?with_meta=1`,
  …
```

この `id` はパッケージデータ(リモート由来)の `nicommons` を `NicommonsTab` が渡し、tRPC の `stringInput` を通っただけの文字列。`?` `#` `..` がそのまま URL の構文として解釈される。

`../../v1/other?x=1` のような値を書かれると、URL 正規化で `..` が解決されて組み立て先が `/v1/works/` から外れる。ホスト部は固定なので他ホストへは飛ばないが、意図しないパス・クエリへのリクエストになり、その応答の `node.thumbnailURL` が `NicommonsTab` のサムネイル `src` に入る。

`encodeURIComponent` を通す。

## 形式の検証はしていない

`^[a-z]{2}\d+$` のような検証も考えたが入れていない。apm-data v3 の実データ 153 件はすべて `sm` 系だが、nicommons の ID には `nc` / `im` / `td` 等があり(`NicommonsTab.tsx` のテストデータ自体が `im1696493` / `nc251912` を使っている)、サードパーティのデータを不当に弾きたくないため。

エスケープだけなら**どんな ID でも works エンドポイントから外れない**ことを保証でき、正当な値を拒否する副作用が無い。

## テスト

`src/main/services/nicommons.test.ts` を新規に追加した(このモジュールにはテストが無かった)。

- **URL の構文になる文字を含む ID でも works エンドポイントから外れない** — 修正前は落ちる
- 通常の ID・404・取得失敗の 3 件は、既存の挙動(失敗をすべて `false` に畳む)を固定するもの

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
