### PR TITLE
refactor(main): squirrel のイベント処理を自前で持つ

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "electron-debug": "^4.1.0",
     "electron-dl": "^4.0.0",
     "electron-log": "^5.4.4",
-    "electron-squirrel-startup": "^1.0.1",
     "electron-store": "^8.2.0",
     "electron-window-state": "^5.0.3",
     "fast-xml-parser": "^5.11.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,7 +6,7 @@ import 'source-map-support/register';
 import { getConfig } from './Config';
 import { registerIpcHandlers } from './ipcHandlers';
 import { ensureAutoUpdateDefault } from './services/appUpdate';
-import * as shortcut from './shortcut';
+import { handleSquirrelEvent } from './squirrel';
 import { launch } from './windows';
 
 // preload: true(既定)のセッション preload 注入は使わない。注入パスの解決が
@@ -40,13 +40,9 @@ log.errorHandler.startCatching({
   },
 });
 
-shortcut.uninstaller(app.getPath('appData'));
-// 静的 import にしない: ESM の規則でこのファイルの本体より先に評価され、
-// 直前の shortcut.uninstaller より先に Squirrel のイベント処理が始まってしまう
-// (--squirrel-uninstall では Update.exe の完了で app.quit() が走るため、
-// AviUtl のショートカット削除が間に合わなくなりうる)。位置を保つために
-// require のまま残し、vite.base.config.ts で外部化して同梱する
-if (require('electron-squirrel-startup')) app.quit();
+// Squirrel のイベント(インストール / 更新 / アンインストール)。AviUtl の
+// ショートカット削除との順序は handleSquirrelEvent の中で文として書かれている
+if (handleSquirrelEvent(app.getPath('appData'))) app.quit();
 log.debug(process.versions);
 
 const isDevEnv = process.env.NODE_ENV === 'development';
@@ -66,7 +62,7 @@ debug({ showDevTools: false }); // Press F12 to open DevTools
 // ロックは userData 単位なので、setPath('userData') より後で取得すること
 // (--user-data-dir 隔離の E2E や _Dev プロファイルの開発起動と干渉させない)。
 // ロック失敗時に即 return せず後続のトップレベル初期化を素通しするのは
-// electron-squirrel-startup と同じ流儀 — quit 済みなら ready が発火せず
+// すぐ上の handleSquirrelEvent と同じ流儀 — quit 済みなら ready が発火せず
 // 窓生成(launch)には到達しない
 if (!app.requestSingleInstanceLock()) {
   app.quit();

--- a/src/main/shortcut.ts
+++ b/src/main/shortcut.ts
@@ -31,15 +31,3 @@ export function removeAviUtlShortcut(appDataPath: string) {
     unlinkSync(getShortcutPath(appDataPath));
   }
 }
-
-/**
- * Uninstaller for shortcuts. This function must be executed before uninstalling apm. Therefore, it is placed before the interpretation of squirrelCommand.
- * @param {string} appDataPath - The path to AppData
- */
-export function uninstaller(appDataPath: string) {
-  if (process.platform === 'win32') {
-    const squirrelCommand = process.argv[1];
-    if (squirrelCommand === '--squirrel-uninstall')
-      removeAviUtlShortcut(appDataPath);
-  }
-}

--- a/src/main/squirrel.test.ts
+++ b/src/main/squirrel.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleSquirrelEvent } from './squirrel';
+
+const mocks = vi.hoisted(() => ({
+  quit: vi.fn(),
+  spawn: vi.fn<(exe: string, args: string[]) => { on: () => void }>(() => ({
+    on: vi.fn(),
+  })),
+  removeAviUtlShortcut: vi.fn(),
+}));
+
+vi.mock('electron', () => ({ app: { quit: mocks.quit } }));
+vi.mock('node:child_process', () => ({ spawn: mocks.spawn }));
+vi.mock('./shortcut', () => ({
+  removeAviUtlShortcut: mocks.removeAviUtlShortcut,
+}));
+
+const APP_DATA = 'C:\\Users\\x\\AppData\\Roaming';
+
+describe('handleSquirrelEvent', () => {
+  const platform = process.platform;
+  const argv = process.argv;
+
+  const setUp = (command: string, plat: string = 'win32') => {
+    Object.defineProperty(process, 'platform', { value: plat });
+    process.argv = ['apm.exe', command];
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: platform });
+    process.argv = argv;
+  });
+
+  it('win32 以外では何もしない', () => {
+    setUp('--squirrel-uninstall', 'darwin');
+    expect(handleSquirrelEvent(APP_DATA)).toBe(false);
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(mocks.removeAviUtlShortcut).not.toHaveBeenCalled();
+  });
+
+  it('Squirrel のイベントでなければ何もしない', () => {
+    setUp('--some-other-flag');
+    expect(handleSquirrelEvent(APP_DATA)).toBe(false);
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it('インストール・更新ではショートカットを作る', () => {
+    for (const command of ['--squirrel-install', '--squirrel-updated']) {
+      vi.clearAllMocks();
+      setUp(command);
+      expect(handleSquirrelEvent(APP_DATA)).toBe(true);
+      expect(mocks.spawn.mock.calls[0][1]).toEqual([
+        expect.stringContaining('--createShortcut='),
+      ]);
+      // 作る側では AviUtl のショートカットに触らない
+      expect(mocks.removeAviUtlShortcut).not.toHaveBeenCalled();
+    }
+  });
+
+  it('アンインストールでは AviUtl のショートカットを Update.exe より先に消す', () => {
+    setUp('--squirrel-uninstall');
+
+    expect(handleSquirrelEvent(APP_DATA)).toBe(true);
+
+    // 順序がこのテストの主眼。Update.exe は detached で spawn され、その完了で
+    // app.quit() が走るため、後回しにすると削除が間に合わない
+    expect(mocks.removeAviUtlShortcut).toHaveBeenCalledWith(APP_DATA);
+    expect(mocks.removeAviUtlShortcut.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.spawn.mock.invocationCallOrder[0],
+    );
+    expect(mocks.spawn.mock.calls[0][1]).toEqual([
+      expect.stringContaining('--removeShortcut='),
+    ]);
+  });
+
+  it('obsolete では Update.exe を呼ばずに終了する', () => {
+    setUp('--squirrel-obsolete');
+    expect(handleSquirrelEvent(APP_DATA)).toBe(true);
+    expect(mocks.quit).toHaveBeenCalled();
+    expect(mocks.spawn).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/squirrel.ts
+++ b/src/main/squirrel.ts
@@ -1,0 +1,52 @@
+import { app } from 'electron';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { removeAviUtlShortcut } from './shortcut';
+
+/**
+ * Runs Squirrel's `Update.exe` with the given arguments.
+ * @param {string[]} args - Arguments passed to Update.exe.
+ */
+function runUpdateExe(args: string[]) {
+  const updateExe = path.resolve(
+    path.dirname(process.execPath),
+    '..',
+    'Update.exe',
+  );
+  spawn(updateExe, args, { detached: true }).on('close', () => app.quit());
+}
+
+/**
+ * Handles the Squirrel.Windows startup events.
+ *
+ * 旧 electron-squirrel-startup を取り込んだもの。あちらは
+ * `module.exports = check()` で **require したその瞬間に** イベントを
+ * 処理するため、AviUtl のショートカット削除を先に済ませる必要が
+ * 「index.ts の行の位置」でしか担保できなかった(#2417)。ここへ畳むと
+ * 順序が文として書かれ、テストも書ける。
+ * @param {string} appDataPath - The path to AppData.
+ * @returns {boolean} Whether a Squirrel event was handled (the app should quit).
+ */
+export function handleSquirrelEvent(appDataPath: string): boolean {
+  if (process.platform !== 'win32') return false;
+
+  const target = path.basename(process.execPath);
+  switch (process.argv[1]) {
+    case '--squirrel-install':
+    case '--squirrel-updated':
+      runUpdateExe([`--createShortcut=${target}`]);
+      return true;
+    case '--squirrel-uninstall':
+      // apm 自身が消える前に AviUtl のショートカットを消す。Update.exe は
+      // detached で spawn され、その完了で app.quit() が走るため、こちらを
+      // 後回しにすると間に合わない
+      removeAviUtlShortcut(appDataPath);
+      runUpdateExe([`--removeShortcut=${target}`]);
+      return true;
+    case '--squirrel-obsolete':
+      app.quit();
+      return true;
+    default:
+      return false;
+  }
+}

--- a/vite.base.config.ts
+++ b/vite.base.config.ts
@@ -17,41 +17,14 @@ const assetBearingDependencies = [
 ];
 
 /**
- * 評価順を保つために生の `require()` のまま残す依存と、その実行時依存。
+ * Rollup の external にするもの(= バンドルから外し、node_modules ごと同梱する)。
  *
- * webpack は `require()` を静的に解決して「その行の位置のまま」bundle して
- * いたが、Rollup にその機能は無い。静的 import へ直すと ESM の規則で
- * import 側の本体より先に評価されてしまい、副作用の順序が変わる。
+ * かつては「評価順を保つために生の `require()` のまま残す依存」もここにあった
+ * (electron-squirrel-startup)。require したその瞬間に Squirrel のイベントを
+ * 処理する作りで、AviUtl のショートカット削除との順序が index.ts の行の位置に
+ * しか書かれていなかったため、#2417 で src/main/squirrel.ts へ畳んだ。
  */
-const positionalRequireDependencies = [
-  // require した時点で Squirrel のイベントを処理し、--squirrel-uninstall では
-  // Update.exe を spawn してその完了で app.quit() する。apm 側の
-  // shortcut.uninstaller(AviUtl のショートカット削除)を必ず先に走らせる
-  // 必要があるため(src/main/shortcut.ts の JSDoc)、位置を動かせない
-  'electron-squirrel-startup',
-];
-
-/** Rollup の external にするもの(= バンドルから外し、node_modules ごと同梱する)。 */
-export const externalDependencies = [
-  ...assetBearingDependencies,
-  ...positionalRequireDependencies,
-];
-
-/**
- * 同梱だけするもの(external にはしない)。
- *
- * 外部化した依存がさらに実行時 require する分。external に足すと
- * 「バンドル内の別のコードからの import」まで外部化されてしまい、
- * 起動時の require が無駄に増えるため、同梱の一覧にだけ載せる。
- */
-const runtimeOnlyDependencies = [
-  // electron-squirrel-startup → debug → ms
-  'debug',
-  'ms',
-];
+export const externalDependencies = [...assetBearingDependencies];
 
 /** パッケージへ同梱する node_modules 一覧。 */
-export const packagedDependencies = [
-  ...externalDependencies,
-  ...runtimeOnlyDependencies,
-];
+export const packagedDependencies = [...externalDependencies];

--- a/yarn.lock
+++ b/yarn.lock
@@ -638,9 +638,9 @@
   optionalDependencies:
     undici "^7.24.4"
 
-"@electron/node-gyp@git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2":
+"@electron/node-gyp@https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2":
   version "10.2.0-electron.1"
-  resolved "git+https://github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2"
+  resolved "https://github.com/electron/node-gyp#06b29aafb7708acef8b3669835c8a7857ebc92d2"
   dependencies:
     env-paths "^2.2.0"
     exponential-backoff "^3.1.1"
@@ -4054,13 +4054,6 @@ electron-log@^5.4.4:
   version "5.4.4"
   resolved "https://registry.yarnpkg.com/electron-log/-/electron-log-5.4.4.tgz#957cb6fc43a73759bad32fadd4927f870eed0254"
   integrity sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==
-
-electron-squirrel-startup@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/electron-squirrel-startup/-/electron-squirrel-startup-1.0.1.tgz#c9171568d724884c7a2b03760bfeedcf921c63ab"
-  integrity sha512-sTfFIHGku+7PsHLJ7v0dRcZNkALrV+YEozINTW8X1nM//e5O3L+rfYuvSW00lmGHnYmUjARZulD8F2V8ISI9RA==
-  dependencies:
-    debug "^2.2.0"
 
 electron-store@^8.2.0:
   version "8.2.0"


### PR DESCRIPTION
closes #2417

## 問題

起動処理は 2 文が**この順序で並んでいること**に依存していました。

```ts
shortcut.uninstaller(app.getPath('appData'));
if (require('electron-squirrel-startup')) app.quit();
```

`electron-squirrel-startup` は `module.exports = check()` で、**require したその瞬間に** Squirrel のイベントを処理します。`--squirrel-uninstall` では `Update.exe` を detached で spawn し、その完了で `app.quit()` が走るため、AviUtl のショートカット削除を後回しにすると間に合いません。

つまり**正しさが「行の位置」に埋まっていて、機械的に守られていませんでした。** 実際に Vite 移行では静的 import へ直した時点で順序が逆転しています（ESM は import 側の本体より先に評価するため）。webpack が `require()` を位置のまま bundle していたので、それまでは偶然成立していました。

## この PR でやること

35 行・Windows 専用・実質凍結（v1.0.1）のパッケージで、しかも **apm 側にも `--squirrel-uninstall` の判定が二重にありました**（`shortcut.ts` の `uninstaller`）。`src/main/squirrel.ts` へ畳みます。

```ts
case '--squirrel-uninstall':
  // apm 自身が消える前に AviUtl のショートカットを消す。Update.exe は
  // detached で spawn され、その完了で app.quit() が走るため、こちらを
  // 後回しにすると間に合わない
  removeAviUtlShortcut(appDataPath);
  runUpdateExe([`--removeShortcut=${target}`]);
  return true;
```

順序が**文として書かれ**、テストも書けるようになります。この経路は **Windows × アンインストール時限定**で開発機でも CI でも踏めないので、**テストが書けること自体が主目的**です。

## 副次的に、AGENTS.md の落とし穴が 1 つ消えます

「**評価順を保つために生の `require()` のまま残す依存**」というカテゴリが**ゼロになりました**。`positionalRequireDependencies` ごと削除でき、その実行時依存だった `debug` / `ms` も同梱不要です。

同梱する node_modules は **`7zip-bin` と `win-7zip` の 2 つだけ**になり、どちらも「自身の `__dirname` からファイルを読む」ほうの理由に揃います。パッケージ版で実際に確認しました。

```
$ ls .../app.asar.unpacked/node_modules
7zip-bin
win-7zip
```

## 検証

`src/main/squirrel.test.ts` を足しました。5 件。

- win32 以外では何もしない
- Squirrel のイベントでなければ何もしない
- install / updated ではショートカットを作り、AviUtl のショートカットには触らない
- **uninstall では AviUtl のショートカット削除が `Update.exe` の spawn より先**（`invocationCallOrder` で順序そのものを見ています）
- obsolete では `Update.exe` を呼ばずに終了する

`yarn lint` / `yarn lint:ts` / `yarn test`（330 件）緑。**同梱物を削るので `yarn package` → `yarn test:e2e`（7 件）まで回して緑**を確認済みです（`MODULE_NOT_FOUND` は lint も型もすり抜けるため）。