### PR TITLE
fix(shared): 本体の更新で上書き禁止のファイルを潰さないようにする

### DIFF
--- a/src/shared/install.test.ts
+++ b/src/shared/install.test.ts
@@ -67,6 +67,52 @@ describe('install', () => {
     expect(await pathExists(path.join(inst, 'readme.txt'))).toBe(true);
   });
 
+  it('isProgram でも isUninstallOnly の既存ファイルは上書きしない', async () => {
+    // 拡張編集の更新で exedit.ini が初期化される経路。apm-schema の
+    // isUninstallOnly は "Overwriting prohibited" と定義されている
+    const src = await makeTempDir('apm-install-src-');
+    const inst = await makeTempDir('apm-install-dst-');
+    await writeFile(path.join(src, 'exedit.auf'), 'new plugin');
+    await writeFile(path.join(src, 'exedit.ini'), 'default settings');
+    await writeFile(path.join(inst, 'exedit.ini'), 'user settings');
+
+    const result = await install(
+      src,
+      inst,
+      [
+        { filename: 'exedit.auf' },
+        { filename: 'exedit.ini', isUninstallOnly: true },
+      ],
+      true,
+    );
+
+    expect(result).toBe(true);
+    expect(await readFile(path.join(inst, 'exedit.ini'), 'utf8')).toBe(
+      'user settings',
+    );
+    // 保護対象でないものは従来どおり上書きされる
+    expect(await readFile(path.join(inst, 'exedit.auf'), 'utf8')).toBe(
+      'new plugin',
+    );
+  });
+
+  it('isProgram で isUninstallOnly のファイルが未配置なら初回はコピーする', async () => {
+    const src = await makeTempDir('apm-install-src-');
+    const inst = await makeTempDir('apm-install-dst-');
+    await writeFile(path.join(src, 'exedit.ini'), 'default settings');
+
+    await install(
+      src,
+      inst,
+      [{ filename: 'exedit.ini', isUninstallOnly: true }],
+      true,
+    );
+
+    expect(await readFile(path.join(inst, 'exedit.ini'), 'utf8')).toBe(
+      'default settings',
+    );
+  });
+
   it('通常インストールは files に列挙されたファイルだけを配置する', async () => {
     const src = await makeTempDir('apm-install-src-');
     const inst = await makeTempDir('apm-install-dst-');

--- a/src/shared/install.ts
+++ b/src/shared/install.ts
@@ -46,7 +46,22 @@ export async function install(
   isProgram = false,
 ) {
   if (isProgram) {
-    await copy(unzippedPath, installationPath);
+    // isUninstallOnly は apm-schema で "Overwriting prohibited"(設定ファイル等)
+    // と定義されているが、この分岐は files を見ずに展開結果を丸ごとコピーする
+    // ため守られていなかった。fs-extra の copy は既定で上書きするので、
+    // ユーザーが編集した設定が本体の更新のたびに初期化される。
+    // ファイル単位のコピーに作り替えないのは、プログラムのアーカイブには
+    // files に列挙されていない同梱物(script/ や exe_files/ 等)があり、
+    // 丸ごとコピーであることが配置の前提になっているため
+    const protectedPaths = new Set(
+      files
+        .filter((file) => file.isUninstallOnly)
+        .map((file) => path.resolve(installationPath, file.filename)),
+    );
+    await copy(unzippedPath, installationPath, {
+      filter: (_src, dest) =>
+        !(protectedPaths.has(path.resolve(dest)) && existsSync(dest)),
+    });
   } else {
     // Delete obsolete files
     for (const file of files) {


### PR DESCRIPTION
## 症状

**AviUtl 本体・拡張編集を更新すると、アーカイブに同梱されている設定ファイルがユーザーの編集ごと初期化されます。**

## 原因

apm-schema は `isUninstallOnly` を **"Overwriting prohibited"**(設定ファイル等)と定義しています。通常のインストール経路はこれを守っています。

```ts
if (file.isUninstallOnly) {
  if (existsSync(filePath[0]) && !existsSync(filePath[1])) filesToCopy.push(filePath);
} else filesToCopy.push(filePath);
```

ところが `isProgram` 分岐は **`files` を一切見ません**。

```ts
if (isProgram) {
  await copy(unzippedPath, installationPath);   // fs-extra の既定は overwrite: true
}
```

`core.json` は `aviutl.ini` / `aviutl.key` / `aviutl.sav` / `aviutl.aup` に `isUninstallOnly` を付けていますが、**この経路では 1 つも効いていません**。

同じ根で `#1138`(SplitWindow を更新すると設定が消える)が報告され、その対策として `isUninstallOnly` が apm-schema に入りました。パッケージ側は直り、プログラム側は直っていなかった、という形です。

## 修正

`copy` の `filter` で「`isUninstallOnly` かつ既に配置先にあるファイル」だけを除外します。

ファイル単位のコピーに作り替えていないのは、**プログラムのアーカイブには `files` に列挙されていない同梱物がある**(拡張編集なら `exedit.txt` 以外にも入っている)ため。丸ごとコピーであることが配置の前提になっています。「1 つの挙動だけを変える」ために filter を使いました。

## この修正だけでは足りません(apm-data 側)

現在の `core.json` の `exedit` セクションを見ると:

```
exedit.anm / exedit.auf / exedit.aui / exedit.auo / exedit.cam /
exedit.ini / exedit.obj / exedit.scn / exedit.tra / exedit.txt /
lua.txt / lua51.dll                       ← 旗なし
lua51jit.dll                              ← isUninstallOnly
```

**`exedit.ini` に旗が付いていません。** そして `verifyFilesByCount` が `exedit.ini` の存在を要求する(旗が無いので計数対象)ため、`exedit.ini` はアーカイブに同梱されていて必ず上書きされます。

拡張編集 0.92 → 0.93rc1 の更新で、ユーザーが編集した `exedit.ini`(`[extension]` の対応拡張子など、L-SMASH Works を使うなら触る場所)が初期化されます。

**apm-data の `core.json` で `exedit.ini` に `isUninstallOnly` を付ける**必要があります。この PR は apm 側で「旗を立てれば効く」状態にするところまでです。

## テスト

2 件追加しました。

- **isProgram でも isUninstallOnly の既存ファイルは上書きしない** — 修正前は落ちる。保護対象でないファイルが従来どおり上書きされることも同時に確認
- **isProgram で isUninstallOnly のファイルが未配置なら初回はコピーする** — 初回インストールで既定の設定ファイルが置かれることの確認(修正前後どちらでも通る回帰ガード)

既存の「isProgram はフォルダ全体をコピーする」(`files` に無い `readme.txt` も入ること)は変えずに通ります。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
