### PR TITLE
fix(main): 整合性の不一致を「破損」と決めつけない

### DIFF
--- a/src/main/services/core.test.ts
+++ b/src/main/services/core.test.ts
@@ -56,7 +56,7 @@ vi.mock('electron', () => ({
   BrowserWindow: class {},
 }));
 vi.mock('electron-log/main', () => ({
-  default: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  default: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 vi.mock('../shortcut', () => ({
   addAviUtlShortcut: vi.fn(),
@@ -259,13 +259,14 @@ describe('core service', () => {
       expect(await ledger.get('core.aviutl')).toBe('1.10');
     });
 
-    it('integrity 不一致で再ダウンロードを断ると corrupt', async () => {
+    it('integrity 不一致で中止を選ぶと corrupt', async () => {
       const withIntegrity = structuredClone(coreInfo);
       withIntegrity.aviutl.releases[0].integrity.archive =
         'sha384-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
       await writeCachedCoreInfo(withIntegrity);
       mocks.downloadFile.mockResolvedValueOnce(await makeCoreZip());
-      mocks.showMessageBox.mockResolvedValueOnce({ response: 1 });
+      // 0=再ダウンロード / 1=このままインストール / 2=中止
+      mocks.showMessageBox.mockResolvedValueOnce({ response: 2 });
 
       expect(await installCoreProgram(ctx, inst, 'aviutl', '1.10')).toBe(
         'corrupt',

--- a/src/main/services/installFlow.ts
+++ b/src/main/services/installFlow.ts
@@ -24,7 +24,7 @@ export type ArchiveResolution<TFailure extends string> =
  * @param {string} [flow.corruptLogUrl] - The URL logged when the user refuses to re-download.
  * @param {() => Promise<ArchiveResolution<TFailure>>} flow.redownloadArchive - Re-resolves the archive after a verification failure.
  * @param {(archivePath: string) => Promise<boolean>} flow.install - Installs the archive and returns whether it succeeded.
- * @returns {Promise<'success' | 'corrupt' | 'installFailed' | TFailure>} The result status.
+ * @returns {Promise<'success' | 'corrupt' | 'installFailed' | TFailure>} The result status ('corrupt' = the user aborted after an integrity mismatch).
  */
 export async function runInstallFlow<TFailure extends string>(
   win: BrowserWindow,
@@ -42,10 +42,36 @@ export async function runInstallFlow<TFailure extends string>(
 
   if (flow.integrity) {
     while (!(await verifyFile(archivePath, flow.integrity))) {
-      // 検証に落ちたアーカイブは残さない。downloadFile の loadCache は
-      // 中身を見ずに既存ファイルを返すので、置いたままだと次回以降の
-      // インストールが毎回このファイルを掴んで破損ダイアログを出し続ける
-      // (再ダウンロードを断ったときは上書きも起きないため復帰できない)。
+      // apm は「ファイルが壊れている」と「apm のデータより新しい版が来た」を
+      // 区別できない。integrity は latestVersion に紐づく 1 リリース分しか
+      // 持たないのに、downloadURLs の多くは releases/latest(= 常に上流の
+      // 最新)を指すため、apm-data が追いつくまでの間は正常なファイルでも
+      // 必ず不一致になる。断定せずユーザーに選ばせる
+      const dialogResult = await dialog.showMessageBox(win, {
+        title: '確認',
+        message:
+          'ダウンロードしたファイルが、apm に登録されているものと一致しません。',
+        detail:
+          '配布元で新しい版が公開され、apm のデータが追いついていない可能性があります。\n' +
+          'ファイルが壊れている、または別のファイルをダウンロードした可能性もあります。',
+        type: 'warning',
+        buttons: ['再ダウンロード', 'このままインストール', '中止'],
+        defaultId: 0,
+        cancelId: 2,
+      });
+
+      // 「このままインストール」。アーカイブは消さずに検証を抜ける
+      if (dialogResult.response === 1) {
+        log.warn(
+          `Installing an archive that does not match the integrity. URL:${flow.corruptLogUrl}`,
+        );
+        break;
+      }
+
+      // ここから先はこのアーカイブを使わない。残さないのは、downloadFile の
+      // loadCache が中身を見ずに既存ファイルを返すため — 置いたままだと
+      // 次回以降のインストールが毎回このファイルを掴んで同じダイアログを
+      // 出し続ける(中止したときは上書きも起きないため復帰できない)。
       // archivePath は必ず downloadFile か openBrowser の保存先で
       // userData/Data 配下にあり、ユーザーが指定したファイルではない
       try {
@@ -57,18 +83,10 @@ export async function runInstallFlow<TFailure extends string>(
         log.error(e);
       }
 
-      const dialogResult = await dialog.showMessageBox(win, {
-        title: 'エラー',
-        message:
-          'ダウンロードされたファイルは破損しています。再ダウンロードしますか？',
-        type: 'warning',
-        buttons: ['はい', 'いいえ'],
-        cancelId: 1,
-      });
-
+      // 「中止」
       if (dialogResult.response !== 0) {
         log.error(
-          `The downloaded archive file is corrupt. URL:${flow.corruptLogUrl}`,
+          `The downloaded archive does not match the integrity. URL:${flow.corruptLogUrl}`,
         );
         return 'corrupt';
       }

--- a/src/main/services/migration.test.ts
+++ b/src/main/services/migration.test.ts
@@ -56,7 +56,7 @@ vi.mock('electron', () => ({
   BrowserWindow: class {},
 }));
 vi.mock('electron-log/main', () => ({
-  default: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  default: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 vi.mock('./download', () => ({ downloadFile: mocks.downloadFile }));
 

--- a/src/main/services/packages.test.ts
+++ b/src/main/services/packages.test.ts
@@ -59,7 +59,7 @@ vi.mock('electron', () => ({
   BrowserWindow: class {},
 }));
 vi.mock('electron-log/main', () => ({
-  default: { error: vi.fn(), info: vi.fn(), debug: vi.fn() },
+  default: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 vi.mock('./download', () => ({ downloadFile: mocks.downloadFile }));
 vi.mock('./browser', () => ({ openBrowser: mocks.openBrowser }));
@@ -389,12 +389,13 @@ describe('packages service', () => {
       expect(result).toBe('downloadFailed');
     });
 
-    it('integrity 不一致で再ダウンロードを断ると corrupt', async () => {
+    it('integrity 不一致で中止を選ぶと corrupt', async () => {
       const dir = path.join(mocks.userDataDir.value, 'Data/package');
       const file = path.join(dir, 'corrupt.auf');
       await writeFile(file, 'tampered');
       mocks.downloadFile.mockResolvedValueOnce(file);
-      mocks.showMessageBox.mockResolvedValueOnce({ response: 1 });
+      // 0=再ダウンロード / 1=このままインストール / 2=中止
+      mocks.showMessageBox.mockResolvedValueOnce({ response: 2 });
 
       const result = await installPackageFlow(
         ctx,
@@ -425,6 +426,48 @@ describe('packages service', () => {
       // 破損したアーカイブは残さない(残すと downloadFile の loadCache が
       // 次回もこのファイルを返し、毎回 corrupt になって復帰できない)
       expect(await pathExists(file)).toBe(false);
+    });
+
+    it('integrity 不一致でも「このままインストール」を選べば続行する', async () => {
+      const dir = path.join(mocks.userDataDir.value, 'Data/package');
+      const file = path.join(dir, 'mismatch.auf');
+      await writeFile(file, 'newer than apm-data');
+      mocks.downloadFile.mockResolvedValueOnce(file);
+      // 0=再ダウンロード / 1=このままインストール / 2=中止
+      mocks.showMessageBox.mockResolvedValueOnce({ response: 1 });
+
+      const result = await installPackageFlow(
+        ctx,
+        inst,
+        {
+          id: 'a/b',
+          info: {
+            name: 'x',
+            latestVersion: '1',
+            files: [],
+            directURL: 'u',
+            releases: [
+              {
+                version: '1',
+                integrity: {
+                  archive:
+                    'sha384-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                  file: [],
+                },
+              },
+            ],
+          },
+        } as unknown as Parameters<typeof installPackageFlow>[2],
+        { direct: true },
+      );
+
+      expect(result).toBe('success');
+      // 続行を選んだアーカイブは削除しない(展開先へ移動される)
+      expect(await pathExists(path.join(dir, 'a/b', 'mismatch.auf'))).toBe(
+        true,
+      );
+      // 再ダウンロードもしていない
+      expect(mocks.downloadFile).toHaveBeenCalledOnce();
     });
 
     it('integrity 不一致の再ダウンロードは旧実装どおり subDir core へ落ち、失敗すると redownloadFailed', async () => {

--- a/src/renderer/main/aviutl/BatchInstallButton.tsx
+++ b/src/renderer/main/aviutl/BatchInstallButton.tsx
@@ -96,9 +96,9 @@ function BatchInstallButton(): JSX.Element {
           packageState: { id: packageState.id, info: packageState.info },
           direct: true,
         });
-        // 旧 installPackage の direct ルート: 破損・ダウンロード失敗は throw
+        // 旧 installPackage の direct ルート: 中止・ダウンロード失敗は throw
         if (result === 'corrupt') {
-          throw new Error('The downloaded archive file is corrupt.');
+          throw new Error('The archive does not match the integrity.');
         }
         if (result === 'redownloadFailed') {
           throw new Error('Failed downloading the archive file.');

--- a/src/renderer/main/aviutl/ProgramRow.tsx
+++ b/src/renderer/main/aviutl/ProgramRow.tsx
@@ -99,7 +99,7 @@ function ProgramRow({
       return;
     }
     if (result === 'corrupt') {
-      showError('ダウンロードされたファイルは破損しています。');
+      showError('ファイルが一致しないため中止しました。');
       return;
     }
     if (result === 'redownloadFailed') {

--- a/src/renderer/main/packages/PackageActions.tsx
+++ b/src/renderer/main/packages/PackageActions.tsx
@@ -222,7 +222,7 @@ function PackageActions({
     } else if (result === 'downloadFailed') {
       install.finish('ダウンロード中にエラーが発生しました。', 'danger');
     } else if (result === 'corrupt') {
-      install.finish('ダウンロードされたファイルは破損しています。', 'danger');
+      install.finish('ファイルが一致しないため中止しました。', 'danger');
     } else if (result === 'redownloadFailed') {
       install.finish('ファイルのダウンロードに失敗しました。', 'danger');
     } else if (result === 'success') {


### PR DESCRIPTION
> [#2454](https://github.com/team-apm/apm/pull/2454) の上に積んでいましたが、そちらがマージされたので **main へリベース済み**です(削除の位置を動かす必要があるため積んでいました)。

## いま起きていること

**v3.14.0 で 13 件のパッケージがインストールできません。** rigaya のエンコーダ 6 本(NVEnc / QSVEnc / VCEEnc / x265guiEx / svtAV1guiEx / ffmpegOut)を含みます。出るのは:

> ダウンロードされたファイルは破損しています。再ダウンロードしますか？

**ファイルは壊れていません。** 再ダウンロードしても同じ結果になります。

## 原因

`downloadURLs` は `releases/latest`(**常に上流の最新**)を指す一方、integrity は `latestVersion`(**apm-data が記録した固定の版**)で引いています。apm-data が上流に追いつかなくなった瞬間、この 2 つは別物を指します。

apm-data v3(285 パッケージ)を取得し、GitHub API で上流の最新タグと突き合わせた結果:

| | 件数 |
| --- | --- |
| `downloadURLs[0]` が `releases/latest` | 74 |
| うち `latestVersion` 一致 release に `integrity.archive` あり | 64 |
| **上流のタグと食い違っている** | **13** |

13 件とも `directURL` を持たない(apm-data 全体で `directURL` は 2 件だけ)ので、全部ブラウザ手動 DL 経路です。[#2385](https://github.com/team-apm/apm/pull/2385)(2026-08-20 マージ)が検証をこの経路へ広げるまでは無検証で通っていました。`git tag --contains` で確認すると、このマージコミットを含むタグは **v3.14.0 のみ**です。

**#2385 が悪かったわけではありません。** あれは実在の穴を塞いだ正しい判断で、露出したのはその下にあった設計の食い違い — 動く URL に固定ハッシュを当てている、という点です。

## 変更

apm は「壊れている」と「新しすぎる」を区別できません。`releases` は `version` と `integrity` しか持たず、落ちてきたファイルがどの版かを判定する材料がないためです。**断定をやめて、ユーザーに選ばせます。**

```
ダウンロードしたファイルが、apm に登録されているものと一致しません。

配布元で新しい版が公開され、apm のデータが追いついていない可能性があります。
ファイルが壊れている、または別のファイルをダウンロードした可能性もあります。

  [再ダウンロード]  [このままインストール]  [中止]
```

| ボタン | 動き |
| --- | --- |
| 再ダウンロード(既定) | アーカイブを捨てて同じ URL を開き直す。従来の「はい」 |
| このままインストール | **検証を抜けて配置へ進む(新規)**。`log.warn` に URL を残す |
| 中止 | アーカイブを捨てて `corrupt` を返す。従来の「いいえ」 |

**アーカイブの削除は「このままインストール」の後ろへ移しました。** 続行を選んだファイルを消してしまうと配置できません(これが #2454 に積んでいる理由です)。

## corrupt の意味が変わります

「ファイルが壊れている」→「不一致でユーザーが中止した」。renderer の文言を合わせました。

| 場所 | 変更後 |
| --- | --- |
| `PackageActions.tsx` | ファイルが一致しないため中止しました。 |
| `ProgramRow.tsx` | 同上 |
| `BatchInstallButton.tsx` | `The archive does not match the integrity.`(内部) |

ステータス名 `corrupt` 自体は変えていません。型と分岐を横断する構造変更になるので分けます。

## テスト

- **integrity 不一致でも「このままインストール」を選べば続行する** — 新規。修正前は `corrupt` になって落ちます。アーカイブが削除されずに展開先へ移ること、再ダウンロードが走らないことも確認
- 既存の 2 件(`packages.test.ts` / `core.test.ts`)は「再ダウンロードを断ると corrupt」→「**中止を選ぶと** corrupt」に更新。ボタン番号が 1 → 2 に変わります
- `electron-log` のモックに `warn` を追加(3 ファイル)

## これで十分ではありません

これは**出血を止めるだけ**です。ハッシュ検証は上流が更新されるたび自動的に無意味になり続けます。恒久策は `packages` の `releases[]` に `core` と同じ `url` を足し、integrity を「**その url のアーカイブ**のハッシュ」と定義しなおすことですが、apm-schema と apm-data の変更を伴います。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。

