### PR TITLE
fix(renderer): タブペインを指す CSS セレクタが効いていない問題を直す

### DIFF
--- a/e2e/launch.spec.ts
+++ b/e2e/launch.spec.ts
@@ -22,6 +22,21 @@ test('起動して main 窓が開き、パッケージ一覧が描画される',
     timeout: 240_000,
   });
 
+  // 検索欄や操作ボタンを載せたカードがペインに収まり、一覧だけが内側で
+  // スクロールする(収まらないと一覧と一緒に画面外へ流れていく)
+  const heights = await window.evaluate(() => {
+    const pane = document.querySelector('section[role="tabpanel"].active');
+    const container = pane?.querySelector('.container-lg');
+    return {
+      pane: pane ? Math.round(pane.getBoundingClientRect().height) : 0,
+      container: container
+        ? Math.round(container.getBoundingClientRect().height)
+        : 0,
+    };
+  });
+  expect(heights.pane).toBeGreaterThan(0);
+  expect(heights.container).toBeLessThanOrEqual(heights.pane);
+
   expect(
     pageErrors.map((e) => e.message),
     'renderer で uncaught exception が発生していない',

--- a/src/renderer/main/App.tsx
+++ b/src/renderer/main/App.tsx
@@ -80,7 +80,15 @@ function App(): JSX.Element {
 
       <Tab.Content as="main" id="nav-tabContent">
         {TABS.map((tab) => (
-          <Tab.Pane key={tab.id} as="section" eventKey={tab.id} id={tab.id}>
+          // id は react-bootstrap が useId 由来のものへ実行時に差し替えるため
+          // CSS からは掴めない(react-aria…-tabpane-packages になる)。
+          // ペインを指すセレクタは className で持つ
+          <Tab.Pane
+            key={tab.id}
+            as="section"
+            eventKey={tab.id}
+            className={`pane-${tab.id}`}
+          >
             {tab.pane}
           </Tab.Pane>
         ))}

--- a/src/renderer/main/index.css
+++ b/src/renderer/main/index.css
@@ -6,12 +6,12 @@ body,
 /* React のマウント先。body 直下に挟まるため高さの継承に加える */
 #root,
 section,
-section#packages .container-lg,
-section#packages .container-lg > .card,
-section#packages .container-lg > .card > .card-body,
-section#nicommons .container-lg,
-section#nicommons .container-lg > .card,
-section#nicommons .container-lg > .card > .card-body {
+.pane-packages .container-lg,
+.pane-packages .container-lg > .card,
+.pane-packages .container-lg > .card > .card-body,
+.pane-nicommons .container-lg,
+.pane-nicommons .container-lg > .card,
+.pane-nicommons .container-lg > .card > .card-body {
   height: 100%;
 }
 main {
@@ -91,11 +91,11 @@ img.emoji {
   vertical-align: -0.1em;
 }
 
-section#nicommons img {
+.pane-nicommons img {
   max-height: 64px;
 }
 @media screen and (min-width: 576px) {
-  section#nicommons img {
+  .pane-nicommons img {
     max-height: 96px;
   }
 }


### PR DESCRIPTION
## 何が起きているか

`src/renderer/main/index.css` の `section#packages` / `section#nicommons` のルールが、**v3.14.0 の出荷物で 1 つも効いていません。**

react-bootstrap の `Tab.Pane` は、渡した `id` を `useId` 由来のものへ**実行時に差し替えます**（`@restart/ui` の `useTabPanel` が `Object.assign({}, props, { role, id: getControlledId(eventKey), ... })` と props の後に `id` を書いています）。

パッケージ版を実際に起動して DOM を測りました。

```
paneIds:  [ "react-aria5587684078-_r_0_-tabpane-aviutl",
            "react-aria5587684078-_r_0_-tabpane-packages", ... ]
activeId:                 "react-aria5587684078-_r_0_-tabpane-packages"
cssRuleMatches:           false     ← section#packages .container-lg に一致しない
paneHeight:               526
containerHeight:        24841       ← height: 100% が効いていない
```

`.container-lg` が **526px のペインに対して 24841px** になっています。検索欄・並べ替え・フィルタ・操作ボタンを載せたカードがペインに収まらず、**一覧を内側でスクロールさせるつもりが、カードごと画面外へ流れていきます。** ニコニ・コモンズタブのサムネイルも `max-height` が `none`（本来 64px / 576px 以上で 96px）になっています。

## いつ入ったか

`d3561071 refactor(renderer): タブと dropdown を react-bootstrap 化して Bootstrap data API 依存を解消` です（`git tag --contains` で **v3.14.0 に含まれることを確認**）。

コミット本文は dropdown 側について「参照する CSS・E2E は無い」と確認を書いています。タブペイン側は `id` をソース上そのまま渡しているので一見保存されて見えますが、実行時に上書きされる点は検討されていません。E2E は `role=tab` と `#packages-list` など**内側の** id しか見ていないので検出できませんでした。

## この PR でやること

`id` は実 DOM に出ないので CSS からは掴めません。`className` で持たせます。

```
<Tab.Pane ... className={`pane-${tab.id}`}>
```

```
.pane-packages .container-lg, … { height: 100%; }
.pane-nicommons img { max-height: 64px; }
```

`#packages-table` / `#packages-list` などの id はコンポーネント自身が出しているもので、影響ありません。

## 検証

`e2e/launch.spec.ts` に、**カードの高さがペイン高を超えないこと**を足しました。実データの一覧で測るので、既に一覧の描画を待っているこのテストに置いています。

- 修正なし: `Expected: <= 526` / `Received: 23946` で落ちる
- 修正あり: `containerHeight` が 526 になり通る

どちらも手元で実測済みです。

- `yarn lint` / `yarn lint:ts` / `yarn test`（308 件）緑
- `yarn package` → `yarn test:e2e`（7 件）緑