### PR TITLE
fix(renderer): インストール先のパスをホバーで読めるようにする

### DIFF
--- a/e2e/install.spec.ts
+++ b/e2e/install.spec.ts
@@ -91,6 +91,11 @@ test('dataURL の差し替えとパッケージのインストール・アンイ
       timeout: 120_000,
     },
   );
+  // 幅に収まらないパスはホバーで全体が読める
+  await expect(window.locator('#installation-path')).toHaveAttribute(
+    'title',
+    installationPath,
+  );
 
   // 差し替え前のデータにはダミープラグインが存在しない
   await window.getByRole('tab', { name: 'プラグイン&スクリプト' }).click();

--- a/src/renderer/main/aviutl/AviutlTab.tsx
+++ b/src/renderer/main/aviutl/AviutlTab.tsx
@@ -56,6 +56,10 @@ function AviutlTab(): JSX.Element {
                 placeholder="AviUtlフォルダ"
                 aria-label="Installation path"
                 readOnly
+                // 幅に収まらないパスはフォルダ選択ボタンの下に潜って読めなくなる。
+                // 省略記号も出ない(plaintext の input なので text-overflow が効かない)。
+                // 幅を広げるとボタンが押し出されるため、ホバーで全体を出す
+                title={installationPath}
                 value={installationPath}
               />
             </div>


### PR DESCRIPTION
## 何が起きているか

E2E ハーネスで実際に起動して気づいたものです。**パスが幅に収まらないと、「AviUtlインストールフォルダを選択」ボタンの下に潜り込んで読めなくなります。**

```
┌────────────────────────────────────────────┬─────────────────────────┐
│ 🗀 /var/folders/_s/wj414jj95pn6yy249s8m95cm0│ AviUtlインストールフォルダを選択 │
└────────────────────────────────────────────┴─────────────────────────┘
                                             ↑ ここで切れる。省略記号も出ない
```

- **省略記号(`…`)が出ません。** `plaintext` の `<input>` なので `text-overflow: ellipsis` が効きません
- **ツールチップも出ません。** `title` 属性がありませんでした
- 実 `input` なのでクリックして End キーを押せば末尾は見られますが、それが必要だと分かる手掛かりがありません

アプリでいちばん大事な状態（いまどの AviUtl フォルダを見ているのか）が、パスが長いと確認できない状態です。Windows でも `C:\Users\<長い名前>\Documents\...\AviUtl` のような構成で普通に起きます。

## この PR でやること

入力欄を広げるとボタンが押し出されるので、**幅は変えずに `title` を足します。**

```
title={installationPath}
```

## この PR に入れていないもの

本筋は「どちら側を省略するか」だと思っています。パスは**末尾のフォルダ名のほうが情報量が多い**（`…/Documents/AviUtl`）ので、頭を省いて末尾を見せるほうが合っています。ただしそれは見た目の変更になるので分けました。

## 検証

`e2e/install.spec.ts` の、既にインストール先の表示を見ている箇所に 1 行足しました。

修正を外すと `Expected: "/var/folders/.../aviutl"` / `Received: ""` で落ちること、戻すと通ることを手元で確認済みです。

- `yarn lint` / `yarn lint:ts` 緑
- `yarn package` → `yarn test:e2e e2e/install.spec.ts` 緑