### PR TITLE
fix(main): インストール先の変更を最後まで通ってから確定する

### DIFF
--- a/src/main/services/core.test.ts
+++ b/src/main/services/core.test.ts
@@ -376,6 +376,19 @@ describe('core service', () => {
       expect(mocks.refreshPackagesList).not.toHaveBeenCalled();
     });
 
+    it('途中で失敗したら config のインストール先を書き換えない', async () => {
+      config.setInstallationPath('/old/aviutl');
+      mocks.updateInfo.mockRejectedValueOnce(new Error('offline'));
+
+      await expect(changeInstallationPath(ctx, inst)).rejects.toThrow(
+        'offline',
+      );
+
+      // 先に確定させると、移行も再取得も済んでいないパスが config に残り、
+      // 呼び出し側は失敗を受けて画面を更新しないので表示と食い違う
+      expect(config.getInstallationPath()).toBe('/old/aviutl');
+    });
+
     it('installationPath が存在しなければ migration も変換も行わない', async () => {
       mocks.getInfo.mockResolvedValue(
         modInfo({

--- a/src/main/services/core.ts
+++ b/src/main/services/core.ts
@@ -230,7 +230,6 @@ export async function changeInstallationPath(
   inst: Installation,
 ): Promise<void> {
   const { win, config } = ctx;
-  config.setInstallationPath(inst.path);
 
   // update 1
   await updateInfo(win, config);
@@ -283,6 +282,13 @@ export async function changeInstallationPath(
       log.error(e);
     }
   }
+
+  // 確定はここまで通ってから。先頭で書くと、updateInfo や migration が
+  // 失敗したときに「config は新しいパスなのに移行も再取得も済んでいない」
+  // 状態がディスクに残る。呼び出し側(SelectInstallationPathButton)は
+  // 失敗すると renderer 側のストアを更新しないので、そのセッションは
+  // 旧パスに対して操作しながら次回起動で無言で新パスへ切り替わる
+  config.setInstallationPath(inst.path);
 }
 
 /**

--- a/src/renderer/main/aviutl/SelectInstallationPathButton.tsx
+++ b/src/renderer/main/aviutl/SelectInstallationPathButton.tsx
@@ -38,8 +38,20 @@ function SelectInstallationPathButton(): JSX.Element {
 
       const installationPath = selectedPath[0];
       // mod 情報の更新・migration・変換辞書の適用と、必要なデータの再取得は
-      // main プロセス側(services/core.ts の changeInstallationPath)が行う
-      await changeInstallationPathMutation.mutateAsync(installationPath);
+      // main プロセス側(services/core.ts の changeInstallationPath)が行う。
+      // catch しないと、失敗しても何のメッセージも出ないまま
+      // 「選んだのに変わらない」状態になる(このボタンは phase を持たず
+      // ラベルが変わらないので、押した結果が画面に一切現れない)
+      try {
+        await changeInstallationPathMutation.mutateAsync(installationPath);
+      } catch {
+        await openDialogMutation.mutateAsync({
+          title: 'エラー',
+          message: 'インストール先の変更に失敗しました。',
+          type: 'error',
+        });
+        return;
+      }
       // 再描画通知(旧 changeInstallationPath と同一)
       window.dispatchEvent(new Event('apm-core-changed'));
       window.dispatchEvent(new Event('apm-packages-changed'));


### PR DESCRIPTION
## 症状

インストール先の変更が途中で失敗すると、**何のメッセージも出ないまま画面のパスは元のまま**になる。そのセッション中の操作は旧フォルダに対して行われるが、**次回起動時に apm は無言で新フォルダへ切り替わる**。ユーザーから見ると「入れたはずのプラグインが消えた」ように見える。

再現: インストール先を A にした状態でオフラインにし、`Data/list.json` を消してから「AviUtlインストールフォルダを選択」で B を選ぶ。

## 原因

### 1. 確定が先頭にある(`src/main/services/core.ts`)

```ts
export async function changeInstallationPath(ctx, inst) {
  const { win, config } = ctx;
  config.setInstallationPath(inst.path);   // ← ディスクへ即確定

  await updateInfo(win, config);           // ← throw しうる
  …migrationByFolder / convertPackageIds / 再取得…
}
```

途中で失敗すると「config には新しいパスが書かれたが、移行も ID 変換もデータ再取得も済んでいない」状態がディスクに残る。

### 2. 呼び出し側が失敗を捨てている(`SelectInstallationPathButton.tsx`)

`mutateAsync` を try/catch していないので、以降の `setInstallationPath(installationPath)`(renderer 側ストア)に到達しない。`onClick={() => void selectInstallationPath()}` なので未処理 rejection も表に出ない。

この 2 つが合わさって **config = 新パス / 画面 = 旧パス** の乖離が起きる。

## 修正

### 1. すべて通ってから確定する

関数内で `config.getInstallationPath()` を読む箇所は無い(読むのは `ensureInstallationPath` だけで、startup フローではこの関数より前に走る)。したがって成功時の挙動は変わらない。

失敗時は config も renderer 側ストアも旧パスのまま残り、**両者が一致する**。

### 2. 失敗をダイアログに出す

同じファイルの「拡張編集が plugins フォルダにある」判定と同じ形に揃えた。

## テスト

`core.test.ts` に「途中で失敗したら config のインストール先を書き換えない」を追加(`updateInfo` を reject させる)。修正前は落ちる。

既存の「mod 情報が新しければ scripts・core・packages を再取得する」が `config.getInstallationPath()` の確定を見ているので、**成功時の挙動が保たれていること**はそちらで担保される。

## 残る課題(別 issue 向け)

失敗時、`migrationByFolder` / `convertPackageIds` が新フォルダに対して既に走っている場合がある。これらは冪等なので次回やり直せるが、「どこまで進んだか」を記録していないのは事実。起動フロー全体の失敗の扱い(`startup.ts` の catch がすべてを「予期しないエラーが発生しました。」に丸め、`installationPath` が空のまま残る)も同じ根で、そちらはより大きな設計判断になる。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
