### PR TITLE
fix(renderer): コアのインストールボタンに読み上げ名を戻す

### DIFF
--- a/e2e/core.spec.ts
+++ b/e2e/core.spec.ts
@@ -46,15 +46,20 @@ test('AviUtl 本体のインストールができる', async ({ cleanup, launchA
     },
   );
 
+  // 待機中のボタンはキャレットだけで文字が無いので、読み上げ名で辿れること
+  await expect(
+    window.getByRole('button', { name: 'AviUtlをインストール' }),
+  ).toBeVisible();
+
   // バージョン選択ドロップダウンから最新版(1.10)をインストールする
   await window.locator('#install-aviutl').click();
   await window
     .locator('#aviutl-version-select .dropdown-item', { hasText: '1.10' })
     .click();
-  await expect(window.locator('#install-aviutl')).toHaveText(
-    'インストール完了',
-    { timeout: 120_000 },
-  );
+  // 完了メッセージがそのまま読み上げ名になる(待機中の aria-label が残っていない)
+  await expect(
+    window.getByRole('button', { name: 'インストール完了' }),
+  ).toBeVisible({ timeout: 120_000 });
 
   // 実ファイルが置かれ、インストール済みバージョンが表示される
   expect(existsSync(path.join(installationPath, 'aviutl.exe'))).toBe(true);

--- a/src/renderer/main/aviutl/ProgramRow.tsx
+++ b/src/renderer/main/aviutl/ProgramRow.tsx
@@ -37,6 +37,12 @@ function ProgramRow({
   const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   useEffect(() => () => clearTimeout(timer.current), []);
 
+  // 待機中のボタンはキャレットだけになり、読み上げ名が空になる。文字を出すと
+  // 列の幅が変わって行の整列が崩れるため、見た目は変えずに名前だけを与える。
+  // 状態メッセージを出している間は付けない — aria-label は要素の文字を上書きするので、
+  // 「インストール完了」が読み上げから消えてしまう
+  const idleName = phase === 'idle' ? `${label}をインストール` : undefined;
+
   const utils = TRPCReact.useUtils();
   const coreInfoQuery = TRPCReact.core.getCoreInfo.useQuery();
   const installedTextsQuery =
@@ -143,6 +149,8 @@ function ProgramRow({
             className={buttonRoundedClass}
             id={`install-${program}`}
             disabled={phase === 'loading'}
+            aria-label={idleName}
+            title={idleName}
           >
             {phase === 'loading' ? (
               <>


### PR DESCRIPTION
## 何が起きているか

AviUtl タブの AviUtl / 拡張編集の行のボタンは、待機中は**キャレットだけで文字がありません**。

アクセシブル名が空なので、スクリーンリーダーでは「ボタン」としか読まれず、何を起動するボタンなのか分かりません（WCAG 2.1 の 4.1.2 に相当）。マウス利用者にもツールチップが無いので手掛かりがありません。

## なぜこうなったか

元は文字が入っていました。

| コミット | 日付 | ボタンの文字 |
| --- | --- | --- |
| `697ac4b0` | 2021-06-21 | `AviUtlをインストール` |
| `9f47d4bf` | 2021-12-30 | `インストール` |
| `73c8498b` | 2023-10-15 | **（空）** |

`73c8498b` "feat: improvements in main tab" は、3 カラム（`col-sm-3` / `col-sm-6` / `col-sm-3`）の行を flex の 1 行へ畳んだコミットです。その差分で `w-100` と一緒に文字も消えています。コミットの主題はレイアウトの刷新で、文言を消す意図には触れていないため、レイアウト整理の取りこぼしと判断しました。

## この PR でやること

**見た目は変えません。** 文字をそのまま戻すとボタンの幅が変わり、行に沿って縦に並ぶボタン列（`rounded-start-0` などで 1 本の帯に見せている）の整列が崩れるためです。`aria-label` と `title` で名前だけを与えます。

```
aria-label={idleName}
title={idleName}
```

**状態メッセージを出している間は付けません。** `aria-label` は要素の文字を上書きするため、付けたままだと「インストール完了」が読み上げから消えます。

なお「見える文字を戻すかどうか」は別の判断なので、この PR には含めていません。

## 検証

`e2e/core.spec.ts` に 2 つ足しました。

- 待機中：`getByRole('button', { name: 'AviUtlをインストール' })` で辿れる
- 完了後：`getByRole('button', { name: 'インストール完了' })` で辿れる（＝ `aria-label` が状態メッセージを覆い隠していない番人）

修正を外した状態で E2E が落ちること、戻すと通ることの両方を手元で確認済みです。

- `yarn lint` / `yarn lint:ts` / `yarn test` 緑
- `yarn package` → `yarn test:e2e e2e/core.spec.ts` 緑
