### PR TITLE
fix(renderer): 失敗しても操作ボタンが loading のまま固まらないようにする

### DIFF
--- a/src/renderer/main/monacoEditorRenderer.tsx
+++ b/src/renderer/main/monacoEditorRenderer.tsx
@@ -181,27 +181,34 @@ export const MonacoEditorRenderer: React.FC = () => {
 
     save.start();
 
-    // getAction / getModel が null を返すのはエディタ破棄後。ここは
-    // 直前に editor の生存を確かめているので必ず取れる
-    await editor.getAction('editor.action.formatDocument')!.run();
-    let error =
-      monaco.editor
-        .getModelMarkers({})
-        .filter(
-          (m) =>
-            m.severity === monaco.MarkerSeverity.Warning ||
-            m.severity === monaco.MarkerSeverity.Error,
-        ).length > 0;
-
-    let json;
+    // 全体を囲うのは、途中で投げると phase が loading のまま残り、
+    // 保存ボタンが二度と押せなくなるため(usePhase の復帰タイマーは
+    // finish 系でしか張られない)。JSON の構文エラーと同じ 'エラー' に
+    // 寄せるのは、ユーザーから見ればどちらも「保存できなかった」ため
     try {
-      json = JSON.parse(editor.getValue());
-    } catch {
-      error = true;
-    }
-    if (error) {
-      save.finish('エラー', 'danger');
-    } else {
+      // getAction / getModel が null を返すのはエディタ破棄後。ここは
+      // 直前に editor の生存を確かめているので必ず取れる
+      await editor.getAction('editor.action.formatDocument')!.run();
+      let error =
+        monaco.editor
+          .getModelMarkers({})
+          .filter(
+            (m) =>
+              m.severity === monaco.MarkerSeverity.Warning ||
+              m.severity === monaco.MarkerSeverity.Error,
+          ).length > 0;
+
+      let json;
+      try {
+        json = JSON.parse(editor.getValue());
+      } catch {
+        error = true;
+      }
+      if (error) {
+        save.finish('エラー', 'danger');
+        return;
+      }
+
       // editorPackages.json の読み書きは main プロセス側
       // (src/main/services/packages.ts)
       await setEditorPackagesMutation.mutateAsync({
@@ -212,6 +219,8 @@ export const MonacoEditorRenderer: React.FC = () => {
       // このイベントを購読して行う
       window.dispatchEvent(new Event('apm-check-packages-list'));
       save.finish('保存完了', 'success');
+    } catch {
+      save.finish('エラー', 'danger');
     }
   };
   // Ctrl+S のコマンド登録は onMount で 1 回だけ行うため、最新の実装を

--- a/src/renderer/main/packages/PackageActions.tsx
+++ b/src/renderer/main/packages/PackageActions.tsx
@@ -300,7 +300,16 @@ function PackageActions({
       return;
     }
 
-    const exists = await openFolderMutation.mutateAsync(selectedEntry.p.id);
+    // catch しないと phase が loading のまま残り、ActionButton の
+    // disabled が外れずボタンが二度と押せなくなる(usePhase の復帰
+    // タイマーは finish 系でしか張られない)
+    let exists: boolean;
+    try {
+      exists = await openFolderMutation.mutateAsync(selectedEntry.p.id);
+    } catch {
+      folder.finish('エラーが発生しました。', 'danger');
+      return;
+    }
     if (!exists) {
       folder.finish('このパッケージはダウンロードされていません。', 'danger');
       return;
@@ -313,8 +322,15 @@ function PackageActions({
     if (share.phase.kind === 'loading') return;
     share.start();
 
-    const text = await utils.packages.getShareString.fetch(installationPath);
-    await writeClipboardMutation.mutateAsync({ text });
+    // getShareString は main 側で一覧の取得・状態判定まで辿るので、
+    // list.json 未取得や apm.json の読み込み失敗で普通に throw する
+    try {
+      const text = await utils.packages.getShareString.fetch(installationPath);
+      await writeClipboardMutation.mutateAsync({ text });
+    } catch {
+      share.finish('エラーが発生しました。', 'danger');
+      return;
+    }
     share.finish('コピーしました', 'info');
   };
 


### PR DESCRIPTION
## 症状

「共有」「ダウンロードフォルダ」「(データエディタの)保存」のいずれかが失敗すると、**そのボタンがスピナー表示のまま二度と押せなくなる**。エラーメッセージも出ない。復帰させるにはアプリを再起動するしかない。

## 原因

`usePhase` の復帰タイマーは `finish` 系でしか張られない。

```ts
const start = () => { clearTimeout(timer.current); setPhase({ kind: 'loading' }); };
const finish = (message, color) => {
  clearTimeout(timer.current);
  setPhase({ kind: 'message', message, color });
  timer.current = setTimeout(() => setPhase({ kind: 'idle' }), 3000);   // ← ここだけ
};
```

`start()` の後で例外が出て `finish` に到達しないと phase は `'loading'` のまま残る。`ActionButton` は `disabled={phase.kind === 'loading'}` なので押せなくなる。呼び出しは `onClick={() => void sharePackages()}` の形なので、rejection は未処理のまま捨てられる。

該当は 3 箇所。

| ハンドラ | catch していない await |
| --- | --- |
| `PackageActions.openPackageFolder` | `openFolderMutation.mutateAsync` |
| `PackageActions.sharePackages` | `getShareString.fetch` / `writeClipboardMutation.mutateAsync` |
| `monacoEditorRenderer.saveEditorData` | `formatDocument.run` / `setEditorPackagesMutation.mutateAsync` |

**同じファイルの `installPackage` / `uninstallPackage` / `installScript` は try/catch で日本語メッセージに落としている。** 失敗経路の扱いが不揃いだった。

実際に throw しうる:

- `getShareString` は main 側で `buildShareString` → `resolveInstallationStatus` → `getPackages` → `getIdDict` → `getInfo` まで辿るので、list.json 未取得・パース失敗・apm.json 読み込み失敗で throw する
- `saveEditorData` は JSON の構文エラーだけを拾っていたため、**同じ操作でエラー表示が出る場合と黙って固まる場合があった**

## 修正

既存の形(try/catch → `finish(..., 'danger')`)に揃える。新しい文言は増やしていない。

`saveEditorData` は本体全体を囲った。JSON の構文エラーと同じ `'エラー'` に寄せているのは、ユーザーから見ればどちらも「保存できなかった」ため。

## テストが無いことについて

自動テストを付けていない。

- ユニットテストでは書けない(`vitest.config.ts` の environment は `node` で、React コンポーネントを描画できない)
- E2E で確実に失敗させる手段が無い。書き込み権限を落とす方法は Windows で chmod がほぼ無効なため、CI(windows-latest)で「失敗しないので `'エラー'` にならない」となって逆に落ちる

代わりに、**同じファイル内の既に catch している 3 ハンドラと同じ形に揃える**ことで、レビューで差分が見えるようにした。

## 別に扱うもの

- `usePhase` に「実行関数を受け取り必ず finish する」ラッパを足せば構造的に防げるが、全ボタンの書き換えになるので構造変更の PR として分ける
- `monacoEditorRenderer` の `apm-core-changed` リスナが `onMount` で登録されたまま解除されない(再マウントで多重登録)のは別の不具合

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
