### PR TITLE
fix(renderer): おすすめプラグイン一覧が空のインストール先で問い合わせる問題を修正する

### DIFF
--- a/e2e/batch-install-list.spec.ts
+++ b/e2e/batch-install-list.spec.ts
@@ -1,0 +1,64 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { serveFixtures, writeDataSet } from './fixtures';
+import { expect, getMainWindow, test } from './helpers';
+
+test('おすすめプラグイン一覧が起動直後からインストール先の状態を反映する', async ({
+  cleanup,
+  launchApp,
+}) => {
+  const workDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-'));
+  cleanup(() => rmSync(workDir, { recursive: true, force: true }));
+  const fixturesDir = path.join(workDir, 'fixtures');
+  const installationPath = path.join(workDir, 'aviutl');
+  mkdirSync(installationPath, { recursive: true });
+  // インストール先に実ファイルだけを置く(apm.json は作らない)。
+  // インストール先が正しく読めていれば「手動インストール済み」になり、
+  // 空のまま問い合わせていれば「未インストール」になる
+  writeFileSync(path.join(installationPath, 'batch.auf'), 'dummy');
+
+  const { baseUrl, close } = await serveFixtures(fixturesDir);
+  cleanup(close);
+  // おすすめ一覧に載るのは directURL を持つパッケージだけ
+  writeDataSet(fixturesDir, {
+    packages: [
+      {
+        id: 'e2e/batchPlugin',
+        name: 'E2E おすすめプラグイン',
+        overview: 'E2E テスト用のおすすめプラグイン',
+        description: 'AviUtl タブの一括インストール一覧の検証用。',
+        developer: 'apm-e2e',
+        pageURL: `${baseUrl}/`,
+        downloadURLs: [`${baseUrl}/files/batch.zip`],
+        directURL: `${baseUrl}/files/batch.zip`,
+        latestVersion: '1.0.0',
+        files: [{ filename: 'batch.auf' }],
+      },
+    ],
+  });
+
+  const app = await launchApp({
+    config: {
+      dataVersion: '3',
+      installationPath,
+      dataURL: { main: `${baseUrl}/`, extra: '' },
+    },
+  });
+  const window = await getMainWindow(app);
+  // 起動フローの完了を待つ(完了するとインストール先が入る)
+  await expect(window.locator('#installation-path')).toHaveValue(
+    installationPath,
+    { timeout: 120_000 },
+  );
+
+  // 初期表示の AviUtl タブのまま。タブ切り替えも再取得操作もしない
+  const row = window.locator('#batch-install-packages .batch-install-package', {
+    hasText: 'E2E おすすめプラグイン',
+  });
+  await expect(row).toBeVisible({ timeout: 120_000 });
+  await expect(row.locator('.installed-version')).toHaveText(
+    '手動インストール済み',
+    { timeout: 120_000 },
+  );
+});

--- a/src/renderer/main/aviutl/BatchInstallList.tsx
+++ b/src/renderer/main/aviutl/BatchInstallList.tsx
@@ -1,8 +1,11 @@
-import React, { type JSX, useEffect, useState } from 'react';
+import React, { type JSX, useEffect, useSyncExternalStore } from 'react';
 import { ListGroup } from 'react-bootstrap';
 import type { PackageState } from '../../../types/packageState';
 import { TRPCReact } from '../../trpc';
-import { getInstallationPath } from '../installationPath';
+import {
+  getInstallationPath,
+  subscribeInstallationPath,
+} from '../installationPath';
 
 /**
  * The list of the recommended plugins (directURL packages) shown in the
@@ -12,12 +15,15 @@ import { getInstallationPath } from '../installationPath';
  * 旧 package.ts の updateBatchInstallList と同一の表示。
  * クエリは PackagesTab と同じキー(adoptManuallyInstalled: true)でキャッシュを共有する
  * (apm.json の整合性補正は冪等のため表示結果は旧実装と変わらない)。
- * レガシー側からの再描画通知(apm-packages-changed イベント)で自動更新する。
+ * インストール先は installationPath ストアの購読で追う。apm-packages-changed
+ * を待つと、起動フロー(startup.ts)も SelectInstallationPathButton も
+ * setInstallationPath より前にそれを撃つため、確定前の値を読んでしまう。
  * @returns {JSX.Element} The rendered component.
  */
 function BatchInstallList(): JSX.Element {
-  const [installationPath, setInstallationPath] = useState(() =>
-    getInstallationPath(),
+  const installationPath = useSyncExternalStore(
+    subscribeInstallationPath,
+    getInstallationPath,
   );
 
   const utils = TRPCReact.useUtils();
@@ -26,10 +32,10 @@ function BatchInstallList(): JSX.Element {
     { refetchOnWindowFocus: false },
   );
 
-  // レガシー側(preload の package.ts)からの再描画通知を受けて最新化する
+  // 他コンポーネント(BatchInstallButton / PackageActions / packagesListCheck)
+  // からの再取得通知。インストール先の変化はストアの購読で別に追う
   useEffect(() => {
     const listener = () => {
-      setInstallationPath(getInstallationPath());
       void utils.packages.getPackagesWithStatus.invalidate();
     };
     window.addEventListener('apm-packages-changed', listener);


### PR DESCRIPTION
## 症状

**AviUtl タブのおすすめプラグイン一覧が、起動後ずっと「未インストール」を表示する。** 実際には導入済みでも変わらない。

一括インストールを実行するか設定タブで「更新」を押すと初めて正しくなる。

## 原因

`BatchInstallList` はインストール先を `apm-packages-changed` のリスナ内で `getInstallationPath()` から読み直していた。ところが**イベントを撃つ側は、撃ったあとでストアを更新する**。

```
startup.ts:86   apm-core-changed     を dispatch
startup.ts:87   apm-packages-changed を dispatch   ← BatchInstallList はここで読む
startup.ts:94   setInstallationPath(installationPath)
startup.ts:97   apm-core-changed     を dispatch
```

`SelectInstallationPathButton` も同じ順序(44,45 → 47 → 50)。

リスナが走る時点のストアはまだ空文字なので、以後 `apm-packages-changed`(発火はすべてユーザー操作起点)が来るまで空のまま。一覧は `getPackagesWithStatus({ installationPath: '', adoptManuallyInstalled: true })` の結果を出し続ける。

**`PackagesTab` / `NicommonsTab` / `ProgramRow` が同じ問題を踏まないのは、2 度目の `apm-core-changed`(startup.ts:97 = `setInstallationPath` の後)も購読しているため。** `BatchInstallList` だけが `apm-packages-changed` しか見ていない。

## 修正

`AviutlTab` と同じく `useSyncExternalStore(subscribeInstallationPath, getInstallationPath)` でストアを直接購読する。イベントの発火順に依存しなくなるので、起動時もインストール先の変更時も追従する。

`apm-packages-changed` のリスナはクエリの invalidate 用に残す(役割が「再取得の通知」だけになる)。

## テスト

`e2e/batch-install-list.spec.ts` を追加した。インストール先に `batch.auf` を置いただけ(`apm.json` は作らない)の状態で起動し、**タブ切り替えも再取得操作もせずに**一覧の表示を見る。

| | 表示 |
| --- | --- |
| 修正前 | `未インストール` ❌ |
| 修正後 | `手動インストール済み` ✅ |

手元(macOS)で `yarn package` → `yarn test:e2e` を修正前後それぞれで実行して確認済み。修正後は既存 5 件を含む 6 件すべて green。

ユニットテストで書けないのは、これが「DOM イベントの発火順とストア更新の競合」で、renderer のコンポーネントを描画しないと再現しないため(vitest の environment は `node`)。

## 触っていないもの

`PackagesTab` / `NicommonsTab` / `ProgramRow` も同じ `useState` + DOM イベントの形で、ストア購読へ揃えたほうが発火順への依存が消える。ただしこの 3 つは 2 度目の `apm-core-changed` で救われていて**挙動は変わらない**ので、「挙動変更と構造変更を同じ PR に混ぜない」に従って別 PR にする。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
