### PR TITLE
refactor(shared): 参照されていない pathRelated を削除する

### DIFF
--- a/src/shared/apmPath.test.ts
+++ b/src/shared/apmPath.test.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { isParent, pathRelated, resolveInside } from './apmPath';
+import { isParent, resolveInside } from './apmPath';
 
 describe('isParent', () => {
   it('returns true for a direct child path', () => {
@@ -18,21 +18,6 @@ describe('isParent', () => {
     const parent = path.join('/data', 'apm');
     const sibling = path.join('/data', 'other', 'file.json');
     expect(isParent(parent, sibling)).toBe(false);
-  });
-});
-
-describe('pathRelated', () => {
-  it('returns true when either path is a parent of the other', () => {
-    const parent = path.join('/data', 'apm');
-    const child = path.join('/data', 'apm', 'list.json');
-    expect(pathRelated(parent, child)).toBe(true);
-    expect(pathRelated(child, parent)).toBe(true);
-  });
-
-  it('returns false for unrelated paths', () => {
-    const pathA = path.join('/data', 'apm');
-    const pathB = path.join('/other', 'apm');
-    expect(pathRelated(pathA, pathB)).toBe(false);
   });
 });
 

--- a/src/shared/apmPath.ts
+++ b/src/shared/apmPath.ts
@@ -12,16 +12,6 @@ export function isParent(parent: string, child: string) {
 }
 
 /**
- * Determine if two paths have a parent-child relationship.
- * @param {string} pathA - A path
- * @param {string} pathB - A path
- * @returns {boolean} - Boolean value
- */
-export function pathRelated(pathA: string, pathB: string) {
-  return isParent(pathA, pathB) || isParent(pathB, pathA);
-}
-
-/**
  * Resolves a path under {parent}, rejecting anything that escapes it.
  *
  * パッケージデータのファイル名・フォルダ名はリモート由来なので、結合結果が


### PR DESCRIPTION
## 内容

`pathRelated` は `src/` にも `e2e/` にも呼び出しがありません(`git grep` で `apmPath.test.ts` のテストのみ)。`isParent` の対称版という道具立てだけが残っている状態です。

```ts
export function pathRelated(pathA: string, pathB: string) {
  return isParent(pathA, pathB) || isParent(pathB, pathA);
}
```

テストもろとも削除します。2 行の関数なので、必要になったら git 履歴から戻せます。

`isParent` はそのままです(6 箇所の関門で使われています)。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
