### PR TITLE
fix(renderer): 握りつぶしている例外をログに残す

### DIFF
--- a/src/renderer/main/aviutl/BatchInstallButton.tsx
+++ b/src/renderer/main/aviutl/BatchInstallButton.tsx
@@ -1,4 +1,5 @@
 import type { Core } from 'apm-schema';
+import log from 'electron-log/renderer';
 import React, { type JSX, useEffect, useRef, useState } from 'react';
 import { Button, Spinner } from 'react-bootstrap';
 import { states } from '../../../shared/packageDisplay';
@@ -118,7 +119,8 @@ function BatchInstallButton(): JSX.Element {
       } else {
         finish('インストール完了', 'success');
       }
-    } catch {
+    } catch (e) {
+      log.error('Failed to run the batch install.', e);
       finish('エラーが発生しました。', 'danger');
     }
   };

--- a/src/renderer/main/aviutl/ProgramRow.tsx
+++ b/src/renderer/main/aviutl/ProgramRow.tsx
@@ -1,4 +1,5 @@
 import type { Core } from 'apm-schema';
+import log from 'electron-log/renderer';
 import React, {
   type JSX,
   useEffect,
@@ -107,7 +108,8 @@ function ProgramRow({
         version,
         installationPath,
       });
-    } catch {
+    } catch (e) {
+      log.error(`Failed to install ${program} ${version}.`, e);
       showError('エラーが発生しました。');
       return;
     }

--- a/src/renderer/main/aviutl/SelectInstallationPathButton.tsx
+++ b/src/renderer/main/aviutl/SelectInstallationPathButton.tsx
@@ -1,3 +1,4 @@
+import log from 'electron-log/renderer';
 import React, { type JSX } from 'react';
 import { Button } from 'react-bootstrap';
 import { TRPCReact } from '../../trpc';
@@ -44,7 +45,11 @@ function SelectInstallationPathButton(): JSX.Element {
       // ラベルが変わらないので、押した結果が画面に一切現れない)
       try {
         await changeInstallationPathMutation.mutateAsync(installationPath);
-      } catch {
+      } catch (e) {
+        log.error(
+          `Failed to change the installation path: ${installationPath}`,
+          e,
+        );
         await openDialogMutation.mutateAsync({
           title: 'エラー',
           message: 'インストール先の変更に失敗しました。',

--- a/src/renderer/main/monacoEditorRenderer.tsx
+++ b/src/renderer/main/monacoEditorRenderer.tsx
@@ -5,6 +5,7 @@ import MonacoEditor, {
 } from '@monaco-editor/react';
 import { Packages } from 'apm-schema';
 import schema from 'apm-schema/v3/schema/packages.json';
+import log from 'electron-log/renderer';
 // Type-only import to avoid bundling the entire monaco-editor package
 // (enforced by @typescript-eslint/no-restricted-imports). The runtime editor
 // is NOT loaded from a CDN (the CSP does not allow it): @monaco-editor/loader
@@ -205,6 +206,9 @@ export const MonacoEditorRenderer: React.FC = () => {
       try {
         json = JSON.parse(editor.getValue());
       } catch {
+        // ここだけログしない。編集途中の不正な JSON は想定内の入力状態で、
+        // エディタが既にマーカーで指している。ログに出すと、保存を押すたびに
+        // 本物の失敗と同じ体裁の行が積まれて切り分けの邪魔になる
         error = true;
       }
       if (error) {
@@ -222,7 +226,8 @@ export const MonacoEditorRenderer: React.FC = () => {
       // このイベントを購読して行う
       window.dispatchEvent(new Event('apm-check-packages-list'));
       save.finish('保存完了', 'success');
-    } catch {
+    } catch (e) {
+      log.error('Failed to save the extra packages.', e);
       save.finish('エラー', 'danger');
     }
   };
@@ -278,7 +283,10 @@ export const MonacoEditorRenderer: React.FC = () => {
         editor.setValue(JSON.stringify(packages));
         await editor.getAction('editor.action.formatDocument')!.run();
       } catch {
-        // nop
+        // ここだけログしない。パッケージ一覧をまだ取得していないプロファイルでは
+        // getEditorPackages が必ず 'The version file does not exist.' で throw する
+        // (e2e/monaco.spec.ts が実測で押さえている)。本物の失敗と区別できないので、
+        // 区別できるようにしてからログする
       }
     };
     void loadEditorPackages();

--- a/src/renderer/main/packages/PackageActions.tsx
+++ b/src/renderer/main/packages/PackageActions.tsx
@@ -1,4 +1,5 @@
 import type { Scripts } from 'apm-schema';
+import log from 'electron-log/renderer';
 import React, { type JSX, useEffect } from 'react';
 import { Button, Spinner } from 'react-bootstrap';
 import { states } from '../../../shared/packageDisplay';
@@ -131,7 +132,8 @@ function PackageActions({
         installationPath,
         url,
       });
-    } catch {
+    } catch (e) {
+      log.error(`Failed to install the script: ${url}`, e);
       result = null; // installFailed 相当
     }
 
@@ -213,7 +215,8 @@ function PackageActions({
         packageState: { id: installedPackage.id, info: installedPackage.info },
         direct: false,
       });
-    } catch {
+    } catch (e) {
+      log.error(`Failed to install ${installedPackage.id}.`, e);
       result = 'installFailed';
     }
 
@@ -276,7 +279,8 @@ function PackageActions({
           info: uninstalledPackage.info,
         },
       });
-    } catch {
+    } catch (e) {
+      log.error(`Failed to uninstall ${uninstalledPackage.id}.`, e);
       result = 'removeFailed';
     }
 
@@ -308,7 +312,8 @@ function PackageActions({
     let exists: boolean;
     try {
       exists = await openFolderMutation.mutateAsync(selectedEntry.p.id);
-    } catch {
+    } catch (e) {
+      log.error(`Failed to open the folder of ${selectedEntry.p.id}.`, e);
       folder.finish('エラーが発生しました。', 'danger');
       return;
     }
@@ -329,7 +334,8 @@ function PackageActions({
     try {
       const text = await utils.packages.getShareString.fetch(installationPath);
       await writeClipboardMutation.mutateAsync({ text });
-    } catch {
+    } catch (e) {
+      log.error('Failed to get the share string.', e);
       share.finish('エラーが発生しました。', 'danger');
       return;
     }

--- a/src/renderer/main/settings/CacheSettings.tsx
+++ b/src/renderer/main/settings/CacheSettings.tsx
@@ -1,3 +1,4 @@
+import log from 'electron-log/renderer';
 import React, { type JSX } from 'react';
 import { Button, Col, Form, Row, Spinner } from 'react-bootstrap';
 import { formatBytes } from '../../../shared/formatBytes';
@@ -24,7 +25,8 @@ function CacheSettings(): JSX.Element {
       }
       await cacheSize.refetch();
       clear.finish(`${formatBytes(freed)}を削除`, 'success');
-    } catch {
+    } catch (e) {
+      log.error('Failed to clear the download cache.', e);
       clear.finish('エラー', 'danger');
     }
   };

--- a/src/renderer/main/settings/DataUrlSettings.tsx
+++ b/src/renderer/main/settings/DataUrlSettings.tsx
@@ -1,3 +1,4 @@
+import log from 'electron-log/renderer';
 import React, { type JSX, useEffect, useRef, useState } from 'react';
 import { Button, Col, Form, Row, Spinner } from 'react-bootstrap';
 import { TRPCReact } from '../../trpc';
@@ -56,7 +57,8 @@ function DataUrlSettings() {
       } else {
         setPhase('danger');
       }
-    } catch {
+    } catch (e) {
+      log.error('Failed to set the data URLs.', e);
       setPhase('danger');
     }
     timer.current = setTimeout(() => setPhase('idle'), 3000);


### PR DESCRIPTION
[#2474](https://github.com/team-apm/apm/pull/2474)（tRPC 境界）の renderer 側です。

## 何が起きているか

renderer には **error オブジェクトを捨てる `} catch {` が 13 箇所**あります。UI には「エラーが発生しました。」だけが出て、何が起きたのかはどこにも残りません。

対象は日常の操作ほぼ全部です — インストール、アンインストール、スクリプトのインストール、共有、フォルダを開く、ダウンロードキャッシュの削除、インストール先の変更、データ取得先の設定、追加テキストデータの保存。

## この PR でやること

**11 箇所に `log.error` を足します。** メッセージには操作の対象を添えます。

```
log.error(`Failed to install ${installedPackage.id}.`, e);
log.error(`Failed to change the installation path: ${installationPath}`, e);
log.error(`Failed to install the script: ${url}`, e);
```

スタックだけ残っても**どの操作のものか分からない**ためです。ログは開発者向けの内部文字列なので AGENTS.md の言語規約に従って英語にしています（UI に出る日本語のメッセージは変えていません）。

### renderer から electron-log が使えることは実測しました

preload の `import 'electron-log/preload'` が `__electronLog` を両ワールドに生やしているので、メインワールドの React からも `electron-log/renderer` が使えます。パッケージ版を起動して確認しました。

```
bridge=object  logsDir=~/Library/Logs/AviUtl Package Manager  found=true
```

## 残した 2 箇所と、その理由

**どちらも正常な入力・状態で必ず通る経路**です。error として出すと本物の失敗が埋もれるので、コメントに理由を書いて残しました。

1. **編集途中の不正な JSON**（`monacoEditorRenderer.tsx`）— エディタが既にマーカーで指しています。保存を押すたびに本物の失敗と同じ体裁の行が積まれます

2. **一覧未取得のプロファイルでの `getEditorPackages`** — こちらは最初ログを足したのですが、**E2E が捕まえました。**

```
Error: expect(received).toEqual(expected)
+   "console: Failed to load the editor packages.
+    TRPCClientError: The version file does not exist."
```

`e2e/monaco.spec.ts` が console のエラーを拾っているおかげで、**素のプロファイルでは必ずこの経路を通る**ことが実測で分かりました。正常系なのでログしません。

なお、ここは**「一覧をまだ取得していない」と「本当に失敗した」が区別できていない**という別の問題を含んでいます。区別できるようにしてからログすべきなので、この PR では触っていません。

## 検証

- `yarn lint` / `yarn lint:ts` / `yarn test`（308 件）緑
- `yarn package` → `yarn test:e2e`（7 件）緑 — **上のとおり、この PR では E2E が検出線として実際に働きました**

## マージ順の注意

**この PR は最後にマージしてください。** [#2469](https://github.com/team-apm/apm/pull/2469) と [#2470](https://github.com/team-apm/apm/pull/2470) も `src/renderer/main/aviutl/ProgramRow.tsx` を触るので、それらが main に入った時点でここが conflict になります（今は個別に main へ当たるので MERGEABLE に見えています）。

**衝突するのは import 行だけです。** 手元で 12 本すべてを 1 本のブランチにマージして確かめました。

<details>
<summary>解決後の import（これだけ）</summary>

```
import log from 'electron-log/renderer';
import React, {
  type JSX,
  useEffect,
  useRef,
  useState,
  useSyncExternalStore,
} from 'react';
```
</details>

`catch` の中身は git が自動マージできています。12 本を全部マージした状態で `yarn lint` / `yarn lint:ts` / `yarn test`（32 ファイル 325 件）/ `yarn package` → `yarn test:e2e`（7 件）まで緑を確認済みです。
