### PR TITLE
feat(renderer): ログフォルダを開くボタンをその他タブに足す

### DIFF
--- a/src/main/api/app.test.ts
+++ b/src/main/api/app.test.ts
@@ -1,0 +1,81 @@
+import type { IpcMainInvokeEvent } from 'electron';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type Config from '../Config';
+import { appProcedures } from './app';
+import { t } from './trpc';
+
+const mocks = vi.hoisted(() => ({
+  showItemInFolder: vi.fn(),
+  openPath: vi.fn(),
+  logFilePath: { value: '' },
+}));
+
+vi.mock('electron', () => ({
+  app: { getVersion: () => '0.0.0', getName: () => 'apm', quit: vi.fn() },
+  BrowserWindow: { getFocusedWindow: () => null },
+  clipboard: { writeText: vi.fn() },
+  dialog: { showMessageBox: vi.fn(), showOpenDialog: vi.fn() },
+  shell: {
+    showItemInFolder: mocks.showItemInFolder,
+    openPath: mocks.openPath,
+  },
+}));
+vi.mock('electron-log/main', () => ({
+  default: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    transports: {
+      file: { getFile: () => ({ path: mocks.logFilePath.value }) },
+    },
+  },
+}));
+vi.mock('../aboutWindow', () => ({ openAboutWindow: vi.fn() }));
+vi.mock('../Config', () => ({ getConfig: () => ({}) }));
+vi.mock('../installation', () => ({ openInstallation: vi.fn() }));
+vi.mock('../services/appUpdate', () => ({
+  checkUpdate: vi.fn(),
+  isExeVersion: () => false,
+}));
+
+const caller = t.createCallerFactory(t.router(appProcedures))({
+  event: {} as IpcMainInvokeEvent,
+  config: {} as Config,
+});
+
+describe('openLogFolder', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dir = mkdtempSync(path.join(tmpdir(), 'apm-log-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('ログファイルを選択した状態でフォルダを開く', async () => {
+    const logPath = path.join(dir, 'main.log');
+    writeFileSync(logPath, 'log');
+    mocks.logFilePath.value = logPath;
+
+    await caller.openLogFolder();
+
+    expect(mocks.showItemInFolder).toHaveBeenCalledWith(logPath);
+    expect(mocks.openPath).not.toHaveBeenCalled();
+  });
+
+  it('ログファイルがまだ無いときはフォルダだけを開く', async () => {
+    mocks.logFilePath.value = path.join(dir, 'not-written-yet.log');
+
+    await caller.openLogFolder();
+
+    expect(mocks.openPath).toHaveBeenCalledWith(dir);
+    expect(mocks.showItemInFolder).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/api/app.ts
+++ b/src/main/api/app.ts
@@ -4,7 +4,11 @@ import {
   clipboard,
   dialog,
   type OpenDialogOptions,
+  shell,
 } from 'electron';
+import log from 'electron-log/main';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
 import { openAboutWindow } from '../aboutWindow';
 import {
   checkUpdate as checkAppUpdate,
@@ -70,6 +74,19 @@ export const appProcedures = {
   }),
   openAboutWindow: procedure.mutation(() => {
     openAboutWindow();
+  }),
+  // バグ報告に添えるログへの導線。場所は app.getPath('logs') で組み立てず
+  // electron-log 自身に聞く(transports.file の設定を変えても追従する)
+  openLogFolder: procedure.mutation(async () => {
+    const logPath = log.transports.file.getFile().path;
+    // 添付するのはファイルなので、選択した状態でフォルダを開く。
+    // 起動時に必ず 1 行書くので通常は存在するが、書き込みに失敗している
+    // ときこそ開きたいので、無ければフォルダだけ開く
+    if (existsSync(logPath)) {
+      shell.showItemInFolder(logPath);
+      return;
+    }
+    await shell.openPath(path.dirname(logPath));
   }),
   openDialog: procedure.input(dialogInput).mutation(async ({ input }) => {
     await dialog.showMessageBox({

--- a/src/renderer/main/others/OthersTab.tsx
+++ b/src/renderer/main/others/OthersTab.tsx
@@ -17,6 +17,7 @@ import { TRPCReact } from '../../trpc';
 function OthersTab() {
   const { data: appName } = TRPCReact.getAppName.useQuery();
   const openAboutWindow = TRPCReact.openAboutWindow.useMutation();
+  const openLogFolder = TRPCReact.openLogFolder.useMutation();
   const quitApp = TRPCReact.quitApp.useMutation();
 
   return (
@@ -89,6 +90,21 @@ function OthersTab() {
                 >
                   <i className="bi bi-github"></i> GitHub (要アカウント)
                   <i className="bi bi-box-arrow-up-right"></i>
+                </Button>
+              </Col>
+            </Row>
+            <Row className="mb-3">
+              <Col as="p" sm={6} className="col-form-label">
+                バグ報告に添えるログ
+              </Col>
+              <Col sm={6}>
+                <Button
+                  variant="primary"
+                  className="w-100"
+                  id="open-log-folder"
+                  onClick={() => openLogFolder.mutate()}
+                >
+                  ログフォルダを開く <i className="bi bi-folder2-open"></i>
                 </Button>
               </Col>
             </Row>


### PR DESCRIPTION
## 何が起きているか

E2E ハーネスで実際に起動して、その他タブを見て気づいたものです。

**機能要求・バグ報告の導線は 2 つ（Google フォーム / GitHub）あるのに、ログを開く導線がどこにもありません。** 報告を促しておいて、報告に添える材料を渡していません。

## なぜ今これを足すか

**実際に効いています。**

open な bug issue 14 件を 1 件ずつ調べたところ、**5 件が「たぶん直っているが、報告者に聞かないと確認できない」で止まりました**（#1430 #1561 #1883 #2123 #2180）。多くは Google フォーム経由の匿名報告で、症状が「エラーの発生」「画面が点滅する」のように薄いものです。

たとえば #1561（「予期せぬエラーが発生しました」で強制終了）は、`net.request` に error ハンドラが無く未処理例外になっていた経路が `a8822bb2` で塞がれているので**おそらく直っています**が、報告にログが無いので確定できません。

## この PR でやること

その他タブに「バグ報告に添えるログ / ログフォルダを開く」の行を 1 つ足します。終了ボタンの直前、機能要求・バグ報告の行の下です。

ログの場所は `app.getPath('logs')` で組み立てず、**electron-log 自身に聞きます。**

```
const logPath = log.transports.file.getFile().path;
```

`transports.file` の設定を変えても追従しますし、プラットフォーム差（macOS は `~/Library/Logs/`、Windows は `%APPDATA%\{appName}\logs\`）を再実装せずに済みます。

添付するのはファイルなので `shell.showItemInFolder` で**選択した状態で**開きます。起動時に必ず 1 行書く（`index.ts` の `log.debug(process.versions)`）ので通常は存在しますが、**書き込みに失敗しているときこそ開きたい**ので、無ければ `shell.openPath` でフォルダだけ開きます。

## 関連

[#2474](https://github.com/team-apm/apm/pull/2474)（tRPC 境界で例外をログに残す）と対になります。**導線だけ付けても中身が空では意味がない**ので、両方あって初めて効きます。順番としては #2474 のほうが先です。

## 検証

`src/main/api/app.test.ts` を足しました。ファイルがあるときは選択して開き、無いときはフォルダだけ開くこと。

- `yarn lint` / `yarn lint:ts` / `yarn test`（310 件）緑
- `yarn package` → 実際にその他タブを開いてボタンが出ることを確認済み