### PR TITLE
docs: ドキュメントの記述を実体に合わせる

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ The languages and frameworks used include:
 - TypeScript
 - JavaScript (Node.js)
 - HTML / CSS
-- React (About window; main window migration in progress)
-- tRPC (partial)
+- React (all windows)
+- tRPC (all IPC except one preload-only channel)
 
 ## Issues
 
@@ -69,16 +69,19 @@ By running `yarn package`, the packaged app is output to `out/`, so run it.
 
 ```text
 src/
-├── common/          # Shared constants (IPC channel names)
-├── lib/             # Shared libraries (config, paths, integrity, etc.)
-├── main/            # Electron main process
-├── migration/       # Data version migrations
+├── shared/          # Pure modules with no Electron dependency (the main unit-test target)
+├── lib/             # Electron-dependent modules used from the renderer (preload only)
+├── common/          # Channel names of the preload-only IPC
+├── main/            # Electron main process (api/ = tRPC routers, services/ = business logic)
 ├── renderer/
 │   ├── about/       # About window (React)
-│   ├── main/        # Main window (legacy DOM; being migrated)
+│   ├── main/        # Main window (React; one root, one directory per tab)
 │   └── splash/      # Splash screen
 └── types/           # TypeScript declarations
 ```
+
+[ARCHITECTURE.md](./ARCHITECTURE.md) describes the process layout, the breakdown of the
+main process, and the data flow in detail (in Japanese).
 
 See [BRANCHING.md](./BRANCHING.md) for branch workflow.
 

--- a/README.en.md
+++ b/README.en.md
@@ -119,7 +119,8 @@ Also, I'm Japanese, so any pull requests related to English or i18n are most wel
   - TypeScript
   - HTML / CSS
   - JavaScript
-  - React (About window; main window migration in progress)
+  - React (all windows)
+  - tRPC
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ yarn start
   - TypeScript
   - HTML / CSS
   - JavaScript
-  - React (About window; main window migration in progress)
+  - React (全窓)
+  - tRPC
 
 ## ライセンス
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,7 +51,7 @@ Release tags are always cut on top of `main`, so this is a fast-forward and need
 
 ### 4. CI publishes binaries
 
-Pushing a `v*` tag triggers [`.github/workflows/release.yml`](../.github/workflows/release.yml), which runs `electron-forge publish` on macOS, Ubuntu, and Windows and attaches installers to the GitHub Release.
+Pushing a `v*` tag triggers [`.github/workflows/release.yml`](./.github/workflows/release.yml), which runs `electron-forge publish` on macOS, Ubuntu, and Windows and attaches installers to the GitHub Release.
 
 ### 5. Publish the draft release
 


### PR DESCRIPTION
ドキュメントがコードの変更に追随しそこねている箇所を 3 つ直す。いずれも事実の誤りで、方針の判断は含まない。

## 1. RELEASING.md のリンクがリポジトリ外を指している

```
[`.github/workflows/release.yml`](../.github/workflows/release.yml)
```

b0ea3411「リリース手順書をリポジトリ直下へ移す」は `docs/RELEASING.md => RELEASING.md` の**純粋な rename(内容差分 0)**で、BRANCHING.md と AGENTS.md の参照は追随させたが、移動したファイル自身の中の相対リンクが残った。`docs/` にあったときは `../.github/…` が正しく、直下に来た今はリポジトリの外を指す。

同じ内容を書いている BRANCHING.md:18 は正しく `.github/workflows/release.yml` になっており、2 文書で片方だけ壊れていた。

## 2. CONTRIBUTING.md のディレクトリツリーが実体と違う

| 記述 | 実体 |
| --- | --- |
| `src/migration/` がある | 存在しない(版移行は `src/main/services/migration.ts`) |
| `src/shared/` が無い | 存在する。AGENTS.md が**ユニットテストの主対象**と位置づける中心的ディレクトリ |
| `lib/` = "Shared libraries (config, paths, integrity, etc.)" | 中身は `ipcWrapper.ts` 1 本(config は `src/main/Config.ts`、integrity は `src/shared/integrity.ts`) |
| `main/` = "Main window (legacy DOM; being migrated)" | React 単一ルート + タブ単位のディレクトリ(移行完了) |

67a79b99「update directory structure」(2026-06)の時点では `src/migration/` は**実在していた**ので、当時の記述は正しかった。その後の Phase 5(DDD 設計しなおし)でディレクトリが変わったときに追随していない。

ツリーは実体に合わせたうえで、ARCHITECTURE.md への案内を添えた。同じ内容を 2 箇所で保守するとまた食い違うため、詳細は「構造が変わる PR では同じ PR で更新する」と自ら定めている ARCHITECTURE.md 側に寄せている。

> **判断が要るなら**: ツリーごと削除して ARCHITECTURE.md へのリンク 1 行にするほうが再発しません。ただし CONTRIBUTING.md は英語、ARCHITECTURE.md は日本語なので、英語話者向けの導線をどうするかの判断が要ると考え、この PR では実体に合わせるに留めました。

## 3. 「main window migration in progress」(3 文書)

`CONTRIBUTING.md:18` / `README.md:117` / `README.en.md:122` の

```
- React (About window; main window migration in progress)
```

は、AGENTS.md の確定方針「main 窓のタブ移行(Strangler Fig)は完了」と正面から矛盾する。あわせて、記載の無かった tRPC を足した。

CONTRIBUTING.md の `- tRPC (partial)` は「preload 専用の 1 チャンネルを除く全 IPC」と具体的にした(`src/common/ipc.ts` のコメントが理由まで書いている)。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
