### PR TITLE
fix(main): 整合性検証に落ちたアーカイブを残さない

### DIFF
--- a/src/main/services/installFlow.ts
+++ b/src/main/services/installFlow.ts
@@ -1,6 +1,8 @@
-import { type BrowserWindow, dialog } from 'electron';
+import { app, type BrowserWindow, dialog } from 'electron';
 import log from 'electron-log/main';
+import path from 'node:path';
 import { verifyFile } from '../../shared/integrity';
+import { safeRemove } from '../../shared/safeRemove';
 
 /**
  * アーカイブ取得の結果。取得できたらそのパス、できなければ呼び出し元固有の
@@ -40,6 +42,21 @@ export async function runInstallFlow<TFailure extends string>(
 
   if (flow.integrity) {
     while (!(await verifyFile(archivePath, flow.integrity))) {
+      // 検証に落ちたアーカイブは残さない。downloadFile の loadCache は
+      // 中身を見ずに既存ファイルを返すので、置いたままだと次回以降の
+      // インストールが毎回このファイルを掴んで破損ダイアログを出し続ける
+      // (再ダウンロードを断ったときは上書きも起きないため復帰できない)。
+      // archivePath は必ず downloadFile か openBrowser の保存先で
+      // userData/Data 配下にあり、ユーザーが指定したファイルではない
+      try {
+        await safeRemove(
+          archivePath,
+          path.join(app.getPath('userData'), 'Data'),
+        );
+      } catch (e) {
+        log.error(e);
+      }
+
       const dialogResult = await dialog.showMessageBox(win, {
         title: 'エラー',
         message:

--- a/src/main/services/packages.test.ts
+++ b/src/main/services/packages.test.ts
@@ -401,6 +401,9 @@ describe('packages service', () => {
       );
 
       expect(result).toBe('corrupt');
+      // 破損したアーカイブは残さない(残すと downloadFile の loadCache が
+      // 次回もこのファイルを返し、毎回 corrupt になって復帰できない)
+      expect(await pathExists(file)).toBe(false);
     });
 
     it('integrity 不一致の再ダウンロードは旧実装どおり subDir core へ落ち、失敗すると redownloadFailed', async () => {


### PR DESCRIPTION
## 症状

**一度ダウンロードが壊れると、そのパッケージは二度とインストールできなくなる。** ネットワークが正常に戻っても「ダウンロードされたファイルは破損しています。再ダウンロードしますか？」が毎回出る。

「おすすめプラグインの一括インストール」では 1 件の破損がボタン全体を毎回失敗させる(`corrupt` で `BatchInstallButton` が throw してループを中断するため)。

## 原因

`downloadFile` の `loadCache` は**中身を見ずに**既存ファイルのパスを返す。

```ts
if (loadCache && fs.existsSync(retFilePath)) return retFilePath;
```

一方 `runInstallFlow` は検証に落ちたアーカイブを削除しない。したがって破損ファイルがディスクに残り続け、次回以降の `installPackageFlow` が同じファイルを掴む。

パッケージの direct 経路はさらに悪い。**初回取得と再ダウンロードで落とし先が違う。**

| | subDir | 保存先 |
| --- | --- | --- |
| 初回(`loadCache: true`) | `package` | `Data/package/archive/…` |
| 再ダウンロード | `core` | `Data/core/archive/…` |

`// 再ダウンロード先が subDir 'core' なのは旧実装のままの挙動` とコメントがある。このため「はい」で再取得しても**破損ファイルは上書きされず残る**。

`core` の経路(`installCoreProgram`)は初回・再取得とも `subDir: 'core'` + `overwrite: true` なので上書きされるが、**「いいえ」を選んだ場合は同じく残る**。

補足: 「キャッシュ削除」でも消えない場合がある。`clearCache()` が消すのは `Data/{core,package}/archive` だけで、アーカイブ以外の拡張子(`.auf` 等の直リンク)は `Data/package` 直下に置かれるため対象外。

## 修正

検証に落ちた時点でそのアーカイブを削除する。整合性を満たさないファイルはキャッシュとしての価値が無い。

`safeRemove(archivePath, userData/Data)` を通しているのは、**将来 `archivePath` の出所が変わってもデータフォルダの外を消さない**ため。現状 `archivePath` は必ず `downloadFile` か `openBrowser` の保存先で、`userData/Data` 配下にある(renderer からの `archivePath` 入力はどこからも渡されておらず、`scriptInstall` の redirect 経路がブラウザ窓の保存先を渡すだけ)。

## 触っていないもの

再ダウンロード先の `subDir: 'core'` はそのまま。削除するようになれば `loadCache` が破損ファイルを返すことは無くなり、ループは解消する。`subDir` を揃えるのは旧実装からの挙動差の整理なので、特性化テスト(`integrity 不一致の再ダウンロードは旧実装どおり subDir core へ落ち…`)の更新を含めて別 PR にしたい。

## テスト

既存の「integrity 不一致で再ダウンロードを断ると corrupt」に、**破損ファイルが残っていないこと**の確認を足した。修正前は落ちる。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
