### PR TITLE
fix(main): apm.json の書き込みを原子的にする

### DIFF
--- a/src/main/Ledger.test.ts
+++ b/src/main/Ledger.test.ts
@@ -1,4 +1,11 @@
-import { mkdtemp, pathExists, readJson, remove, writeJson } from 'fs-extra';
+import {
+  ensureDir,
+  mkdtemp,
+  pathExists,
+  readJson,
+  remove,
+  writeJson,
+} from 'fs-extra';
 import { promises as fsPromises } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -359,6 +366,33 @@ describe('Ledger', () => {
         const reader = await Ledger.load(installationPath);
         expect(await reader.get('core.aviutl')).toBe('1.10');
       });
+    });
+  });
+
+  describe('原子書き込み', () => {
+    it('書き込みに失敗しても apm.json は前の内容のまま残る', async () => {
+      const installationPath = await makeInstPath();
+      const ledger = await Ledger.load(installationPath);
+      await ledger.setCore('aviutl', '1.10');
+
+      // 書き込み先を「ディレクトリ」にして rename を失敗させる
+      // (実ファイルへ直接書いていると、この時点で apm.json が壊れる)
+      await ensureDir(Ledger.getPath(installationPath) + '.tmp');
+
+      await expect(ledger.setCore('aviutl', '1.20')).rejects.toThrow();
+
+      const json = await readJson(Ledger.getPath(installationPath));
+      expect(json.core.aviutl).toBe('1.10');
+    });
+
+    it('書き損じた一時ファイルを残さない', async () => {
+      const installationPath = await makeInstPath();
+      const ledger = await Ledger.load(installationPath);
+      await ledger.setCore('aviutl', '1.10');
+
+      expect(await pathExists(Ledger.getPath(installationPath) + '.tmp')).toBe(
+        false,
+      );
     });
   });
 });

--- a/src/main/Ledger.ts
+++ b/src/main/Ledger.ts
@@ -5,7 +5,7 @@ import {
   setProperty,
 } from 'dot-prop';
 import log from 'electron-log';
-import { readJson, writeJson } from 'fs-extra';
+import { readJson, remove, rename, writeJson } from 'fs-extra';
 import path from 'node:path';
 import { type LedgerObject } from '../types/ledger';
 
@@ -88,9 +88,25 @@ class Ledger {
    * @returns {Promise<void>} A promise that resolves when the object is saved.
    */
   private save(): Promise<void> {
-    const queued = this.saveQueue.then(() =>
-      writeJson(this.path, this.object, { spaces: 2 }),
-    );
+    // 一時ファイルへ書いてから rename する。実ファイルへ直接 writeJson
+    // すると、書き込み中の電断・強制終了・ディスクフルで apm.json が
+    // 途中まで書かれた不正 JSON として残り、次回 load() が既定値へ
+    // フォールバックして導入記録が読めなくなる。同一ディレクトリなら
+    // rename は同じファイルシステム上の操作なので原子的に置き換わる
+    // (config.json 側は electron-store が同じことをしている)。
+    // 一時ファイル名を固定にできるのは saveQueue で直列化しているため
+    const queued = this.saveQueue.then(async () => {
+      const tempPath = this.path + '.tmp';
+      try {
+        await writeJson(tempPath, this.object, { spaces: 2 });
+        await rename(tempPath, this.path);
+      } catch (e) {
+        // 書き損じた一時ファイルを残さない(次回の rename が
+        // 中途半端な内容を本体へ持ち込まないようにする)
+        await remove(tempPath).catch(() => undefined);
+        throw e;
+      }
+    });
     // 失敗は呼び出し元へは queued で伝播させ、後続の書き込みは止めない
     this.saveQueue = queued.catch(() => {});
     return queued;


### PR DESCRIPTION
## 何が起きうるか

`apm.json` の書き込み中にプロセスが落ちる(電断・強制終了・ディスクフル)と、**導入記録が確定的に消える**。

1. `save()` が実ファイルへ直接 `writeJson` するので、途中まで書かれた不正 JSON が残る
2. 次回起動の `load()` は ENOENT 以外を `log.error` に出すだけで、**空の Ledger へフォールバックする**(警告なし)
3. Ledger は全体書き戻しなので、その後**最初の `set` / `addPackage` が空の内容をディスクへ上書き**する

3 の起点は自動で、ユーザー操作を待たない。AviUtl タブが起動直後に呼ぶ `getInstalledVersionTexts` が integrity 一致で `ledger.setCore()` を実行する。

ユーザーから見えるのは「全部未インストールになった」だけで、ダイアログも出ない。

**`config.json` 側は electron-store が原子書き込みをしている。`apm.json` だけが無防備だった。**

## 修正

一時ファイル(`apm.json.tmp`)へ書いてから `rename` する。同一ディレクトリなので同じファイルシステム上の操作になり、原子的に置き換わる。

- 一時ファイル名を固定にできるのは、既存の `saveQueue` が書き込みを直列化しているため
- 失敗時は一時ファイルを消す(次回の `rename` が中途半端な内容を本体へ持ち込まないように)
- `apm.json.tmp` は `getInstalledFiles` の拡張子フィルタにも `verifyFilesByCount` にも引っかからないので、一覧や検証には影響しない

## テスト

2 件追加した。

- **書き込みに失敗しても apm.json は前の内容のまま残る** — 一時ファイルのパスをディレクトリにして `rename` を失敗させる。やや作為的な作り方だが、確かめたい性質(**保存に失敗しても本体は壊れない**)はこれで固定できる。修正前は「書き込み自体が成功してしまう」ので落ちる
- **書き損じた一時ファイルを残さない**

## 触っていないもの

**読み込み失敗時の扱いは変えていない。** 「黙って空へ倒す」のをやめて退避 + 通知にするか、書き込みを禁止するかは設計判断が要る(#2435 とも近い話)。この PR は**破損そのものを減らす側**だけを直す。

`load()` の判定が `typeof value === 'object'` だけで `null` と配列を通してしまう問題(以後 dot-prop の `setProperty` が無言で no-op になり、書き込みが永久に捨てられる)も同じ箇所だが、こちらは挙動判断を含むので分ける。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
