### PR TITLE
fix(main): null や配列の apm.json を壊れているものとして扱う

### DIFF
--- a/src/main/Ledger.test.ts
+++ b/src/main/Ledger.test.ts
@@ -73,6 +73,39 @@ describe('Ledger', () => {
         'not a json {{{',
       );
     });
+
+    it('中身が null の apm.json は壊れているものとして扱う', async () => {
+      // typeof null === 'object' なので素通りしていた。素通りすると
+      // dot-prop の setProperty が無言で何もせず、以後の書き込みが
+      // 永久に捨てられる
+      const installationPath = await makeInstPath();
+      await fsPromises.writeFile(Ledger.getPath(installationPath), 'null');
+
+      const ledger = await Ledger.load(installationPath);
+
+      expect(await ledger.get('dataVersion')).toBe('3');
+      // 既定値へ倒れていれば書き込みが効く
+      await ledger.addPackage('author/plugin', '1.0');
+      expect(await ledger.hasPackage('author/plugin')).toBe(true);
+      expect(
+        (await readJson(Ledger.getPath(installationPath))).packages,
+      ).toEqual({ 'author/plugin': { id: 'author/plugin', version: '1.0' } });
+    });
+
+    it('中身が配列の apm.json は壊れているものとして扱う', async () => {
+      // 配列だと setProperty は成功するが JSON.stringify が付加プロパティを
+      // 落とすので、やはり書き込みが毎回失われる
+      const installationPath = await makeInstPath();
+      await fsPromises.writeFile(Ledger.getPath(installationPath), '[]');
+
+      const ledger = await Ledger.load(installationPath);
+
+      expect(await ledger.get('dataVersion')).toBe('3');
+      await ledger.setCore('aviutl', '1.10');
+      expect((await readJson(Ledger.getPath(installationPath))).core).toEqual({
+        aviutl: '1.10',
+      });
+    });
   });
 
   describe('get / has', () => {

--- a/src/main/Ledger.ts
+++ b/src/main/Ledger.ts
@@ -65,9 +65,17 @@ class Ledger {
     this.path = path;
 
     try {
-      const value = await readJson(path);
-      if (typeof value === 'object') {
-        this.object = value;
+      const value: unknown = await readJson(path);
+      // typeof null === 'object' なので null と配列も通ってしまう。通すと
+      // dot-prop の setProperty が無言で何もせず(null)、あるいは
+      // JSON.stringify が付加プロパティを落として(配列)、以後の書き込みが
+      // 永久に捨てられる。壊れたファイルとして既定値へ倒す
+      if (
+        value !== null &&
+        typeof value === 'object' &&
+        !Array.isArray(value)
+      ) {
+        this.object = value as LedgerObject;
       } else {
         throw new Error('Invalid apm.json.');
       }


### PR DESCRIPTION
## 内容

`load()` の判定が `typeof value === 'object'` だけです。**`typeof null === 'object'`** なので `null` がそのまま採用され、配列も通ります。

```ts
const value = await readJson(path);
if (typeof value === 'object') {
  this.object = value;      // ← null や [] がここを通る
} else {
  throw new Error('Invalid apm.json.');
}
```

## 何が起きるか

**`null` の場合**: dot-prop の `setProperty` / `deleteProperty` は先頭で「オブジェクトでなければ何もせず返す」ので、`setCore` も `removePackage` も**例外を出さずに全部捨てられます**。`save()` は `null` を書き戻すだけ。

一度この状態になると、インストールしてもアンインストールしても `apm.json` は永久に `null` のままで、UI は毎回「未インストール」に戻ります。**ログにも何も出ません。**

**配列の場合**: `setProperty` 自体は成功しますが、`JSON.stringify` が配列の付加プロパティを落とすので、やはり書き込みが毎回失われます。

到達経路は手編集・他機からのコピー・生成スクリプトの事故など。

## いまは無言と例外が混在しています

[#2463](https://github.com/team-apm/apm/pull/2463) でパッケージ操作を dot-prop のパスからキーの直接操作へ変えたので、`null` のときは `addPackage` が **TypeError** になるようになりました。`setCore` は今も無言で捨てます。同じ壊れ方に対して 2 通りの反応が返る状態です。

## 修正

どちらも既定値へ倒します(壊れた JSON と同じ扱い)。

## テスト

2 件追加しました。既定値へ倒れたことだけでなく、**そのあとの書き込みが実際にディスクへ届くこと**まで確認しています。修正前は 2 件とも落ちます。

## 触っていないもの

`load()` が壊れたファイルを検知したときに**ユーザーへ知らせない**点は変えていません。「黙って空へ倒す」のをやめて退避 + 通知にするかは設計判断なので分けます([#2458](https://github.com/team-apm/apm/pull/2458) の PR 本文でも同じ整理をしました)。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
