### PR TITLE
refactor(renderer): 参照されていない common.ts を削除する

### DIFF
--- a/src/renderer/main/common.ts
+++ b/src/renderer/main/common.ts
@@ -1,3 +1,0 @@
-// programs / programsDisp は共有文字列の検証(shared/shareString.ts)でも
-// 使うため src/shared/programs.ts へ移設した。既存の import 経路を維持する
-export { programs, programsDisp } from '../../shared/programs';


### PR DESCRIPTION
## 内容

`src/renderer/main/common.ts` は全 3 行の re-export だけになっている。

```ts
// programs / programsDisp は共有文字列の検証(shared/shareString.ts)でも
// 使うため src/shared/programs.ts へ移設した。既存の import 経路を維持する
export { programs, programsDisp } from '../../shared/programs';
```

**その「既存の import 経路」はもう存在しない。**

- `git grep` で `renderer/main/common` を import しているファイルは `src/` にも `e2e/` にも 0 件
- 現在の利用側は `src/renderer/main/aviutl/BatchInstallButton.tsx` と `src/main/services/packageShare.ts` で、どちらも `shared/programs` を直接 import している

## 経緯

かつては install / verifyFilesByCount / programs 等を持つ renderer の共通モジュールだった。

| コミット | 移した先 |
| --- | --- |
| 078f9fa2 | `install` / `verifyFilesByCount` → `shared/install.ts` |
| eaeecc08 | `installPackage` / `uninstallPackage` の計算部分 → main プロセス |
| 180aa5ed | `programs` / `programsDisp` → `shared/programs.ts` |

180aa5ed が re-export だけを残したのは正しかった — その時点では `src/renderer/main/core.ts:14` と `package.ts:25` が実際に `'./common'` を import していた。両ファイルは React 化で消えている。

## 残すもの

`src/shared/install.test.ts:14` の

```ts
// 旧 src/renderer/main/common.ts の install / verifyFilesByCount の特性化テスト
```

は歴史的記述で「旧」の語が効いているのでそのまま。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
