### PR TITLE
fix(renderer): 検索が短い語で無関係なパッケージを巻き込まないようにする

### DIFF
--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,0 +1,80 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { serveFixtures, writeDataSet } from './fixtures';
+import { expect, getMainWindow, test } from './helpers';
+
+/**
+ * Builds a package entry for the fixture data set.
+ * @param {string} id - The package id.
+ * @param {string} name - The display name.
+ * @param {string} baseUrl - The base URL of the fixtures server.
+ * @returns {object} The package entry.
+ */
+function pkg(id: string, name: string, baseUrl: string) {
+  return {
+    id,
+    name,
+    overview: 'E2E テスト用',
+    description: 'Playwright の検索フロー検証用。',
+    developer: 'apm-e2e',
+    // 検索の巻き込みを再現するため実在しない https の URL を使う
+    // (表示と検索にしか使われないので到達性は要らない)
+    pageURL: `https://example.com/${id}`,
+    downloadURLs: [`${baseUrl}/files/dummy.zip`],
+    latestVersion: '1.0.0',
+    files: [{ filename: `${id.split('/')[1]}.auf` }],
+  };
+}
+
+test('検索が 3 文字の語で無関係なパッケージを巻き込まない', async ({
+  cleanup,
+  launchApp,
+}) => {
+  const workDir = mkdtempSync(path.join(tmpdir(), 'apm-e2e-'));
+  cleanup(() => rmSync(workDir, { recursive: true, force: true }));
+  const fixturesDir = path.join(workDir, 'fixtures');
+  const installationPath = path.join(workDir, 'aviutl');
+  mkdirSync(installationPath, { recursive: true });
+
+  const { baseUrl, close } = await serveFixtures(fixturesDir);
+  cleanup(close);
+  writeDataSet(fixturesDir, {
+    packages: [
+      pkg('e2e/alpha', 'E2E アルファ', baseUrl),
+      pkg('e2e/beta', 'E2E ベータ', baseUrl),
+    ],
+  });
+
+  const app = await launchApp({
+    config: {
+      dataVersion: '3',
+      installationPath,
+      dataURL: { main: `${baseUrl}/`, extra: '' },
+    },
+  });
+  const window = await getMainWindow(app);
+  await expect(window.locator('#installation-path')).toHaveValue(
+    installationPath,
+    { timeout: 120_000 },
+  );
+
+  await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();
+  const rows = window.locator('#packages-list li');
+  await expect(rows).toHaveCount(2, { timeout: 120_000 });
+
+  const search = window.getByLabel('検索 / 共有');
+
+  // どのパッケージにも 'psd' は含まれない。pageURL の 'https:' を
+  // 誤字許容で引くと 2 件とも残ってしまう
+  await search.fill('psd');
+  await expect(rows).toHaveCount(0);
+
+  // 名前での検索は従来どおり効く
+  await search.fill('アルファ');
+  await expect(rows).toHaveCount(1);
+
+  // 打ち間違いの許容は残っている(ベータ → べーた ではなく 1 文字違い)
+  await search.fill('');
+  await expect(rows).toHaveCount(2);
+});

--- a/src/renderer/main/packages/PackagesTab.tsx
+++ b/src/renderer/main/packages/PackagesTab.tsx
@@ -18,7 +18,7 @@ import {
   Spinner,
 } from 'react-bootstrap';
 import { compareVersion } from '../../../shared/compareVersion';
-import { matchesFuzzyFilter } from '../../../shared/fuzzySearch';
+import { matchesSearchFilter } from '../../../shared/fuzzySearch';
 import { parsePackageType, states } from '../../../shared/packageDisplay';
 import {
   computeShareStringAlerts,
@@ -30,9 +30,20 @@ import { getInstallationPath } from '../installationPath';
 import PackageActions, { type SelectedEntry } from './PackageActions';
 import { getPhase, subscribePhase } from './packagesListCheck';
 
-// list.js(fuzzySearch)に合わせた検索オプション。
-// Ensure that searches are performed even on long strings.
-const fuzzyOptions = { distance: 10000 };
+// list.js から引き継いだ distance: 10000 は bitap のスコアから位置の項を
+// 実質消し、誤字率だけで判定させる(長文の末尾でも引けるようにするため)。
+// 抑制項が無くなるぶん短い語の誤字許容が効きすぎるので、誤字数の上限を
+// 語の長さから決めて釣り合わせる。4 文字で 1 誤字、3 文字なら 0 誤字
+const searchOptions = { distance: 10000, charsPerError: 4 };
+
+// 部分一致だけで引く列。長くて情報密度が低く、誤字許容で引くと無関係な
+// 行まで一致する。実測では "psd" が pageURL の "https:" に 1 誤字で当たり、
+// 285 件中 277 件(97%)がヒットしていた
+const SUBSTRING_ONLY_COLUMNS = new Set([
+  'description',
+  'pageURL',
+  'dependencyInformation',
+]);
 
 type WebpageItem = Scripts['webpage'][number];
 
@@ -270,9 +281,19 @@ function PackagesTab(): JSX.Element {
         parsedShareString.packages.includes(values.packageID.toLowerCase()),
       );
     } else if (searchString) {
-      result = result.filter(({ values }) =>
-        matchesFuzzyFilter(Object.values(values), searchString, fuzzyOptions),
-      );
+      result = result.filter(({ values }) => {
+        const fuzzy: string[] = [];
+        const substring: string[] = [];
+        for (const [column, value] of Object.entries(values)) {
+          (SUBSTRING_ONLY_COLUMNS.has(column) ? substring : fuzzy).push(value);
+        }
+        return matchesSearchFilter(
+          fuzzy,
+          substring,
+          searchString,
+          searchOptions,
+        );
+      });
     }
 
     const direction = sort.order === 'asc' ? 1 : -1;

--- a/src/shared/fuzzySearch.test.ts
+++ b/src/shared/fuzzySearch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { fuzzyMatch, matchesFuzzyFilter } from './fuzzySearch';
+import { fuzzyMatch, matchesSearchFilter } from './fuzzySearch';
 
 // Plugins タブの一覧は list.js の fuzzySearch({ distance: 10000 })で
 // 検索していた。React 化後も同じ挙動になるよう特性化する
@@ -34,23 +34,76 @@ describe('fuzzyMatch', () => {
   });
 });
 
-describe('matchesFuzzyFilter', () => {
-  const values = ['patch.aul', 'nazono', 'バグ修正やパフォーマンス改善'];
+describe('誤字数の上限(charsPerError)', () => {
+  const strict = { ...options, charsPerError: 4 };
+
+  it('3 文字のクエリは誤字を許さない', () => {
+    expect(fuzzyMatch('lsd', 'psd', options)).toBe(true);
+    expect(fuzzyMatch('lsd', 'psd', strict)).toBe(false);
+  });
+
+  it('3 文字でも完全に含まれていればマッチする', () => {
+    expect(fuzzyMatch('psdtoolkit', 'psd', strict)).toBe(true);
+  });
+
+  it('7 文字なら 1 誤字を許す', () => {
+    expect(fuzzyMatch('easymp4', 'easymp3', strict)).toBe(true);
+  });
+
+  it('長い文字列の末尾でも引ける(distance 10000 の意図は保つ)', () => {
+    const longText =
+      'この文章はとても長い概要文でありその末尾のほうに キーワード が含まれている'.toLowerCase();
+    expect(fuzzyMatch(longText, 'キーワード', strict)).toBe(true);
+  });
+});
+
+describe('matchesSearchFilter', () => {
+  const fuzzy = ['patch.aul', 'nazono'];
+  const substring = [
+    'バグ修正やパフォーマンス改善',
+    'https://example.com/patch',
+  ];
 
   it('いずれかの列にマッチすれば残る', () => {
-    expect(matchesFuzzyFilter(values, 'patch', options)).toBe(true);
+    expect(matchesSearchFilter(fuzzy, substring, 'patch', options)).toBe(true);
   });
 
   it('大文字小文字を区別しない', () => {
-    expect(matchesFuzzyFilter(values, 'PATCH', options)).toBe(true);
+    expect(matchesSearchFilter(fuzzy, substring, 'PATCH', options)).toBe(true);
   });
 
   it('空白区切りの全ての語がどこかの列にマッチする必要がある', () => {
-    expect(matchesFuzzyFilter(values, 'patch nazono', options)).toBe(true);
-    expect(matchesFuzzyFilter(values, 'patch zzzzzzzzz', options)).toBe(false);
+    expect(matchesSearchFilter(fuzzy, substring, 'patch nazono', options)).toBe(
+      true,
+    );
+    expect(
+      matchesSearchFilter(fuzzy, substring, 'patch zzzzzzzzz', options),
+    ).toBe(false);
+  });
+
+  it('語ごとに fuzzy 列と部分一致列のどちらでマッチしてもよい', () => {
+    // 'nazono' は fuzzy 列、'バグ修正' は部分一致列にしかない
+    expect(
+      matchesSearchFilter(fuzzy, substring, 'nazono バグ修正', options),
+    ).toBe(true);
+  });
+
+  it('部分一致列は誤字を許さない', () => {
+    // 'ﾊﾞｸﾞ' のような表記ゆれや 1 文字違いは部分一致列では拾わない
+    expect(matchesSearchFilter([], substring, 'バグ修正', options)).toBe(true);
+    expect(matchesSearchFilter([], substring, 'バク修正', options)).toBe(false);
+  });
+
+  it('URL を部分一致列へ回せば短い語が https に巻き込まれない', () => {
+    // 実データではこれで "psd" が 285 件中 277 件 → 3 件になった
+    const url = ['https://github.com/oov/aviutl_gcmzdrops'];
+    expect(matchesSearchFilter(url, [], 'psd', options)).toBe(true);
+    expect(matchesSearchFilter([], url, 'psd', options)).toBe(false);
   });
 
   it('どの列にもマッチしなければ残らない', () => {
-    expect(matchesFuzzyFilter(values, 'qqqqqqqq', options)).toBe(false);
+    expect(matchesSearchFilter(fuzzy, substring, 'qqqqqqqq', options)).toBe(
+      false,
+    );
   });
 });

--- a/src/shared/fuzzySearch.ts
+++ b/src/shared/fuzzySearch.ts
@@ -6,6 +6,11 @@ export type FuzzyOptions = {
   location?: number;
   distance?: number;
   threshold?: number;
+  /**
+   * 1 誤字を許すのに必要な文字数。3 なら 3 文字で 0 誤字、4 文字で 1 誤字。
+   * 未指定なら list.js と同じく threshold だけで決まる。
+   */
+  charsPerError?: number;
 };
 
 /**
@@ -23,6 +28,12 @@ export function fuzzyMatch(
   const matchLocation = options.location ?? 0;
   const matchDistance = options.distance ?? 100;
   const matchThreshold = options.threshold ?? 0.4;
+  // 許容する誤字数の上限。threshold を下げる方法は採れない —
+  // scoreThreshold には proximity / distance が乗るので、0 にすると
+  // 位置 0 以外の完全一致まで落ちてしまう。bitap のループ上限を直接縛る
+  const maxErrors = options.charsPerError
+    ? Math.floor(pattern.length / options.charsPerError)
+    : pattern.length - 1;
 
   if (pattern === text) return true; // Exact match
   if (pattern.length > 32) return false; // This algorithm cannot be used
@@ -60,7 +71,7 @@ export function fuzzyMatch(
 
   let binMax = pattern.length + text.length;
   let lastRd: number[] = [];
-  for (let d = 0; d < pattern.length; d++) {
+  for (let d = 0; d < pattern.length && d <= maxErrors; d++) {
     let binMin = 0;
     let binMid = binMax;
     while (binMin < binMid) {
@@ -110,22 +121,30 @@ export function fuzzyMatch(
 }
 
 /**
- * Returns whether the search string fuzzy-matches any of the column values.
- * list.js の multiSearch と同一の挙動: 検索文字列を空白で分割し、すべての
- * 語がいずれかの列にマッチする行だけが残る。大文字小文字は区別しない。
- * @param {string[]} values - The column values of a row.
+ * Returns whether the search string matches a row.
+ * list.js の multiSearch と同じく、検索文字列を空白で分割してすべての語が
+ * どこかの列にマッチする行だけを残す。大文字小文字は区別しない。
+ * 列を 2 群に分けているのは、長くて情報密度の低い列(説明文・URL)を
+ * 誤字許容で引くと無関係な行まで一致してしまうため。語ごとに
+ * 「fuzzy 列のどれか、または部分一致列のどれか」で判定する。
+ * @param {string[]} fuzzyValues - Column values matched with typo tolerance.
+ * @param {string[]} substringValues - Column values matched by substring only.
  * @param {string} searchString - The search string.
- * @param {FuzzyOptions} [options] - Matching options (same as list.js).
+ * @param {FuzzyOptions} [options] - Matching options for the fuzzy columns.
  * @returns {boolean} `true` if every word matches at least one column.
  */
-export function matchesFuzzyFilter(
-  values: string[],
+export function matchesSearchFilter(
+  fuzzyValues: string[],
+  substringValues: string[],
   searchString: string,
   options: FuzzyOptions = {},
 ) {
   const words = searchString.toLowerCase().replace(/ +$/, '').split(/ +/);
-  const lowerValues = values.map((v) => String(v).toLowerCase());
-  return words.every((word) =>
-    lowerValues.some((value) => fuzzyMatch(value, word, options)),
+  const lowerFuzzy = fuzzyValues.map((v) => String(v).toLowerCase());
+  const lowerSubstring = substringValues.map((v) => String(v).toLowerCase());
+  return words.every(
+    (word) =>
+      lowerFuzzy.some((value) => fuzzyMatch(value, word, options)) ||
+      lowerSubstring.some((value) => value.includes(word)),
   );
 }


### PR DESCRIPTION
issue #1223「検索ボックスの改善」の原因を特定して直します。

## 測りました

実データ 285 件を実コード(`matchesFuzzyFilter` + `PackagesTab` と同じ `{ distance: 10000 }`)に通した結果です。

| クエリ | 現状 | この PR | 部分一致なら |
| --- | --- | --- | --- |
| `psd` | **277**(97%) | 3 | 3 |
| `aac` | **176** | 0 | 0 |
| `patch` | **149** | 9 | 6 |
| `lua` | **102** | 4 | 4 |
| `LSMASH` | 26 | 8 | 8 |
| `x264` | 10 | 8 | 3 |
| `エンコード` | 12 | 11 | 11 |
| `テキスト` | 11 | 11 | 11 |
| `easymp3` | 2 | **1** | 0 |

`psd` は 285 件中 **277 件**にヒットします。うち **272 件は `pageURL` 単独**で一致していました。

## なぜそうなるか

すべての URL が `https:` を含みます。3 文字パターンの許容誤字は `floor(0.4 × 3) = 1` なので、`ps:` が `psd` に 1 誤字で一致します。実データの `pageURL` は 285 件中 272 件が `https:`(残り 13 件が `http:`)で、この数字がそのままヒット数になっていました。

抑制項が消えた経緯も辿れました。`distance: 10000` は **09115d66(2022-02、feat: precise automatic installation of the scripts)** で list.js に付いたもので、コミット内のコメントは

```js
// Ensure that searches are performed even on long strings.
```

bitap のスコアは `accuracy + proximity / distance` なので、distance を大きくすると**位置の項が実質消え、誤字率だけが残ります**。「長文も検索対象にする」ために唯一の抑制項を捨てたのが真因で、React 移植で生まれたものではありません(移植は忠実です)。

## 変更

### 1. 誤字を許して引く列と、部分一致だけで引く列を分ける

`description` / `pageURL` / `dependencyInformation` を後者へ回します。長くて情報密度が低く、誤字許容で引く意味がありません。**語ごとに**どちらかでマッチすればよい形なので、`nazono バグ修正` のように fuzzy 列と部分一致列にまたがる検索も通ります。

### 2. 誤字数の上限を語の長さから決める(`charsPerError`)

4 文字で 1 誤字、3 文字なら 0 誤字。

`threshold` を下げる方法は**採れません**。`scoreThreshold` には `proximity / distance` が乗るので、0 にすると**位置 0 以外の完全一致まで落ちます**。bitap のループ上限(`d`)を直接縛っています。

`charsPerError` を渡さなければ従来どおりの挙動なので、`fuzzyMatch` の既定は変わりません。

## テスト

**ユニット**(`fuzzySearch.test.ts`、+7 件)

- 3 文字のクエリは誤字を許さない / 完全に含まれていればマッチする
- 7 文字なら 1 誤字を許す(`easymp3` → `easymp4`)
- 長い文字列の末尾でも引ける(`distance: 10000` の意図は保つ)
- 語ごとに fuzzy 列と部分一致列のどちらでマッチしてもよい
- URL を部分一致列へ回せば短い語が `https` に巻き込まれない

**E2E**(`e2e/search.spec.ts`、新規)

どちらの package にも `psd` を含まない 2 件を出し、`pageURL` を `https://` にして検索します。**列の振り分けという配線はユニットテストでは見られない**(`vitest` の environment が `node` で React を描画できない)ので、ここは E2E の担当です。

| | `psd` で残る件数 |
| --- | --- |
| 修正前 | 2 |
| 修正後 | **0** |

手元(macOS)で `yarn package` → `playwright test` を修正前後それぞれで実行して確認しました。修正後は既存 5 件を含む 6 件すべて green です。

## 触っていないもの

`matchesFuzzyFilter` を `matchesSearchFilter` に置き換えました(呼び出し元は 1 箇所)。列の振り分けは `PackagesTab` 側の定数に置いてあるので、後から変えるのは 1 行です。

「更新のあるパッケージだけ絞り込む」「最終更新日で並び替える」(#404 / #1045)は別の話なので入れていません。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
