### PR TITLE
fix(renderer): 一括インストールが失敗を無視して「インストール完了」と出す問題を修正する

### DIFF
--- a/src/renderer/main/aviutl/BatchInstallButton.tsx
+++ b/src/renderer/main/aviutl/BatchInstallButton.tsx
@@ -17,8 +17,8 @@ const IDLE_LABEL = 'AviUtl・拡張編集とおすすめプラグインのイン
 /**
  * The batch-install button of the AviUtl tab.
  * 旧 core.ts の batchInstall(+ installProgram の btn なしルート)に相当する。
- * プログラムのインストール失敗は旧実装どおり黙って次へ進み、
- * ダウンロード失敗・破損のみ全体をエラー表示にする。
+ * ダウンロード失敗・破損は旧実装どおり全体を中断し、それ以外の失敗は
+ * 次の対象へ進む。ただし進んだぶんは件数を数えて最後に伝える。
  * @returns {JSX.Element} The rendered component.
  */
 function BatchInstallButton(): JSX.Element {
@@ -49,6 +49,10 @@ function BatchInstallButton(): JSX.Element {
       return;
     }
 
+    // 失敗しても次へ進むが、進んだことを黙っていると 1 件も入らずに
+    // 「インストール完了」と出てしまう。件数だけは持ち回る
+    let failedCount = 0;
+
     try {
       // tRPC の Serialize 型はプロパティを optional 化するため元の型に戻す
       const coreInfo = (await utils.core.getCoreInfo.fetch()) as Core | null;
@@ -61,7 +65,7 @@ function BatchInstallButton(): JSX.Element {
           installationPath,
         });
         // 旧 installProgram の btn なしルート: ダウンロード失敗のみ全体を
-        // エラーにし、他の失敗は黙って次へ進む
+        // エラーにし、他の失敗は次へ進む
         if (result === 'redownloadFailed') {
           throw new Error('Failed downloading the archive file.');
         }
@@ -69,6 +73,10 @@ function BatchInstallButton(): JSX.Element {
           window.dispatchEvent(new Event('apm-core-changed'));
           // 一覧と日付表示の再取得(旧 setPackagesList 相当)
           window.dispatchEvent(new Event('apm-packages-changed'));
+        } else {
+          // installCoreProgram には「既に入っているので何もしない」経路が
+          // 無く、毎回取得して上書きする。success 以外は本当に失敗
+          failedCount++;
         }
       }
 
@@ -98,10 +106,18 @@ function BatchInstallButton(): JSX.Element {
         if (result === 'success') {
           // 一覧と日付表示の再取得(旧 setPackagesList 相当)
           window.dispatchEvent(new Event('apm-packages-changed'));
+        } else {
+          // 対象は notInstalled / installedButBroken に絞ってあるので、
+          // success 以外は本当に失敗
+          failedCount++;
         }
       }
 
-      finish('インストール完了', 'success');
+      if (failedCount > 0) {
+        finish(`${failedCount} 件のインストールに失敗しました。`, 'danger');
+      } else {
+        finish('インストール完了', 'success');
+      }
     } catch {
       finish('エラーが発生しました。', 'danger');
     }


### PR DESCRIPTION
## 症状

「AviUtl・拡張編集とおすすめプラグインのインストール」ボタンは、**対象が 1 件も入らなくても緑の「インストール完了」に変わる**。

オフライン(または配布元が 404)で押すと、各 `installPackage` が `downloadFailed` を返すが、ボタンは成功表示になる。ユーザーはログを見るまで失敗に気づけない。

## 原因

ループが分岐しているのは一部の結果だけ。

```ts
if (result === 'corrupt') throw …            // 全体を中断
if (result === 'redownloadFailed') throw …   // 全体を中断
if (result === 'success') { …イベント発火… }
//   ↑ downloadFailed / installFailed / noVersionData には分岐が無い
```

ループを抜けると無条件に `finish('インストール完了', 'success')` を呼ぶ。

コメントが旧挙動として明示しているのは corrupt / redownloadFailed の扱いだけで、**失敗件数がどこにも出ない**点は進捗表示と実処理のずれになっている。

## 修正

「失敗しても次へ進む」という旧実装の方針は変えず、**進んだ件数を数えて最後に伝える**。1 件でもあれば `N 件のインストールに失敗しました。` を danger で出す。

## 誤検出しないことの確認

`success` 以外を失敗と数えて「実は成功していたもの」を拾わないか確かめた。

- **プログラム側**: `installCoreProgram` に「既に入っているので何もしない」経路は無い。毎回ダウンロードして上書きする(`runInstallFlow` に直行)。したがって `success` 以外は本当に失敗
- **パッケージ側**: 対象を `states.notInstalled` / `states.installedButBroken` に絞ってから回しているので、既にインストール済みのものは試行対象に入らない

## 文言について

ボタンのラベルなので幅が限られており、失敗したものの名前は入れていない(何が失敗したかは main プロセス側のログに出る)。**別の文言が良ければ差し替えてください。**

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
