### PR TITLE
refactor(renderer): インストール先をストアの購読へ揃える

### DIFF
--- a/src/renderer/main/aviutl/ProgramRow.tsx
+++ b/src/renderer/main/aviutl/ProgramRow.tsx
@@ -1,9 +1,18 @@
 import type { Core } from 'apm-schema';
-import React, { type JSX, useEffect, useRef, useState } from 'react';
+import React, {
+  type JSX,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import { Dropdown, Spinner } from 'react-bootstrap';
 import { releaseLabel } from '../../../shared/coreVersionText';
 import { TRPCReact } from '../../trpc';
-import { getInstallationPath } from '../installationPath';
+import {
+  getInstallationPath,
+  subscribeInstallationPath,
+} from '../installationPath';
 
 type ButtonPhase = 'idle' | 'loading' | 'success' | 'danger';
 
@@ -29,8 +38,12 @@ function ProgramRow({
   iconClass,
   buttonRoundedClass,
 }: ProgramRowProps) {
-  const [installationPath, setInstallationPath] = useState(() =>
-    getInstallationPath(),
+  // インストール先はストアを購読する。DOM イベント経由で読み直すと、
+  // 通知の発火とストア更新の順序に依存してしまう(起動フローも
+  // SelectInstallationPathButton も setInstallationPath の前後で撃つ)
+  const installationPath = useSyncExternalStore(
+    subscribeInstallationPath,
+    getInstallationPath,
   );
   const [phase, setPhase] = useState<ButtonPhase>('idle');
   const [buttonMessage, setButtonMessage] = useState('');
@@ -46,10 +59,10 @@ function ProgramRow({
   // 通知元(startup / SelectInstallationPathButton / BatchInstallButton /
   // ManualUpdateTable)とは親子関係に無く、タブもまたぐため props でも
   // Context でも届かない。window イベントで受ける
-  // (queryClient への一本化は未着手 — AGENTS.md 落とし穴)
+  // (queryClient への一本化は未着手 — AGENTS.md 落とし穴)。
+  // インストール先そのものはストアの購読で別に追う
   useEffect(() => {
     const listener = () => {
-      setInstallationPath(getInstallationPath());
       void utils.core.getCoreInfo.invalidate();
       void utils.core.getInstalledVersionTexts.invalidate();
     };

--- a/src/renderer/main/monacoEditorRenderer.tsx
+++ b/src/renderer/main/monacoEditorRenderer.tsx
@@ -14,7 +14,10 @@ import type { editor } from 'monaco-editor';
 import React, { useRef } from 'react';
 import { Button, Col, Spinner } from 'react-bootstrap';
 import { TRPCReact } from '../trpc';
-import { getInstallationPath } from './installationPath';
+import {
+  getInstallationPath,
+  subscribeInstallationPath,
+} from './installationPath';
 import { usePhase } from './usePhase';
 
 // beforeMount / onMount が渡してくるのは window.monaco そのもの。一方
@@ -255,10 +258,12 @@ export const MonacoEditorRenderer: React.FC = () => {
       editor,
       monaco.editor.ContentWidgetPositionPreference.EXACT,
     );
-    // インストール先は起動フロー(startup.ts)が installationPath ストアに設定して
-    // apm-core-changed を発火するため、未確定なら確定を待って一度だけ読み込む
-    // (旧 EditorContextBridge の setOnload / setInstPath の両者待ち合わせ相当。
-    // 読み込み失敗を無視するのも旧実装と同じ)
+    // インストール先は起動フロー(startup.ts)が後から設定するため、未確定なら
+    // 確定を待って一度だけ読み込む(旧 EditorContextBridge の setOnload /
+    // setInstPath の両者待ち合わせ相当。読み込み失敗を無視するのも旧実装と同じ)。
+    // apm-core-changed ではなくストアを購読するのは、通知の発火とストア更新の
+    // 順序に依存しないため。あわせて解除経路も持てる — window へ登録していた
+    // 旧実装は解除しておらず、エディタが作り直されると多重登録になっていた
     let loaded = false;
     const loadEditorPackages = async () => {
       if (loaded) return;
@@ -277,10 +282,10 @@ export const MonacoEditorRenderer: React.FC = () => {
       }
     };
     void loadEditorPackages();
-    window.addEventListener(
-      'apm-core-changed',
+    const unsubscribe = subscribeInstallationPath(
       () => void loadEditorPackages(),
     );
+    editor.onDidDispose(() => unsubscribe());
 
     editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
       void saveEditorDataRef.current();

--- a/src/renderer/main/nicommons/NicommonsTab.tsx
+++ b/src/renderer/main/nicommons/NicommonsTab.tsx
@@ -1,4 +1,10 @@
-import React, { type JSX, useEffect, useMemo, useState } from 'react';
+import React, {
+  type JSX,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import {
   Badge,
   Button,
@@ -12,7 +18,10 @@ import {
 import { parsePackageType } from '../../../shared/packageDisplay';
 import type { PackageState } from '../../../types/packageState';
 import { TRPCReact } from '../../trpc';
-import { getInstallationPath } from '../installationPath';
+import {
+  getInstallationPath,
+  subscribeInstallationPath,
+} from '../installationPath';
 
 type NicommonsItem = {
   name: string;
@@ -110,8 +119,12 @@ function NicommonsRow({
  * @returns {JSX.Element} The rendered component.
  */
 function NicommonsTab(): JSX.Element {
-  const [installationPath, setInstallationPath] = useState(() =>
-    getInstallationPath(),
+  // インストール先はストアを購読する。DOM イベント経由で読み直すと、
+  // 通知の発火とストア更新の順序に依存してしまう(起動フローも
+  // SelectInstallationPathButton も setInstallationPath の前後で撃つ)
+  const installationPath = useSyncExternalStore(
+    subscribeInstallationPath,
+    getInstallationPath,
   );
   // 除外したもの(チェックを外したもの)だけを持つ。一覧の再取得時に全部
   // チェック済みへ戻る旧挙動と同じにするため、checked の集合は持たない
@@ -142,19 +155,14 @@ function NicommonsTab(): JSX.Element {
   );
 
   useEffect(() => {
-    const onCoreChanged = () => {
-      setInstallationPath(getInstallationPath());
-    };
     const onPackagesChanged = () => {
       void utils.packages.getPackages.invalidate();
       void utils.packages.getLedgerInstalledIds.invalidate();
       // 旧実装は再描画のたびに全チェック済みへ戻していた
       setUncheckedIds(new Set());
     };
-    window.addEventListener('apm-core-changed', onCoreChanged);
     window.addEventListener('apm-packages-changed', onPackagesChanged);
     return () => {
-      window.removeEventListener('apm-core-changed', onCoreChanged);
       window.removeEventListener('apm-packages-changed', onPackagesChanged);
     };
   }, [utils]);

--- a/src/renderer/main/packages/PackagesTab.tsx
+++ b/src/renderer/main/packages/PackagesTab.tsx
@@ -26,7 +26,10 @@ import {
 } from '../../../shared/shareString';
 import type { PackageState } from '../../../types/packageState';
 import { TRPCReact } from '../../trpc';
-import { getInstallationPath } from '../installationPath';
+import {
+  getInstallationPath,
+  subscribeInstallationPath,
+} from '../installationPath';
 import PackageActions, { type SelectedEntry } from './PackageActions';
 import { getPhase, subscribePhase } from './packagesListCheck';
 
@@ -170,8 +173,12 @@ const naturalCompare = (a: string, b: string) => {
  * @returns {JSX.Element} The rendered component.
  */
 function PackagesTab(): JSX.Element {
-  const [installationPath, setInstallationPath] = useState(() =>
-    getInstallationPath(),
+  // インストール先はストアを購読する。DOM イベント経由で読み直すと、
+  // 通知の発火とストア更新の順序に依存してしまう(起動フローも
+  // SelectInstallationPathButton も setInstallationPath の前後で撃つ)
+  const installationPath = useSyncExternalStore(
+    subscribeInstallationPath,
+    getInstallationPath,
   );
   const [searchString, setSearchString] = useState('');
   const [alertDismissed, setAlertDismissed] = useState(false);
@@ -196,20 +203,15 @@ function PackagesTab(): JSX.Element {
     { refetchOnWindowFocus: false },
   );
 
-  // 他コンポーネントからの通知: インストール先変更と一覧の再取得要求
+  // 他コンポーネントからの一覧の再取得要求
   useEffect(() => {
-    const onCoreChanged = () => {
-      setInstallationPath(getInstallationPath());
-    };
     const onPackagesChanged = () => {
       void utils.packages.getPackagesWithStatus.invalidate();
       void utils.packages.getScriptsList.invalidate();
       void utils.core.getLedgerCoreVersions.invalidate();
     };
-    window.addEventListener('apm-core-changed', onCoreChanged);
     window.addEventListener('apm-packages-changed', onPackagesChanged);
     return () => {
-      window.removeEventListener('apm-core-changed', onCoreChanged);
       window.removeEventListener('apm-packages-changed', onPackagesChanged);
     };
   }, [utils]);


### PR DESCRIPTION
## 内容

`installationPath.ts` のコメントは自ら

```ts
// React からは
// useSyncExternalStore(subscribeInstallationPath, getInstallationPath) で購読する。
```

と書いているのに、**そうしていたのは `AviutlTab` と `BatchInstallList` の 2 つだけ**でした。残る 4 つは DOM イベントを受けて `getInstallationPath()` を読み直しています。

ストアは 8d48a4e2「preload の初期化フローをメインワールドの起動フローへ移設」で新設され、**同じコミットで更新されたのが `AviutlTab` だけ**、というのが経緯です。

## なぜ直すか

読み直し方は**通知の発火とストア更新の順序に依存**します。撃つ側はこの順です。

```
startup.ts:86   apm-core-changed     を dispatch   ← ここで読むと空
startup.ts:87   apm-packages-changed を dispatch
startup.ts:94   setInstallationPath(installationPath)
startup.ts:97   apm-core-changed     を dispatch   ← ここで読めば正しい
```

**`BatchInstallList` は実際にこれを踏み外していました**(`apm-packages-changed` しか見ておらず、起動後ずっと空パスで問い合わせていた。[#2453](https://github.com/team-apm/apm/pull/2453) で修正済み)。

今回の 4 つは 2 度目の `apm-core-changed` で救われているので**挙動は変わりません**。依存そのものを外します。

## 変更

| ファイル | 変更 |
| --- | --- |
| `PackagesTab` / `NicommonsTab` | 購読へ。`apm-core-changed` は他に何もしていないのでリスナごと削除 |
| `ProgramRow` | 購読へ。`apm-core-changed` のリスナは残す(クエリの invalidate をしているため) |
| `monacoEditorRenderer` | 購読へ。**解除経路が無かったのを直す**(下記) |

`monacoEditorRenderer` は「インストール先の確定を待つ」ためだけに `window` へ登録していて、**解除していませんでした**。`editor.onDidDispose` で解除します。

## 結果

`apm-core-changed` の購読者は `ProgramRow` と `ManualUpdateTable` の 2 つだけになり、**どちらも役割はクエリの invalidate のみ**になります。イベントの意味が「インストール先が変わった」と「データを取り直せ」の 2 つに割れていたのが、後者だけに絞られました。

AGENTS.md の落とし穴が言う「queryClient への一本化」に進むなら、この状態からのほうが差分が小さくなります。

## 検証

挙動変更が無いことの確認なので、E2E を通しました(手元の macOS で `yarn package` → `playwright test`)。**7 件すべて green** です。とくに以下が今回の変更対象を踏みます。

- `batch-install-list.spec.ts` — 起動直後のインストール先の反映
- `install.spec.ts` — インストール先の変更(`#installation-path` の値が追従すること)
- `monaco.spec.ts` — データエディタの起動時読み込み
- `search.spec.ts` — `PackagesTab` の一覧

lint / lint:ts / test(30 ファイル 310 件)も緑です。

---

調査と文面の作成に [Claude Code](https://claude.com/claude-code) を使用しています。
