### PR TITLE
fix(main): ドットを含むパッケージ ID の導入記録が壊れる問題を修正する

### DIFF
--- a/src/main/Ledger.test.ts
+++ b/src/main/Ledger.test.ts
@@ -170,18 +170,47 @@ describe('Ledger', () => {
       expect((await readJson(jsonPath)).packages).toEqual({});
     });
 
-    it('ドットを含むパッケージ ID はネストしたキーとして解釈される(dot-prop 由来の現行仕様)', async () => {
+    it('ドットを含むパッケージ ID をそのままキーにする', async () => {
       const installationPath = await makeInstPath();
       const ledger = await Ledger.load(installationPath);
 
       await ledger.addPackage('author/plugin.en', 'v1.0.0');
 
-      // packages['author/plugin.en'] ではなく packages['author/plugin'].en になる
       expect(await ledger.get('packages')).toEqual({
-        'author/plugin': {
-          en: { id: 'author/plugin.en', version: 'v1.0.0' },
-        },
+        'author/plugin.en': { id: 'author/plugin.en', version: 'v1.0.0' },
       });
+      expect(await ledger.hasPackage('author/plugin.en')).toBe(true);
+      // 読み出し側は packages をフラットな Record として引く
+      expect(
+        ((await ledger.get('packages')) as Record<string, unknown>)[
+          'author/plugin.en'
+        ],
+      ).toBeDefined();
+    });
+
+    it('ドットを含む ID と含まない ID が同居しても互いを壊さない', async () => {
+      const installationPath = await makeInstPath();
+      const ledger = await Ledger.load(installationPath);
+
+      await ledger.addPackage('author/plugin.en', 'v1.0.0');
+      await ledger.addPackage('author/plugin', 'v2.0.0');
+
+      // パス経由だと addPackage('author/plugin') が
+      // packages['author/plugin'] を丸ごと置き換えて前者を消していた
+      expect(await ledger.get('packages')).toEqual({
+        'author/plugin.en': { id: 'author/plugin.en', version: 'v1.0.0' },
+        'author/plugin': { id: 'author/plugin', version: 'v2.0.0' },
+      });
+    });
+
+    it('ドットを含む ID を削除しても空オブジェクトのゴミを残さない', async () => {
+      const installationPath = await makeInstPath();
+      const ledger = await Ledger.load(installationPath);
+
+      await ledger.addPackage('author/plugin.en', 'v1.0.0');
+      await ledger.removePackage('author/plugin.en');
+
+      expect(await ledger.get('packages')).toEqual({});
     });
   });
 

--- a/src/main/Ledger.ts
+++ b/src/main/Ledger.ts
@@ -201,12 +201,53 @@ class Ledger {
   }
 
   /**
+   * Returns the packages record, creating it when the loaded `apm.json`
+   * does not have one.
+   * dot-prop の setProperty は途中の階層を作るので、パス経由だったころは
+   * 暗黙に作られていた。キーを直接触るならここで面倒を見る。
+   * @returns {LedgerObject['packages']} The packages record.
+   */
+  private packagesRecord(): LedgerObject['packages'] {
+    this.object.packages ??= {};
+    return this.object.packages;
+  }
+
+  /**
+   * Records the change: defers the write inside a transaction, writes
+   * immediately otherwise.
+   * @param {boolean} changed - Whether the object actually changed.
+   */
+  private async recordChange(changed: boolean) {
+    if (this.inTransaction) {
+      if (changed) this.dirty = true;
+    } else {
+      await this.save();
+    }
+  }
+
+  /**
+   * Checks whether the package is recorded in `apm.json`.
+   * @param {string} id - The ID of the package
+   * @returns {Promise<boolean>} Whether the package is recorded.
+   */
+  public async hasPackage(id: string): Promise<boolean> {
+    return Object.hasOwn(this.packagesRecord(), id);
+  }
+
+  /**
    * Adds the information of the package to `apm.json`.
+   * パッケージ ID を dot-prop のパスとして渡さないのは、ID に '.' が
+   * 含まれると packages['a/b'].c のようにネストして書かれるため。
+   * 読み出し側(resolveInstallationStatus)は packages をフラットな
+   * Record として引くので、記録したのに未インストール判定になる。
+   * apm-schema の id は '.' を許さないが、dataURL は自由入力(確定方針)
+   * なので schema 非準拠の ID は到達しうる。
    * @param {string} id - The ID of the package
    * @param {string} version - The version of the package
    */
   public async addPackage(id: string, version: string) {
-    await this.set(`packages.${id}`, { id, version });
+    this.packagesRecord()[id] = { id, version };
+    await this.recordChange(true);
   }
 
   /**
@@ -214,7 +255,10 @@ class Ledger {
    * @param {string} id - The ID of the package
    */
   public async removePackage(id: string) {
-    await this.delete(`packages.${id}`);
+    const packages = this.packagesRecord();
+    const existed = Object.hasOwn(packages, id);
+    if (existed) delete packages[id];
+    await this.recordChange(existed);
   }
 }
 

--- a/src/main/services/packageList.ts
+++ b/src/main/services/packageList.ts
@@ -369,7 +369,8 @@ export function getPackagesDates(
 
 /**
  * Returns the subset of the given package ids recorded in the ledger.
- * 旧 displayNicommonsIdList の apmJson.has('packages.' + id) 判定と同一の挙動
+ * 旧 displayNicommonsIdList の apmJson.has('packages.' + id) 判定に相当する
+ * (ID をパスとして渡さないので '.' を含む ID でも正しく引ける)
  * (dot-prop のパス解釈に依存するため判定ごと main 側で行う)。
  * @param {Installation} inst - The target installation.
  * @param {string[]} ids - Package ids to check.
@@ -379,7 +380,7 @@ export async function getLedgerInstalledIds(inst: Installation, ids: string[]) {
   const ledger = await inst.ledger();
   const result: string[] = [];
   for (const id of ids) {
-    if (await ledger.has('packages.' + id)) result.push(id);
+    if (await ledger.hasPackage(id)) result.push(id);
   }
   return result;
 }


### PR DESCRIPTION
## 症状

**ID に `.` を含むパッケージは、インストールしても一覧が「未インストール」のまま**になります。さらに、同じデータに `a/b` と `a/b.c` の両方があると、**`a/b` を入れた時点で `a/b.c` の記録が消えます**。

## 原因

`Ledger` の 3 箇所が ID を dot-prop の**パス**として渡しています。

```ts
await this.set(`packages.${id}`, { id, version });     // addPackage
await this.delete(`packages.${id}`);                   // removePackage
await ledger.has('packages.' + id);                    // getLedgerInstalledIds
```

`id` が `author/plugin.en` だと、書かれるのは

```json
{ "packages": { "author/plugin": { "en": { "id": "author/plugin.en", "version": "v1.0.0" } } } }
```

読み出し側の `resolveInstallationStatus` は `packages` を**フラットな Record** として引き、`getInstalledVersionOfPackage` が `ledgerPackages[p.id]` を見るので、この形は見つかりません。

派生:

- `addPackage('author/plugin')` は `packages['author/plugin']` を丸ごと置き換えるので、**`author/plugin.en` の記録を消します**
- `removePackage('author/plugin.en')` は `packages['author/plugin'] = {}` という空オブジェクトを残します

## 到達経路

apm-schema の `id` は `^[a-zA-Z0-9]+/[a-zA-Z0-9]+$` で `.` を許しません。ただし **apm は取得したデータをこのパターンで検証していません**。dataURL の自由入力は AGENTS.md の確定方針なので、schema 非準拠の ID は到達しうる入力です。

具体的には、`{installationPath}/packages.json`(自作パッケージの検証)やサードパーティの dataURL に `id: 'foo/bar.v2'` を書けば踏みます。

## 修正

パス経由をやめてキーを直接操作します。あわせて `hasPackage` を足しました — `'packages.' + id` という同じ経路を `getLedgerInstalledIds` も通っていたためです。

トランザクション中の遅延書き込み・即時書き込みの振り分けは `recordChange` に切り出して、既存の `set` / `delete` と同じ扱いを保っています(`add` は常に dirty、`remove` は実際に消えたときだけ dirty)。

`packagesRecord()` で `packages` が無いときに作っているのは、dot-prop の `setProperty` が途中の階層を作るので**パス経由だったころは暗黙に作られていた**ためです。

## テスト

現行仕様として固定してあった「ドットを含むパッケージ ID はネストしたキーとして解釈される(dot-prop 由来の現行仕様)」を、**直った後の挙動**に置き換えました。あわせて 2 件追加しています。

- ドットを含む ID と含まない ID が同居しても互いを壊さない
- ドットを含む ID を削除しても空オブジェクトのゴミを残さない

修正前は 3 件とも落ちます。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
