### PR TITLE
fix(main): パッケージ ID を展開先パスに使う前に検証する

### DIFF
--- a/src/main/api/packages.ts
+++ b/src/main/api/packages.ts
@@ -1,5 +1,6 @@
 import {
   isHttpUrl,
+  isSafeRelativePath,
   validatePackageInfo,
 } from '../../shared/packageInfoValidation';
 import {
@@ -50,6 +51,9 @@ const packageStateInput = (
   const { id, info } = value as Record<string, unknown>;
   if (typeof id !== 'string' || typeof info !== 'object' || info === null)
     throw new TypeError('id is expected to be a string and info an object.');
+  // id は展開先フォルダ名になるため、files[].filename と同じ関門を通す
+  if (!isSafeRelativePath(id))
+    throw new TypeError('id is expected to be a safe relative path.');
   // renderer は非信頼。パス・コマンド・URL に到達するフィールドはここで検証する
   return { id, info: validatePackageInfo(info) };
 };

--- a/src/main/services/packageInstall.ts
+++ b/src/main/services/packageInstall.ts
@@ -3,7 +3,7 @@ import log from 'electron-log/main';
 import { existsSync, readdir as fsReaddir, mkdir, rename } from 'fs-extra';
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
-import { isParent } from '../../shared/apmPath';
+import { isParent, resolveInside } from '../../shared/apmPath';
 import { install, verifyFilesByCount } from '../../shared/install';
 import { buildInstallerArgs } from '../../shared/installerArgs';
 import unzip from '../../shared/unzip';
@@ -50,7 +50,12 @@ export async function installPackageArchive(
         return await unzip(archivePath, packageState.id);
       } else {
         // In this line, path.dirname(archivePath) always refers to the 'Data/package' folder.
-        const newFolder = path.join(path.dirname(archivePath), packageState.id);
+        // packageState.id はリモート由来なので、展開経路(unzip)と同じく
+        // データフォルダの外を指していないか確かめてから作る
+        const newFolder = resolveInside(
+          path.dirname(archivePath),
+          packageState.id,
+        );
         await mkdir(newFolder, { recursive: true });
         await rename(
           archivePath,

--- a/src/shared/unzip.test.ts
+++ b/src/shared/unzip.test.ts
@@ -78,6 +78,42 @@ describe('unzip', () => {
     expect(targetPath).toBe(path.join(dir, 'fixture'));
     expect(await pathExists(path.join(targetPath, 'hello.txt'))).toBe(true);
   }, 30000);
+
+  it('展開先の外へ出る folderName を拒否して展開しない', async () => {
+    // 脱出先も後片付けの対象に入るよう、掃除される root の内側に置く
+    const root = await mkdtemp(path.join(os.tmpdir(), 'apm-unzip-'));
+    tempDirs.push(root);
+    const dir = path.join(root, 'inner');
+    await ensureDir(dir);
+    const zipPath = await createZipFixture(dir);
+    const outside = path.join(root, 'escaped');
+
+    await expect(unzip(zipPath, path.join('..', 'escaped'))).rejects.toThrow(
+      /invalid path/,
+    );
+    expect(await pathExists(outside)).toBe(false);
+  }, 30000);
+
+  it('Data フォルダ配下では 1 階層上を基点にしつつ、その外へは出さない', async () => {
+    // 実運用の配置(userData/Data/package/archive/x.zip)を模す。
+    // getTargetPath は基点を Data/package に取るので、'..' 付きの
+    // folderName は Data から外れる前に弾かれる
+    const root = await mkdtemp(path.join(os.tmpdir(), 'apm-unzip-'));
+    tempDirs.push(root);
+    const archiveDir = path.join(root, 'Data', 'package', 'archive');
+    await ensureDir(archiveDir);
+    const zipPath = await createZipFixture(archiveDir);
+
+    const targetPath = await unzip(zipPath, 'author/plugin');
+    expect(targetPath).toBe(
+      path.join(root, 'Data', 'package', 'author', 'plugin'),
+    );
+
+    await expect(
+      unzip(zipPath, path.join('..', '..', 'escaped')),
+    ).rejects.toThrow(/invalid path/);
+    expect(await pathExists(path.join(root, 'escaped'))).toBe(false);
+  }, 60000);
 });
 
 describe('removeSymlinks', () => {

--- a/src/shared/unzip.ts
+++ b/src/shared/unzip.ts
@@ -4,6 +4,7 @@ import { extractFull } from 'node-7z';
 import { chmodSync } from 'node:fs';
 import path from 'node:path';
 import win7zip from 'win-7zip';
+import { resolveInside } from './apmPath';
 
 const isDevEnv = process.env.NODE_ENV === 'development';
 
@@ -52,18 +53,20 @@ export async function removeSymlinks(dir: string) {
  */
 async function unzip(zipPath: string, folderName?: string) {
   const getTargetPath = () => {
-    if (path.resolve(path.dirname(zipPath), '../../').endsWith('Data')) {
-      return path.resolve(
-        path.dirname(zipPath),
-        '../',
-        folderName ?? path.basename(zipPath, path.extname(zipPath)),
-      );
-    } else {
-      return path.resolve(
-        path.dirname(zipPath),
-        folderName ?? path.basename(zipPath, path.extname(zipPath)),
-      );
-    }
+    // folderName はパッケージ ID(リモートのパッケージデータ由来)が渡ってくる。
+    // path.resolve は '..' を素通しするので、基点を明示して resolveInside に
+    // 通す。openPackageFolder が同じ ID に対して既に isParent で守っており、
+    // 展開先だけがこの関門を通っていなかった
+    const base = path.resolve(
+      path.dirname(zipPath),
+      path.resolve(path.dirname(zipPath), '../../').endsWith('Data')
+        ? '../'
+        : '',
+    );
+    return resolveInside(
+      base,
+      folderName ?? path.basename(zipPath, path.extname(zipPath)),
+    );
   };
   const targetPath = getTargetPath();
   const zipStream = extractFull(zipPath, targetPath, {


### PR DESCRIPTION
## 内容

`installPackageArchive` は `packageState.id` をそのまま展開先フォルダ名に使っています。

```ts
return await unzip(archivePath, packageState.id);
// 非アーカイブ拡張子の場合
const newFolder = path.join(path.dirname(archivePath), packageState.id);
```

`unzip` の `getTargetPath` は `path.resolve` で組み立てるだけで、**`resolveInside` を通していません**。

同じ `packageId` を扱う `openPackageFolder` には既にガードがあります。

```ts
// packageId はリモート由来のため、データフォルダ外は拒否する
if (!isParent(dataDir, folderPath)) { … }
```

**展開先だけがこの関門を通っていませんでした。**

## 変更

既存の防御線に載せます。AGENTS.md が「境界で守るのはパス・コマンド・URL に到達するフィールドだけで、形の細部はサービス層(`resolveInside` / `safeRemove` / `execFileSync`)が二重に守る」と書いている設計に沿った形です。

| 場所 | 変更 |
| --- | --- |
| `unzip` | 基点を明示して `resolveInside` を通す |
| `packageInstall` | 非アーカイブ経路も同じ関門へ |
| `packages`(tRPC 境界) | `id` を `isSafeRelativePath` で検証(`files[].filename` 等と同じ扱い) |

`unzip` をファイル単位に作り替えず `resolveInside` を挟むだけにしたのは、`Data` 配下という基点が `zipPath` から決まるためです。基点の取り方(`Data` 配下なら 1 階層上、それ以外はその場)は変えていません。

## テスト

`unzip.test.ts` に 2 件追加しました。

- **展開先の外へ出る folderName を拒否して展開しない** — 修正前は落ちます
- **Data フォルダ配下では 1 階層上を基点にしつつ、その外へは出さない** — 実運用の配置(`userData/Data/package/archive/x.zip`)を模し、基点の取り方が変わっていないことも同時に確認

どちらも脱出先を後片付けの対象内に置いてあるので、テストが外部にファイルを残しません。

## あわせて

これがマージされると、`unzip` の展開先を展開前に掃除する変更(前回のインストールの残骸が新しいインストールに混入する件)も安全に足せるようになります。いまは `targetPath` が関門を通っていないため、`remove()` を足すと「書ける」より危険な「消せる」を無検証のパスに対して行うことになるので保留していました。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
