### PR TITLE
fix(shared): 前回の展開物を残したまま上書き展開しない

### DIFF
--- a/src/shared/unzip.test.ts
+++ b/src/shared/unzip.test.ts
@@ -114,6 +114,25 @@ describe('unzip', () => {
     ).rejects.toThrow(/invalid path/);
     expect(await pathExists(path.join(root, 'escaped'))).toBe(false);
   }, 60000);
+
+  it('前回の展開物を残さない', async () => {
+    // 同じパッケージを更新すると targetPath が再利用される。overwrite だけだと
+    // 旧バージョンにしか無かったファイルが残り、install() のディレクトリコピーで
+    // 新しいインストールへ持ち込まれる
+    const dir = await mkdtemp(path.join(os.tmpdir(), 'apm-unzip-'));
+    tempDirs.push(dir);
+    const zipPath = await createZipFixture(dir);
+    const targetPath = path.join(dir, 'fixture');
+    await ensureDir(path.join(targetPath, 'sub'));
+    await writeFile(path.join(targetPath, 'stale.txt'), 'old version');
+    await writeFile(path.join(targetPath, 'sub', 'nested.txt'), 'old version');
+
+    await unzip(zipPath);
+
+    expect(await pathExists(path.join(targetPath, 'hello.txt'))).toBe(true);
+    expect(await pathExists(path.join(targetPath, 'stale.txt'))).toBe(false);
+    expect(await pathExists(path.join(targetPath, 'sub'))).toBe(false);
+  }, 30000);
 });
 
 describe('removeSymlinks', () => {

--- a/src/shared/unzip.ts
+++ b/src/shared/unzip.ts
@@ -69,6 +69,12 @@ async function unzip(zipPath: string, folderName?: string) {
     );
   };
   const targetPath = getTargetPath();
+  // 展開前に消す。overwrite: 'a' はアーカイブに在るものを上書きするだけで、
+  // 前回の展開物のうち新しいアーカイブに無いファイルは残る。targetPath は
+  // 同じパッケージ・同じアーカイブ名で再利用されるため、残骸が install() の
+  // ディレクトリコピー(isDirectory / isProgram)を通って新しいインストールに
+  // 混入する。resolveInside を通した後なので、消す対象は必ず基点の内側にある
+  await remove(targetPath);
   const zipStream = extractFull(zipPath, targetPath, {
     $bin: pathTo7zip,
     overwrite: 'a',


### PR DESCRIPTION
> **base は `fix/package-id-path-escape`([#2465](https://github.com/team-apm/apm/pull/2465))です。** 理由は下記。#2465 をマージすると自動で main へリターゲットされ、CI が回り直します。

## 内容

`unzip` は `targetPath` を消さずに `overwrite: 'a'` で展開します。**`overwrite` はアーカイブに在るものを上書きするだけ**なので、旧バージョンにしか無かったファイルは残り続けます。

`targetPath` は同じパッケージ(`Data/package/{id}`)・同じアーカイブ名で再利用されるため、残骸は次のインストールに持ち込まれます。

`install()` がファイル単位でコピーする通常経路は列挙されたものしか拾いませんが、

- **`isDirectory` のエントリ**(実データに 55 件)
- **`isProgram`**(展開結果を丸ごとコピー)

は subtree ごと持っていくので、**作者が削除したファイルが AviUtl 側へ再配置されます**。

## なぜ #2465 の上に積むのか

この変更は `remove()` を新しく足します。**`targetPath` が関門を通っていない状態でこれを入れると、「書ける」より取り返しのつかない「消せる」を無検証のパスに対して行うことになります。**

[#2465](https://github.com/team-apm/apm/pull/2465) で `targetPath` が `resolveInside` を通るようになるので、消す対象が必ず基点の内側にあることが保証されます。順序を逆にできません。

## 代償

展開に失敗すると前回の展開物も失われます。アーカイブは `Data/{core,package}/archive` に残っているのでやり直せます。

「壊れた新しい展開物」と「古い展開物が混ざった状態」なら前者のほうが扱いやすい、という判断です。

## テスト

**前回の展開物を残さない** を追加しました。展開先に旧バージョンのファイル(ルート直下とサブディレクトリの両方)を置いてから展開し、消えていることを確認します。修正前は落ちます。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
