### PR TITLE
fix(renderer): 未インストールのアンインストールを「完了」と言わない

### DIFF
--- a/e2e/install.spec.ts
+++ b/e2e/install.spec.ts
@@ -140,4 +140,13 @@ test('dataURL の差し替えとパッケージのインストール・アンイ
   );
   expect(existsSync(path.join(installationPath, 'dummy.auf'))).toBe(false);
   await expect(row).not.toContainText('インストール済み');
+
+  // 未インストールのまま押しても、何が起きたのか分かる文言が出る
+  // (修正前は何も消していないのに「アンインストール完了」と出ていた)
+  await row.click();
+  await window.locator('#uninstall-package').click();
+  await expect(window.locator('#uninstall-package')).toHaveText(
+    'インストールされていません。',
+    { timeout: 30_000 },
+  );
 });

--- a/src/renderer/main/packages/PackageActions.tsx
+++ b/src/renderer/main/packages/PackageActions.tsx
@@ -268,6 +268,18 @@ function PackageActions({
 
     const uninstalledPackage = { ...selectedEntry.p };
 
+    // 未インストールのまま押せてしまい、しかも main 側は成功を返す。
+    // 実測すると「アンインストール完了」と出る — 何も消していないのに
+    // 完了と報告している(#2456 と同じ種類)。
+    // 無効化ではなく説明を出すのは、このボタン群が「押したら理由を言う」
+    // 方式で揃っているため(選択なし・インストール先未設定も同じ形)。
+    // notInstalled だけを弾く。手動インストール済みは記録に無いだけで
+    // ファイルは在るので、消す操作に意味がある
+    if (uninstalledPackage.installationStatus === states.notInstalled) {
+      uninstall.finish('インストールされていません。', 'danger');
+      return;
+    }
+
     let result: Awaited<
       ReturnType<typeof uninstallPackageMutation.mutateAsync>
     >;


### PR DESCRIPTION
実際にアプリを操作して見つけたものです。

## 何が起きているか

**未インストールのパッケージを選んでアンインストールを押せてしまい、しかも「アンインストール完了」と出ます。** 何も消していないのに完了と報告しています。

パッケージ版で実測しました（ボタンの文言を 4 秒間ポーリング）。

```
PROBE-UNINSTALL ["アンインストール完了","アンインストール"]
```

main 側は成功を返すので、renderer はそれをそのまま「完了」として表示します。[#2456](https://github.com/team-apm/apm/pull/2456)（一括インストールが失敗を無視して「インストール完了」と出す）と**同じ種類**の問題です。

## なぜ無効化ではなく文言なのか

このボタン群は**「押したら理由を言う」方式で揃っています。**

```
プラグインまたはスクリプトを選択してください。
インストール先フォルダを指定してください。
```

無効化に倒すと、この 2 つと一貫しなくなるうえ、**理由を言う場所が無くなります**（押せないボタンは何も説明しません）。同じ形で 1 つ足します。

```
インストールされていません。
```

## 弾くのは `notInstalled` だけです

**手動インストール済み**は「記録に無いだけでファイルは在る」状態なので、消す操作に意味があります。`otherInstalled`（他バージョンが導入済み）も同様です。ここを一緒に弾くと、手動導入したものを apm から片付けられなくなります。

## 検証

`e2e/install.spec.ts` の末尾に足しました。アンインストール後にもう一度押して、完了ではなく理由が出ることを見ます。

- 修正なし: `Expected: "インストールされていません。"` / `Received: "アンインストール"` で落ちる（3 秒で idle に戻るため）
- 修正あり: 通る

`yarn lint` / `yarn lint:ts` / `yarn test`（325 件）緑。`yarn package` → `yarn test:e2e`（7 件）緑。