### PR TITLE
docs(main): 実体と食い違う Ledger のコメントを直す

### DIFF
--- a/src/main/Ledger.ts
+++ b/src/main/Ledger.ts
@@ -18,12 +18,14 @@ class Ledger {
   // 全体書き戻しで消し合う(lost update)。操作単位のミューテックスで直列化
   // する案は全サービスの呼び出し境界の再定義が必要で差分が大きく、単一
   // プロセスなら共有オブジェクト化で同じ効果が得られるため採らない。
-  // apm の多重起動(プロセス間の競合)はこの方式では防げない(別課題)
+  // プロセス間の競合は index.ts の requestSingleInstanceLock で防ぐ(2 個目は
+  // 起動しない)。ただしロックは userData 単位なので、_Dev の開発起動と製品版が
+  // 同じインストール先を指す構成だけは防げない
   private static instances = new Map<string, Promise<Ledger>>();
 
-  // 生成は必ず静的ファクトリ(load / getInstance)経由で、どちらも
-  // new した直後に load() を呼ぶ。load() は成功・失敗のどちらの経路でも
-  // この 2 つを設定するが、コンストラクタからは追えないため明示する
+  // 生成は必ず静的ファクトリ(load)経由で、new した直後に load() を呼ぶ。
+  // load() は成功・失敗のどちらの経路でもこの 2 つを設定するが、
+  // コンストラクタからは追えないため明示する
   private path!: string;
   private object!: LedgerObject;
   private inTransaction = false;


### PR DESCRIPTION
[#2442](https://github.com/team-apm/apm/issues/2442) の (1) にあたる部分です。**コメントだけを直します。挙動もコードも変えていません。**

## 1. 解決済みの課題を「別課題」として指したまま

`src/main/Ledger.ts` の共有インスタンス化の説明が、こう締めくくられていました。

> apm の多重起動(プロセス間の競合)はこの方式では防げない(別課題)

その別課題は `79deb8cd fix(main): requestSingleInstanceLock で多重起動を防止` で片付いています。[src/main/index.ts:71](https://github.com/team-apm/apm/blob/main/src/main/index.ts#L71) が 2 個目のプロセスを起動させないので、同一プロファイルの競合は起きません。

ロックを取り損ねた側が後続のトップレベル初期化を素通しするのは事実ですが、そこで触るのは `getConfig()` / `ensureAutoUpdateDefault()` / `registerIpcHandlers()` だけで、Ledger を開くのは `app.whenReady()` 以降です。`quit()` 済みなら ready は発火しないため、apm.json には到達しません。

残っているのは**ロックが userData 単位であることに由来する穴だけ**なので、そこを書くようにしました。`_Dev` の開発起動と製品版が同じインストール先を指す構成です。

## 2. 存在しないメソッドを指している

> 生成は必ず静的ファクトリ(load / **getInstance**)経由で、**どちらも** …

`getInstance` は `src/` にありません。

```
$ grep -rn "getInstance" src/ e2e/
src/main/Ledger.ts:24:  // 生成は必ず静的ファクトリ(load / getInstance)経由で、どちらも
```

ヒットするのはこのコメント自身だけです。実在する静的メンバは `getPath` と `load` のみなので、`load` 一本に直し「どちらも」も落としました。

## この PR に入れていないもの

#2442 の (2)（別プロファイル同士が同じインストール先を触る構成をどう扱うか）はメンテナ判断なので触っていません。調査中に出た判断材料だけ置いておきます。

- 残る構成は実質「`_Dev` の開発起動と製品版が同じインストール先」の 1 通りです。E2E は userData も installationPath も毎回 `mkdtemp` で、`playwright.config.ts` が `workers: 1` / `fullyParallel: false` なので衝突しません
- [#2458](https://github.com/team-apm/apm/pull/2458) で入った原子書き込みの一時ファイル名は `apm.json.tmp` 固定です。プロセスをまたぐと、単なる lost update では済まず ① 先に rename した側があると後続の `rename` が ENOENT で `save()` が throw する ② 他プロセスのスナップショットが本体になる、という壊れ方まで広がります
- 同じインストール先の `packages.json` は tmp+rename すらありません（`packageUninstall.ts` / `scriptInstall.ts`）

## 検証

`yarn lint` / `yarn lint:ts` / `yarn test`（308 件）緑。同梱物を触らないので E2E は不要です。