### PR TITLE
fix(main): tRPC 境界で例外をログに残す

### DIFF
--- a/src/main/api/trpc.test.ts
+++ b/src/main/api/trpc.test.ts
@@ -1,0 +1,50 @@
+import type { IpcMainInvokeEvent } from 'electron';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type Config from '../Config';
+import { procedure, t } from './trpc';
+
+const mocks = vi.hoisted(() => ({ error: vi.fn() }));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { fromWebContents: () => null },
+}));
+vi.mock('electron-log/main', () => ({
+  default: { error: mocks.error, warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../Config', () => ({ getConfig: () => ({}) }));
+vi.mock('../installation', () => ({ openInstallation: vi.fn() }));
+
+const router = t.router({
+  boom: procedure.query(() => {
+    throw new Error('procedure が投げた例外');
+  }),
+  fine: procedure.query(() => 'ok'),
+});
+const createCaller = t.createCallerFactory(router);
+const caller = createCaller({
+  event: {} as IpcMainInvokeEvent,
+  config: {} as Config,
+});
+
+describe('tRPC 境界のログ', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('procedure が投げた例外を、呼び出し元へ返す前にログへ残す', async () => {
+    await expect(caller.boom()).rejects.toThrow('procedure が投げた例外');
+
+    expect(mocks.error).toHaveBeenCalledTimes(1);
+    const [message, error] = mocks.error.mock.calls[0] as [string, Error];
+    // どの procedure の失敗かがログだけで分かる
+    expect(message).toContain('boom');
+    expect(message).toContain('query');
+    expect(error.message).toContain('procedure が投げた例外');
+  });
+
+  it('成功した procedure では何もログしない', async () => {
+    await expect(caller.fine()).resolves.toBe('ok');
+
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/api/trpc.ts
+++ b/src/main/api/trpc.ts
@@ -1,5 +1,6 @@
 import { initTRPC } from '@trpc/server';
 import { BrowserWindow, type IpcMainInvokeEvent } from 'electron';
+import log from 'electron-log/main';
 import type { CreateContextOptions } from 'trpc-electron/main';
 import type Config from '../Config';
 import { getConfig } from '../Config';
@@ -23,7 +24,21 @@ export async function createContext({
 
 export const t = initTRPC.context<Context>().create({ isServer: true });
 
-export const procedure = t.procedure;
+// procedure の throw は trpc-electron 経由で renderer へ返るだけで、main の
+// ログには何も残らない。trpc-electron の createIPCHandler は onError を
+// 受け取らないので、境界に置けるのはこの middleware だけ。
+// renderer 側は catch して「エラーが発生しました。」を出すため、これが無いと
+// 「UI にエラーが出ているのにログが空」になり、報告から原因に辿り着けない。
+// next() は throw せず ok:false を返すので、再 throw は要らない。
+// サービス層が既に log.error している経路とは重複するが、そちらには
+// どの procedure の失敗かが残らないため、path と type はここでしか出せない
+const logErrors = t.middleware(async ({ next, path, type }) => {
+  const result = await next();
+  if (!result.ok) log.error(`trpc ${type} ${path} failed:`, result.error);
+  return result;
+});
+
+export const procedure = t.procedure.use(logErrors);
 
 // 呼び出し元ウィンドウをダイアログ・進捗表示の親として使う procedure。
 // 窓が閉じられた直後などで解決できない場合はエラーにする(定型 19 箇所の集約)


### PR DESCRIPTION
## 何が起きているか

**procedure が投げた例外は、main のログに 1 行も残りません。**

`trpc-electron` の `createIPCHandler` は `{ createContext, router, windows }` しか受け取らず、`onError` がありません。例外は renderer へ返り、renderer 側は `catch` して「エラーが発生しました。」を出します。結果として **UI にエラーが出ているのにログが空**という状態になります。

この経路に乗っているもの:

- 入力検証の失敗（`api/*.ts` の手書きバリデータが投げる `TypeError`）
- 呼び出し元ウィンドウの解決失敗（`winProcedure` の `The calling window was not found.`）
- dataURL 未設定 / release 未検出（`services/core.ts` ほか）

## なぜ今これを直すか

**実運用に効いています。**

open な bug issue 14 件を 1 件ずつ調べたところ、**5 件が「たぶん直っているが、報告者に聞かないと確認できない」で止まりました**（#1430 #1561 #1883 #2123 #2180）。多くは Google フォーム経由の匿名報告で、症状が「エラーの発生」「画面が点滅する」のように薄いものです。ログが 1 枚あれば決着していました。

その他タブには**バグ報告のボタンはあるのにログを開くボタンがありません**が、導線を付けても**中身が空では意味がない**ので、まずこちらを塞ぎます。

## この PR でやること

境界に置けるのは middleware だけなので、そこに 1 つ足します。

```
const logErrors = t.middleware(async ({ next, path, type }) => {
  const result = await next();
  if (!result.ok) log.error(`trpc ${type} ${path} failed:`, result.error);
  return result;
});

export const procedure = t.procedure.use(logErrors);
```

`procedure` は 1 箇所からしか export しておらず、`winProcedure` / `instProcedure` / `winInstProcedure` はすべてこれ由来なので（`src/` に `t.procedure` の直接使用はゼロ）、**これだけで全 procedure に効きます。**

`next()` は throw せず `{ ok: false, error }` を返す（`@trpc/server` 11.18.0 の `MiddlewareResult`）ので、再 throw は不要です。

サービス層が既に `log.error` している経路とは重複しますが、**そちらには「どの procedure の失敗か」が残りません。** `path` と `type` はここでしか出せません。

## 検証

`src/main/api/trpc.test.ts` を足しました。失敗時にどの procedure かが分かる形でログに出ること、成功時には何も出ないこと。

middleware を外すと `expected "spy" to be called 1 times, but got 0 times` で落ちること、戻すと通ることを確認済みです。

- `yarn lint` / `yarn lint:ts` / `yarn test`（310 件）緑
- main プロセスの境界を触るので `yarn package` → `yarn test:e2e`（7 件）も回して緑

## この PR に入れていないもの

renderer 側に **`} catch {` で error オブジェクトを捨てている箇所が 13 あります**（`PackageActions.tsx` 5、`monacoEditorRenderer.tsx` 3、ほか）。そちらは別 PR にします。