### PR TITLE
feat(renderer): インストール不可の理由を一覧に出す

### DIFF
--- a/src/renderer/main/packages/PackagesTab.tsx
+++ b/src/renderer/main/packages/PackagesTab.tsx
@@ -20,6 +20,7 @@ import {
 import { compareVersion } from '../../../shared/compareVersion';
 import { matchesSearchFilter } from '../../../shared/fuzzySearch';
 import {
+  conflictLabel,
   parsePackageType,
   states,
   unmetDependencyLabel,
@@ -748,6 +749,33 @@ function PackagesTab(): JSX.Element {
                                                   ),
                                                 )
                                                 .join('、')}
+                                            </span>
+                                          )}
+                                          {(row.p.conflictingWith ?? [])
+                                            .length > 0 && (
+                                            <span className="d-block fw-normal">
+                                              競合:{' '}
+                                              {(row.p.conflictingWith ?? [])
+                                                .map((group) =>
+                                                  conflictLabel(
+                                                    group,
+                                                    (id) =>
+                                                      packages.find(
+                                                        (p) => p.id === id,
+                                                      )?.info.name,
+                                                  ),
+                                                )
+                                                .filter(
+                                                  (v, i, a) =>
+                                                    a.indexOf(v) === i,
+                                                )
+                                                .join('、')}
+                                            </span>
+                                          )}
+                                          {row.p.installationStatus ===
+                                            states.otherInstalled && (
+                                            <span className="d-block fw-normal">
+                                              別のバージョンが導入済み
                                             </span>
                                           )}
                                         </div>

--- a/src/renderer/main/packages/PackagesTab.tsx
+++ b/src/renderer/main/packages/PackagesTab.tsx
@@ -19,7 +19,11 @@ import {
 } from 'react-bootstrap';
 import { compareVersion } from '../../../shared/compareVersion';
 import { matchesSearchFilter } from '../../../shared/fuzzySearch';
-import { parsePackageType, states } from '../../../shared/packageDisplay';
+import {
+  parsePackageType,
+  states,
+  unmetDependencyLabel,
+} from '../../../shared/packageDisplay';
 import {
   computeShareStringAlerts,
   parseShareString,
@@ -729,6 +733,23 @@ function PackagesTab(): JSX.Element {
                                       row.p.doNotInstall && (
                                         <div className="text-warning">
                                           インストール不可
+                                          {(row.p.unmetDependencies ?? [])
+                                            .length > 0 && (
+                                            <span className="d-block fw-normal">
+                                              要:{' '}
+                                              {(row.p.unmetDependencies ?? [])
+                                                .map((group) =>
+                                                  unmetDependencyLabel(
+                                                    group,
+                                                    (id) =>
+                                                      packages.find(
+                                                        (p) => p.id === id,
+                                                      )?.info.name,
+                                                  ),
+                                                )
+                                                .join('、')}
+                                            </span>
+                                          )}
                                         </div>
                                       )}
                                     {row.kind === 'package' &&

--- a/src/shared/packageDisplay.test.ts
+++ b/src/shared/packageDisplay.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { dependencyDisplayName, unmetDependencyLabel } from './packageDisplay';
+import {
+  conflictLabel,
+  dependencyDisplayName,
+  unmetDependencyLabel,
+} from './packageDisplay';
 
 const nameOf = (id: string) =>
   ({ 'author/a': 'すごいプラグイン' })[id] as string | undefined;
@@ -33,6 +37,14 @@ describe('unmetDependencyLabel', () => {
   it('or 指定は「または」で繋ぐ', () => {
     expect(unmetDependencyLabel('aviutl1.10|exedit0.92', nameOf)).toBe(
       'AviUtl 1.10 または 拡張編集 0.92',
+    );
+  });
+});
+
+describe('conflictLabel', () => {
+  it('and 指定は「かつ」で繋ぐ', () => {
+    expect(conflictLabel('author/a&aviutl1.10', nameOf)).toBe(
+      'すごいプラグイン かつ AviUtl 1.10',
     );
   });
 });

--- a/src/shared/packageDisplay.test.ts
+++ b/src/shared/packageDisplay.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { dependencyDisplayName, unmetDependencyLabel } from './packageDisplay';
+
+const nameOf = (id: string) =>
+  ({ 'author/a': 'すごいプラグイン' })[id] as string | undefined;
+
+describe('dependencyDisplayName', () => {
+  it('一覧にあるパッケージは名前で出す', () => {
+    expect(dependencyDisplayName('author/a', nameOf)).toBe('すごいプラグイン');
+  });
+
+  it('バージョン指定は落として名前だけを出す', () => {
+    expect(dependencyDisplayName('author/a>=1.2', nameOf)).toBe(
+      'すごいプラグイン',
+    );
+  });
+
+  it('一覧に無い aviutl / exedit の擬似 ID は読める形に組み立てる', () => {
+    expect(dependencyDisplayName('aviutl1.10', nameOf)).toBe('AviUtl 1.10');
+    expect(dependencyDisplayName('exedit0.93rc1', nameOf)).toBe(
+      '拡張編集 0.93rc1',
+    );
+  });
+
+  it('解決できない ID はそのまま出す', () => {
+    expect(dependencyDisplayName('author/unknown', nameOf)).toBe(
+      'author/unknown',
+    );
+  });
+});
+
+describe('unmetDependencyLabel', () => {
+  it('or 指定は「または」で繋ぐ', () => {
+    expect(unmetDependencyLabel('aviutl1.10|exedit0.92', nameOf)).toBe(
+      'AviUtl 1.10 または 拡張編集 0.92',
+    );
+  });
+});

--- a/src/shared/packageDisplay.ts
+++ b/src/shared/packageDisplay.ts
@@ -74,3 +74,44 @@ export function parsePackageType(packageType: string[]) {
   }
   return result;
 }
+
+// 依存 ID は `author/pkg` `aviutl1.10` `exedit0.92` のいずれかで、後ろに
+// `>=1.0` のようなバージョン指定が付きうる(packageUtil の isInstalled と
+// 同じ形)。表示では指定を落として名前だけを出す
+const DEPENDENCY_ID =
+  /^((?:[A-Za-z0-9]+\/[A-Za-z0-9]+)|(?:aviutl[A-Za-z0-9.]+)|(?:exedit[A-Za-z0-9.]+))(?:(?:<|<=|=|>=|>)(?:[^<=>&|\n]+))?$/u;
+
+/**
+ * Converts a dependency ID into a name shown to the user.
+ * @param {string} rawId - A dependency ID, optionally with a version specifier.
+ * @param {Function} nameOfPackage - Resolves a package ID to its display name.
+ * @returns {string} The name to show.
+ */
+export function dependencyDisplayName(
+  rawId: string,
+  nameOfPackage: (id: string) => string | undefined,
+): string {
+  const id = DEPENDENCY_ID.exec(rawId)?.[1] ?? rawId;
+  const name = nameOfPackage(id);
+  if (name) return name;
+  // aviutl / exedit はパッケージ一覧に無い擬似 ID なので手で組み立てる
+  if (id.startsWith('aviutl')) return `AviUtl ${id.slice('aviutl'.length)}`;
+  if (id.startsWith('exedit')) return `拡張編集 ${id.slice('exedit'.length)}`;
+  return id;
+}
+
+/**
+ * Converts one entry of `unmetDependencies` into a name shown to the user.
+ * @param {string} group - One dependency entry; `a|b` means either satisfies it.
+ * @param {Function} nameOfPackage - Resolves a package ID to its display name.
+ * @returns {string} The name to show.
+ */
+export function unmetDependencyLabel(
+  group: string,
+  nameOfPackage: (id: string) => string | undefined,
+): string {
+  return group
+    .split('|')
+    .map((id) => dependencyDisplayName(id, nameOfPackage))
+    .join(' または ');
+}

--- a/src/shared/packageDisplay.ts
+++ b/src/shared/packageDisplay.ts
@@ -115,3 +115,19 @@ export function unmetDependencyLabel(
     .map((id) => dependencyDisplayName(id, nameOfPackage))
     .join(' または ');
 }
+
+/**
+ * Converts one entry of `conflictingWith` into a name shown to the user.
+ * @param {string} group - One conflict entry; `a&b` means all of them conflict.
+ * @param {Function} nameOfPackage - Resolves a package ID to its display name.
+ * @returns {string} The name to show.
+ */
+export function conflictLabel(
+  group: string,
+  nameOfPackage: (id: string) => string | undefined,
+): string {
+  return group
+    .split('&')
+    .map((id) => dependencyDisplayName(id, nameOfPackage))
+    .join(' かつ ');
+}

--- a/src/shared/packageUtil.test.ts
+++ b/src/shared/packageUtil.test.ts
@@ -372,6 +372,40 @@ describe('computePackagesStatus', () => {
     expect(result[0].unmetDependencies).toEqual([]);
   });
 
+  it('成立している競合が conflictingWith に入る', () => {
+    const result = computePackagesStatus(
+      [
+        makePackage('author/a', {
+          installationStatus: states.notInstalled,
+          conflicts: ['author/b'],
+        }),
+        makePackage('author/b', { installationStatus: states.installed }),
+      ],
+      '1.10',
+      '0.92',
+    );
+    expect(result[0].doNotInstall).toBe(true);
+    expect(result[0].conflictingWith).toEqual(['author/b']);
+    // 相手が入っていないほうは競合が成立しない
+    expect(result[1].conflictingWith).toEqual([]);
+  });
+
+  it('成立していない競合は conflictingWith に入らない', () => {
+    const result = computePackagesStatus(
+      [
+        makePackage('author/a', {
+          installationStatus: states.notInstalled,
+          conflicts: ['author/b'],
+        }),
+        makePackage('author/b', { installationStatus: states.notInstalled }),
+      ],
+      '1.10',
+      '0.92',
+    );
+    expect(result[0].doNotInstall).toBe(false);
+    expect(result[0].conflictingWith).toEqual([]);
+  });
+
   it('他バージョンがインストール済みのパッケージはインストール不可', () => {
     const result = computePackagesStatus(
       [makePackage('author/a', { installationStatus: states.otherInstalled })],

--- a/src/shared/packageUtil.test.ts
+++ b/src/shared/packageUtil.test.ts
@@ -331,6 +331,47 @@ describe('computePackagesStatus', () => {
     expect(result[0].doNotInstall).toBe(false);
   });
 
+  it('未導入でも、満たせない依存が unmetDependencies に入る', () => {
+    const result = computePackagesStatus(
+      [
+        makePackage('author/a', {
+          installationStatus: states.notInstalled,
+          dependencies: ['exedit0.93rc1'],
+        }),
+      ],
+      '1.10',
+      '0.92',
+    );
+    // 導入前でも「何が足りないか」が分かる(detached は導入済みしか埋めない)
+    expect(result[0].doNotInstall).toBe(true);
+    expect(result[0].unmetDependencies).toEqual(['exedit0.93rc1']);
+    expect(result[0].detached).toEqual([]);
+  });
+
+  it('満たせている依存は unmetDependencies に入らない', () => {
+    const result = computePackagesStatus(
+      [
+        makePackage('author/a', {
+          installationStatus: states.notInstalled,
+          dependencies: ['exedit0.92', 'aviutl9.99'],
+        }),
+      ],
+      '1.10',
+      '0.92',
+    );
+    expect(result[0].unmetDependencies).toEqual(['aviutl9.99']);
+  });
+
+  it('競合が理由のときは unmetDependencies が空になる', () => {
+    const result = computePackagesStatus(
+      [makePackage('author/a', { installationStatus: states.otherInstalled })],
+      '1.10',
+      '0.92',
+    );
+    expect(result[0].doNotInstall).toBe(true);
+    expect(result[0].unmetDependencies).toEqual([]);
+  });
+
   it('他バージョンがインストール済みのパッケージはインストール不可', () => {
     const result = computePackagesStatus(
       [makePackage('author/a', { installationStatus: states.otherInstalled })],

--- a/src/shared/packageUtil.ts
+++ b/src/shared/packageUtil.ts
@@ -265,9 +265,20 @@ export function computePackagesStatus(
     );
   };
 
+  // doNotInstall のもう 1 つの理由。computeInstallable の conflictsInstalled と
+  // 同じ式で、実際に成立している競合だけを残す
+  const activeConflicts = (id: string): string[] => {
+    const thisPackage = packages.filter((p) => p.id === id).find(() => true);
+    if (!thisPackage) return [];
+    return (thisPackage.info.conflicts ?? []).filter((andOfID) =>
+      andOfID.split('&').every((id2) => isInstalled(id2)),
+    );
+  };
+
   packages.forEach((p) => {
     p.doNotInstall = !isInstallable(p.id);
     p.unmetDependencies = p.doNotInstall ? unmetDeps(p.id) : [];
+    p.conflictingWith = p.doNotInstall ? activeConflicts(p.id) : [];
     p.detached = missingDeps(p.id).flatMap((depsID) => {
       const dep = packages.find((pp) => pp.id === depsID);
       return dep ? [dep] : [];

--- a/src/shared/packageUtil.ts
+++ b/src/shared/packageUtil.ts
@@ -253,8 +253,21 @@ export function computePackagesStatus(
     } else return [];
   };
 
+  // doNotInstall の理由のうち「依存が満たせない」ものを取り出す。
+  // computeInstallable の isDepsInstallable と同じ式で、false になった
+  // グループだけを残す。missingDeps と違って導入済みかどうかを問わないので、
+  // まだ入れていないパッケージでも「何が足りないか」が出せる
+  const unmetDeps = (id: string): string[] => {
+    const thisPackage = packages.filter((p) => p.id === id).find(() => true);
+    if (!thisPackage) return [];
+    return (thisPackage.info.dependencies ?? []).filter(
+      (orOfID) => !orOfID.split('|').some((id2) => isInstallable(id2)),
+    );
+  };
+
   packages.forEach((p) => {
     p.doNotInstall = !isInstallable(p.id);
+    p.unmetDependencies = p.doNotInstall ? unmetDeps(p.id) : [];
     p.detached = missingDeps(p.id).flatMap((depsID) => {
       const dep = packages.find((pp) => pp.id === depsID);
       return dep ? [dep] : [];

--- a/src/types/packageState.d.ts
+++ b/src/types/packageState.d.ts
@@ -20,4 +20,9 @@ export type PackageState = {
    * 競合が理由のときは空になる。
    */
   unmetDependencies?: string[];
+  /**
+   * doNotInstall の理由のうち「競合相手が導入済み」のもの。conflicts の
+   * 要素(and は `a&b` のまま)で、実際に成立しているものだけが入る。
+   */
+  conflictingWith?: string[];
 };

--- a/src/types/packageState.d.ts
+++ b/src/types/packageState.d.ts
@@ -14,4 +14,10 @@ export type PackageState = {
   installationStatus?: string;
   detached?: PackageState[];
   doNotInstall?: boolean;
+  /**
+   * doNotInstall の理由のうち「依存が満たせない」もの。dependencies の
+   * 要素(or は `a|b` のまま)で、満たせないグループだけが入る。
+   * 競合が理由のときは空になる。
+   */
+  unmetDependencies?: string[];
 };


### PR DESCRIPTION
実際にアプリを起動して見つけたものです。**素のインストール先でプラグイン&スクリプトタブを開くと、理由の書かれていない黄色い「インストール不可」が並びます。** 実データで数えると **294 行中 57 件**が該当します。

## なぜ理由が出ないのか

理由になる情報は `computeInstallable` が計算しているのに、結果を捨てています。

`doNotInstall` は boolean 1 個です。そして「要導入: 〜」を作る `missingDeps` は

```ts
if (thisPackage && isInstalled(id)) {
```

の中でしか動かないので、**まだ導入していないパッケージには足りないものが構造上いっさい表示されません。** 初回のユーザーが最初に開く画面で、いちばん目立つ色の警告に、いちばん情報が無いという状態です。

## この PR でやること

`computeInstallable` の `isDepsInstallable` と**同じ式**で、満たせなかった依存グループだけを `unmetDependencies` に残します。導入済みかどうかは問いません。競合が理由のときは空になります（依存の問題ではないため）。

```ts
const unmetDeps = (id: string): string[] => {
  const thisPackage = packages.filter((p) => p.id === id).find(() => true);
  if (!thisPackage) return [];
  return (thisPackage.info.dependencies ?? []).filter(
    (orOfID) => !orOfID.split('|').some((id2) => isInstallable(id2)),
  );
};
```

表示は「インストール不可」の下に 1 行足すだけです。

```
インストール不可
要: 拡張編集 0.93rc1、rikkymodule(version2)
```

名前解決は `packageDisplay.ts`（fs 非依存）に置きました。`aviutl` / `exedit` は一覧に無い擬似 ID なので手で組み立て、`>=1.0` のようなバージョン指定は落とします。

## 実データでの結果

パッケージ版を起動して 57 件すべてに理由が出ることを確認しました。

```
Aulsプラグインforaviutl110  || インストール不可 要: 拡張編集 0.93rc1、rikkymodule(version2)
Aulsメモリ参照プラグイン      || インストール不可 要: 拡張編集 0.92
AviUtl効率化 パッケージセット || インストール不可 要: 最終フレーム自動調整、フィルタドラッグ移動、エディットボックス最適化、アイテム内音声波形
patch.aul                 || インストール不可 要: AviUtl 1.10、拡張編集 0.92
```

パッケージ名も解決されていて（`rikkymodule` / `最終フレーム自動調整` など）、擬似 ID は「拡張編集 0.92」「AviUtl 1.10」として出ます。

## 検証

- `yarn test` 333 件（**+8**）緑。未導入でも理由が埋まること／満たせている依存は入らないこと／競合のときは空になること／擬似 ID と or 指定の名前解決
- `yarn lint` / `yarn lint:ts` 緑
- `yarn package` → `yarn test:e2e`（7 件）緑

---

## 追記: 競合と別バージョンも理由に出すようにしました

依存だけだと、**競合が理由のときは理由が空のまま**でした（`unmetDependencies` は依存の話しか持たないため）。`conflictsInstalled` と同じ式で、実際に成立している競合を `conflictingWith` に残し、`installationStatus` が `otherInstalled` のときは「別のバージョンが導入済み」と書きます。

これで**「インストール不可」が理由を持たない経路が無くなりました。**

実データで確認（`patch.aul` を手動導入した状態）:

```
アルティメットプラグイン || インストール不可
                          要: AviUtl 1.10、拡張編集 0.92
                          競合: patch.aul
```

表示名が重複したときは畳んでいます。`ePi/patch` と `nazono/patch` はどちらも名前が「patch.aul」で、そのままだと「競合: patch.aul、patch.aul」になるためです。

### 副次的な効果

[#1880](https://github.com/team-apm/apm/issues/1880)（「Bakusoku 系と patch.aul は競合する」と書いてほしい）は、**apm-data の `conflicts` に書くだけで済むようになります。** apm が自動で「インストール不可」にして、理由まで表示します。

テストは 336 件（+11）。
