### PR TITLE
fix(shared): 別ドライブ・UNC を「インストール先の内側」と判定しないようにする

### DIFF
--- a/src/shared/apmPath.ts
+++ b/src/shared/apmPath.ts
@@ -8,7 +8,14 @@ import path from 'node:path';
  */
 export function isParent(parent: string, child: string) {
   const relative = path.relative(parent, child);
-  return Boolean(relative && !relative.startsWith('..'));
+  // 絶対パスを弾くのは Windows のため。win32 の path.relative は別ドライブや
+  // UNC のように相対化できない相手に対して、相対パスではなく引数をそのまま
+  // 返す(path.win32.relative('C:\\aviutl', 'D:\\evil') === 'D:\\evil')。
+  // '..' で始まらないので、この検査が無いと「インストール先の内側」と
+  // 判定されてしまう。POSIX の path.relative は絶対パスを返さないので無影響
+  return Boolean(
+    relative && !relative.startsWith('..') && !path.isAbsolute(relative),
+  );
 }
 
 /**

--- a/src/shared/apmPath.win32.test.ts
+++ b/src/shared/apmPath.win32.test.ts
@@ -1,0 +1,48 @@
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { isParent, resolveInside } from './apmPath';
+
+// isParent の判定は path.relative の結果に依存し、その挙動は OS で違う。
+// 本番の対象は Windows だが CI のユニットテストは ubuntu で走るため、
+// node:path を win32 実装に差し替えて Windows 側の判定を固定する。
+vi.mock('node:path', async () => {
+  const actual = await vi.importActual<typeof import('node:path')>('node:path');
+  return { ...actual.win32, default: actual.win32 };
+});
+
+describe('isParent (win32)', () => {
+  it('同じドライブの子は内側と判定する', () => {
+    expect(isParent('C:\\aviutl', 'C:\\aviutl\\plugins\\a.auf')).toBe(true);
+  });
+
+  it('別ドライブは内側と判定しない', () => {
+    // path.win32.relative は相対化できず 'D:\\evil\\x' をそのまま返すので、
+    // '..' 始まりの検査だけでは通り抜ける
+    expect(path.win32.relative('C:\\aviutl', 'D:\\evil\\x')).toBe(
+      'D:\\evil\\x',
+    );
+    expect(isParent('C:\\aviutl', 'D:\\evil\\x')).toBe(false);
+  });
+
+  it('UNC パスは内側と判定しない', () => {
+    expect(isParent('C:\\aviutl', '\\\\srv\\share\\x')).toBe(false);
+  });
+
+  it('親へ出るパスは従来どおり内側と判定しない', () => {
+    expect(isParent('C:\\aviutl', 'C:\\evil')).toBe(false);
+  });
+});
+
+describe('resolveInside (win32)', () => {
+  it('別ドライブを指すセグメントを拒否する', () => {
+    expect(() => resolveInside('C:\\aviutl', 'D:\\evil\\x')).toThrow(
+      /invalid path/,
+    );
+  });
+
+  it('インストール先の中は従来どおり解決する', () => {
+    expect(resolveInside('C:\\aviutl', 'plugins', 'a.auf')).toBe(
+      'C:\\aviutl\\plugins\\a.auf',
+    );
+  });
+});


### PR DESCRIPTION
## 内容

`isParent` は `path.relative` の結果が `'..'` で始まらなければ「内側」と判定します。POSIX では `path.relative` が絶対パスを返さないので正しいのですが、**win32 では相対化できない相手に対して引数をそのまま返します**。

```
path.win32.relative('C:\aviutl', 'D:\evil\x')     === 'D:\evil\x'
path.win32.relative('C:\aviutl', '\\srv\share\x') === '\\srv\share\x'
```

どちらも `'..'` で始まらないので **`isParent` が true** を返します。この関数は 6 箇所の関門で使われています。

| 場所 | 何を守っているか |
| --- | --- |
| `resolveInside` | インストール先・展開先の外への書き込み |
| `safeRemove` | インストール先の外の削除 |
| `download.ts` | データフォルダの外へのダウンロード |
| `tempFile.ts` | データフォルダの外の一時ファイル |
| `packageInstall.openPackageFolder` | データフォルダの外を開く |
| `resolvePath` | dataURL の親ディレクトリ脱出 |

**主対象である Windows でだけ、これらが素通りします。** `resolveInside` を入れたコミットの本文は「絶対パス指定や正規化で外へ出る形も同じ関門で弾ける」と書いていますが、この主張は Windows では成立していませんでした。

## 修正

解決結果が絶対パスなら内側と判定しない。1 行です。POSIX の挙動は変わりません。

## 到達経路について

**現時点で到達できる悪用経路は見つかっていません。** 二重の防御線のうち、外側は効いています。

- パッケージデータ由来の `filename` / `archivePath` は tRPC 境界の `isSafeRelativePath` が `/^[A-Za-z]:/` を弾く
- `scripts.json` 由来の `folder` は `resolveInside(inst.path, 'script', folder)` と先行セグメントがあるため、`path.join` がドライブレターと UNC を無害化する(`C:\aviutl\script\D:\evil\x` になる)

**内側の防御線が効いていなかった**、という位置づけの予防的ハードニングです。

## テスト

`src/shared/apmPath.win32.test.ts` を新規追加しました。`node:path` を win32 実装へ差し替えています。

ユニットテストは `Node CI` で ubuntu-latest でしか走らないため、**本番の OS の判定はこの形でしか固定できません**。既存の `apmPath.test.ts` の「絶対パス指定を拒否する」は `path.resolve('/etc/passwd')` を使っており、Windows 上では `C:\etc\passwd` になって同一ドライブなので通ってしまいます(Linux CI では通るので気づけない)。

修正前は 3 件が落ちます。

## 別に扱うもの

`pathRelated` が本体から使われていません(`src/` `e2e/` を全 grep して `apmPath.test.ts` のみ)。削除は構造変更なので分けます。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
