### PR TITLE
ci: 自動修正できる ESLint エラーを CI が見逃さないようにする

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ AviUtl Package Manager (apm) — AviUtl のプラグイン・スクリプトを�
 ## コマンド
 
 ```
-yarn lint       # prettier + eslint(--check。自動修正は yarn fix)
+yarn lint       # prettier --check + eslint(報告のみ。自動修正は yarn fix)
 yarn lint:ts    # tsc --noEmit
 yarn test       # vitest run (src/**/*.test.ts)
 yarn package    # electron-forge package(ThirdPartyNotices 生成込み)

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "test:watch": "vitest"
   },
   "lint-staged": {
-    "*.js": [
+    "*.{ts,tsx,mjs}": [
       "prettier --write",
       "eslint --fix"
     ],
-    "*.{ts,tsx,json,yml,md,html,css,scss}": "prettier --write"
+    "*.{json,yml,md,html,css,scss}": "prettier --write"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "fix:eslint": "eslint --fix .",
     "fix:prettier": "prettier --write .",
     "lint": "run-s lint:prettier lint:eslint",
-    "lint:eslint": "eslint --fix-dry-run .",
+    "lint:eslint": "eslint .",
     "lint:prettier": "prettier --check .",
     "lint:ts": "tsc --noEmit",
     "make": "yarn run notices && electron-forge make",


### PR DESCRIPTION
## 見つけたこと

`lint:eslint` が `eslint --fix-dry-run .` になっている。`--fix-dry-run` は**メモリ上で修正を当ててから「残った問題」だけを報告する**仕様なので、自動修正可能なエラーは報告からも終了コードからも消える。

実測(`prefer-arrow-callback` 違反 — `eslint.config.mjs` が明示的に `error` にしている唯一のスタイル規則 — を含むファイルに対して):

```
$ npx eslint src/__probe.ts
  1:30  error  Unexpected function expression  prefer-arrow-callback
✖ 1 problem (1 error, 0 warnings)
exit=1

$ npx eslint --fix-dry-run src/__probe.ts
exit=0
```

つまり **`yarn lint` が緑でも `yarn fix` が差分を出す状態が main に入りうる**。AGENTS.md も「`yarn lint` # prettier + eslint(--check。自動修正は yarn fix)」と書いているが、`--check` 相当ではない。

`git log -S'--fix-dry-run' -- package.json` のヒットは 079acbd8「ci(GitHub Actions): lint on pushing」(2021-10-17)の 1 件だけで、CI に lint を足した最初のコミットから 5 年近くこの形が続いている。

## 変更

### 1. `lint:eslint` を `eslint .` にする

現時点の main の `fixableErrorCount` は 0(`eslint . -f json` で確認)なので、**この変更で新たに落ちるものは無い**。AGENTS.md のコマンド表も実体に合わせた。

### 2. lint-staged の対象を実在する拡張子に合わせる

`*.js` に `prettier --write` + `eslint --fix` を掛けていたが、**追跡されている `.js` は 0 件**(`git ls-files '*.js'`)でこのエントリは何もしていない。一方 eslint の実対象である `.ts` / `.tsx` / `.mjs` には prettier しか掛かっておらず、eslint は commit 時に走らない。

1 で CI が自動修正可能なエラーを報告するようになるので、コミット時に同じものを直せるようにしておく(でないと CI で初めて気づくことになる)。prettier の対象から漏れていた `.mjs`(`eslint.config.mjs` / `scripts/updateSiteDownloadUrls.mjs`)も同時に拾う。

## 影響

- pre-commit で `.ts` / `.tsx` に `eslint --fix` が走るようになる(自動修正が入るぶん、コミットがわずかに遅くなる)
- CI の Lint ジョブは、現状のコードでは今までどおり通る

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
